### PR TITLE
fix: Place x/peggy EndBlocker after x/staking

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -505,8 +505,8 @@ func New(
 		crisistypes.ModuleName,
 		govtypes.ModuleName,
 		leveragetypes.ModuleName,
-		peggytypes.ModuleName,
 		stakingtypes.ModuleName,
+		peggytypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are


### PR DESCRIPTION
## Description

This was a bug that prevented valsetUpdates creation when a validator unbonds. 

It was failing because:
The hook that updates the lastUnbondingHeight runs after both BeginBlocker and EndBlocker. Meaning in Endblocker this condition is never met: (lastUnbondingHeight == ctx.BlockHeight())  to create a new valsetUpdate

----

### Author Checklist

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
