### PR TITLE
refactor: x/peggy: Allow prefixed and non prefixed hex + Make keeper field private

### DIFF
--- a/x/peggy/client/cli/tx.go
+++ b/x/peggy/client/cli/tx.go
@@ -10,7 +10,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	ethcmn "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
 
@@ -132,20 +131,14 @@ manually, the operator must use the current account nonce.`,
 
 			var ethSig []byte
 			if s, err := cmd.Flags().GetString(FlagOrchEthSig); len(s) > 0 && err == nil {
-				ethSig, err = hexutil.Decode(s)
-				if err != nil {
-					return err
-				}
+				ethSig = ethcmn.FromHex(s)
 			} else {
 				ethPrivKeyStr, err := cmd.Flags().GetString(FlagEthPrivKey)
 				if err != nil {
 					return err
 				}
 
-				privKeyBz, err := hexutil.Decode(ethPrivKeyStr)
-				if err != nil {
-					return fmt.Errorf("failed to parse Ethereum private key: %w", err)
-				}
+				privKeyBz := ethcmn.FromHex(ethPrivKeyStr)
 
 				ethPrivKey, err := ethcrypto.ToECDSA(privKeyBz)
 				if err != nil {

--- a/x/peggy/keeper/attestation.go
+++ b/x/peggy/keeper/attestation.go
@@ -101,7 +101,7 @@ func (k *Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation) {
 func (k *Keeper) processAttestation(ctx sdk.Context, claim types.EthereumClaim) {
 	// then execute in a new Tx so that we can store state on failure
 	xCtx, commit := ctx.CacheContext()
-	if err := k.AttestationHandler.Handle(xCtx, claim); err != nil { // execute with a transient storage
+	if err := k.attestationHandler.Handle(xCtx, claim); err != nil { // execute with a transient storage
 		// If the attestation fails, something has gone wrong and we can't recover it. Log and move on
 		// The attestation will still be marked "Observed", and validators can still be slashed for not
 		// having voted for it.

--- a/x/peggy/keeper/keeper.go
+++ b/x/peggy/keeper/keeper.go
@@ -27,7 +27,7 @@ type Keeper struct {
 	SlashingKeeper types.SlashingKeeper
 	StakingKeeper  types.StakingKeeper
 
-	AttestationHandler interface {
+	attestationHandler interface {
 		Handle(sdk.Context, types.EthereumClaim) error
 	}
 }
@@ -53,7 +53,7 @@ func NewKeeper(
 		SlashingKeeper: slashingKeeper,
 	}
 
-	k.AttestationHandler = NewAttestationHandler(bankKeeper, k)
+	k.attestationHandler = NewAttestationHandler(bankKeeper, k)
 
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {


### PR DESCRIPTION
## Description

- Made AttestationHandler of x/peggy/Keeper private
- Allow optional 0x prefix on set-orchestrator-address for private key and signature.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
