### PR TITLE
fix: x/peggy: Use reverse iterator and add tests

### DIFF
--- a/x/peggy/keeper/pool.go
+++ b/x/peggy/keeper/pool.go
@@ -339,7 +339,7 @@ func (k *Keeper) GetAllBatchFees(ctx sdk.Context) (batchFees []*types.BatchFees)
 // CreateBatchFees iterates over the outgoing pool and creates batch token fee map
 func (k *Keeper) createBatchFees(ctx sdk.Context) map[common.Address]*types.BatchFees {
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.SecondIndexOutgoingTXFeeKey)
-	iter := prefixStore.Iterator(nil, nil)
+	iter := prefixStore.ReverseIterator(nil, nil)
 	defer iter.Close()
 
 	batchFeesMap := make(map[common.Address]*types.BatchFees)

--- a/x/peggy/keeper/pool_test.go
+++ b/x/peggy/keeper/pool_test.go
@@ -134,10 +134,9 @@ func TestTotalBatchFeeInPool(t *testing.T) {
 	}
 
 	batchFees := input.PeggyKeeper.GetAllBatchFees(ctx)
-	/*
-		tokenFeeMap should be
-		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
-		**/
+
+	// tokenFeeMap should be
+	// map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
 	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
 	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(6050)))
 
@@ -149,10 +148,9 @@ func TestTotalBatchFeeInPool(t *testing.T) {
 	t.Logf("___ response: %#v", r)
 
 	batchFees = input.PeggyKeeper.GetAllBatchFees(ctx)
-	/*
-		tokenFeeMap should be
-		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
-		**/
+
+	// tokenFeeMap should be
+	// map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
 	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
 	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(6050)))
 
@@ -164,11 +162,10 @@ func TestTotalBatchFeeInPool(t *testing.T) {
 	t.Logf("___ response: %#v", r)
 
 	batchFees = input.PeggyKeeper.GetAllBatchFees(ctx)
-	/*
-		tokenFeeMap should be
-		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:7039]
-		The lowest fee from the previous batch (11) will be removed so 6050-11+1000=7039
-		**/
+
+	// tokenFeeMap should be
+	// map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:7039]
+	// The lowest fee from the previous batch (11) will be removed so 6050-11+1000=7039
 	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
 	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(7039)))
 

--- a/x/peggy/keeper/pool_test.go
+++ b/x/peggy/keeper/pool_test.go
@@ -126,7 +126,8 @@ func TestTotalBatchFeeInPool(t *testing.T) {
 	// create outgoing pool
 	for i := 0; i < 110; i++ {
 		amount := types.NewERC20Token(uint64(i+100), myToken2ContractAddr).PeggyCoin()
-		fee := types.NewERC20Token(uint64(5), myToken2ContractAddr).PeggyCoin()
+		// use increasing fee to check for ordering. Only the top 100 will make it to the batch.
+		fee := types.NewERC20Token(uint64(i+1), myToken2ContractAddr).PeggyCoin()
 		r, err := input.PeggyKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
 		require.NoError(t, err)
 		t.Logf("___ response: %#v", r)
@@ -135,10 +136,41 @@ func TestTotalBatchFeeInPool(t *testing.T) {
 	batchFees := input.PeggyKeeper.GetAllBatchFees(ctx)
 	/*
 		tokenFeeMap should be
-		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:500]
+		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
 		**/
 	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
-	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(500)))
+	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(6050)))
+
+	// Add a tx with a very low fee. This shouldn't make it to the batch. So the total fee should be remains unchanged.
+	amount := types.NewERC20Token(uint64(100), myToken2ContractAddr).PeggyCoin()
+	fee := types.NewERC20Token(uint64(1), myToken2ContractAddr).PeggyCoin()
+	r, err := input.PeggyKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+	require.NoError(t, err)
+	t.Logf("___ response: %#v", r)
+
+	batchFees = input.PeggyKeeper.GetAllBatchFees(ctx)
+	/*
+		tokenFeeMap should be
+		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:6050]
+		**/
+	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
+	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(6050)))
+
+	// Add a tx with a very high fee. This should make it to the batch. So the total fee should change.
+	amount = types.NewERC20Token(uint64(100), myToken2ContractAddr).PeggyCoin()
+	fee = types.NewERC20Token(uint64(1000), myToken2ContractAddr).PeggyCoin()
+	r, err = input.PeggyKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+	require.NoError(t, err)
+	t.Logf("___ response: %#v", r)
+
+	batchFees = input.PeggyKeeper.GetAllBatchFees(ctx)
+	/*
+		tokenFeeMap should be
+		map[0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5:8 0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0:7039]
+		The lowest fee from the previous batch (11) will be removed so 6050-11+1000=7039
+		**/
+	assert.Equal(t, batchFees[0].TotalFees.BigInt(), big.NewInt(int64(8)))
+	assert.Equal(t, batchFees[1].TotalFees.BigInt(), big.NewInt(int64(7039)))
 
 }
 


### PR DESCRIPTION
## Description

This solution uses the same ReverseIterator as `IterateOutgoingPoolByFee` (https://github.com/umee-network/umee/blob/main/x/peggy/keeper/pool.go#L285) which is the function used to get the TXs that'll make it to the created batch. It's very important to use the same ordering criteria for when we estimate fees and for when we actually create a batch.

Also a simple test was added to check that a new tx with a higher fee makes it to the batch fee estimation and that a new tx with a low fee doesn't make it.

closes: #222

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
