### PR TITLE
fix: require x/peggy batch creators to be validator orchestrators

### DIFF
--- a/x/peggy/keeper/msg_server_test.go
+++ b/x/peggy/keeper/msg_server_test.go
@@ -31,6 +31,8 @@ func TestMsgServer_RequestBatch_InvalidSender(t *testing.T) {
 
 	msgServer := keeper.NewMsgServerImpl(umeeApp.PeggyKeeper)
 
+	// We have not registered a validator orchestrator yet, so the message should
+	// fail.
 	msg := &types.MsgRequestBatch{Orchestrator: orcAddr1.String()}
 	_, err := msgServer.RequestBatch(sdk.WrapSDKContext(ctx), msg)
 	require.Error(t, err)

--- a/x/peggy/keeper/msg_server_test.go
+++ b/x/peggy/keeper/msg_server_test.go
@@ -15,6 +15,27 @@ import (
 	"github.com/umee-network/umee/x/peggy/types"
 )
 
+func TestMsgServer_RequestBatch_InvalidOrchestrator(t *testing.T) {
+	var (
+		umeeApp = app.Setup(t, false, 0)
+		ctx     = umeeApp.NewContext(
+			false,
+			tmproto.Header{
+				Height: 1234567,
+				Time:   time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
+			},
+		)
+
+		orcAddr1, _ = sdk.AccAddressFromBech32("umee1dkfhxs87adz9ll6jfr0jr5jet6u8tjaqx4z8rg")
+	)
+
+	msgServer := keeper.NewMsgServerImpl(umeeApp.PeggyKeeper)
+
+	msg := &types.MsgRequestBatch{Orchestrator: orcAddr1.String()}
+	_, err := msgServer.RequestBatch(sdk.WrapSDKContext(ctx), msg)
+	require.Error(t, err)
+}
+
 func TestMsgServer_SetOrchestratorAddresses(t *testing.T) {
 	ethPrivKey1, err := ethcrypto.GenerateKey()
 	require.NoError(t, err)

--- a/x/peggy/keeper/msg_server_test.go
+++ b/x/peggy/keeper/msg_server_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/umee-network/umee/x/peggy/types"
 )
 
-func TestMsgServer_RequestBatch_InvalidOrchestrator(t *testing.T) {
+func TestMsgServer_RequestBatch_InvalidSender(t *testing.T) {
 	var (
 		umeeApp = app.Setup(t, false, 0)
 		ctx     = umeeApp.NewContext(


### PR DESCRIPTION
## Description

Require batch creators to be validator orchestrators.

closes: #230

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
