### PR TITLE
refactor: codec Marshal and Unmarshal for Token

### DIFF
--- a/x/leverage/keeper/token.go
+++ b/x/leverage/keeper/token.go
@@ -53,7 +53,7 @@ func (k Keeper) SetRegisteredToken(ctx sdk.Context, token types.Token) {
 	store := ctx.KVStore(k.storeKey)
 	tokenKey := types.CreateRegisteredTokenKey(token.BaseDenom)
 
-	bz, err := token.Marshal()
+	bz, err := k.cdc.Marshal(&token)
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode token: %s", err))
 	}
@@ -117,7 +117,7 @@ func (k Keeper) GetRegisteredToken(ctx sdk.Context, denom string) (types.Token, 
 		return token, sdkerrors.Wrap(types.ErrInvalidAsset, denom)
 	}
 
-	err := token.Unmarshal(bz)
+	err := k.cdc.Unmarshal(bz, &token)
 	return token, err
 }
 


### PR DESCRIPTION
## Description

Use `keeper.cdc` for all types other than `sdk.Int` and `sdk.Dec` in `x/leverage` - as it turns out, only `Token` needed any updates.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
