### PR TITLE
feat: borrow limit restrictions

### DIFF
--- a/x/leverage/keeper/borrows.go
+++ b/x/leverage/keeper/borrows.go
@@ -77,7 +77,7 @@ func (k Keeper) GetTotalBorrows(ctx sdk.Context) (sdk.Coins, error) {
 
 // GetBorrowerBorrows returns an sdk.Coins object containing all open borrows
 // associated with an address.
-func (k Keeper) GetBorrowerBorrows(ctx sdk.Context, borrowerAddr sdk.AccAddress) (sdk.Coins, error) {
+func (k Keeper) GetBorrowerBorrows(ctx sdk.Context, borrowerAddr sdk.AccAddress) sdk.Coins {
 	store := ctx.KVStore(k.storeKey)
 	prefix := types.CreateLoanKeyNoDenom(borrowerAddr)
 
@@ -94,7 +94,7 @@ func (k Keeper) GetBorrowerBorrows(ctx sdk.Context, borrowerAddr sdk.AccAddress)
 		var amount sdk.Int
 		if err := amount.Unmarshal(val); err != nil {
 			// improperly marshaled loan amount should never happen
-			return sdk.NewCoins(), err
+			panic(err)
 		}
 
 		// for each loan found, add it to totalBorrowed
@@ -102,7 +102,7 @@ func (k Keeper) GetBorrowerBorrows(ctx sdk.Context, borrowerAddr sdk.AccAddress)
 	}
 
 	totalBorrowed.Sort()
-	return totalBorrowed, nil
+	return totalBorrowed
 }
 
 // GetBorrowUtilization derives the current borrow utilization of an asset type

--- a/x/leverage/keeper/grpc_query.go
+++ b/x/leverage/keeper/grpc_query.go
@@ -82,10 +82,7 @@ func (q Querier) Borrowed(
 	}
 
 	if len(req.Denom) == 0 {
-		tokens, err := q.Keeper.GetBorrowerBorrows(ctx, borrower)
-		if err != nil {
-			return nil, err
-		}
+		tokens := q.Keeper.GetBorrowerBorrows(ctx, borrower)
 
 		return &types.QueryBorrowedResponse{Borrowed: tokens}, nil
 	}

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -249,8 +249,7 @@ func (k Keeper) BorrowAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, borrow
 
 	// Determine the total amount of denom borrowed (previously borrowed + newly borrowed)
 	newBorrow := borrowed.AmountOf(borrow.Denom).Add(borrow.Amount)
-	err = k.SetBorrow(ctx, borrowerAddr, sdk.NewCoin(borrow.Denom, newBorrow))
-	if err != nil {
+	if err := k.SetBorrow(ctx, borrowerAddr, sdk.NewCoin(borrow.Denom, newBorrow)); err != nil {
 		return err
 	}
 	return nil

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -243,7 +243,7 @@ func (k Keeper) BorrowAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, borrow
 	}
 
 	loanTokens := sdk.NewCoins(borrow)
-	if err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, borrowerAddr, loanTokens); err != nil {
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, borrowerAddr, loanTokens); err != nil {
 		return err
 	}
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -430,8 +430,8 @@ func (s *IntegrationTestSuite) TestBorrowAsset_Reserved() {
 	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 1000000000))
 	s.Require().Error(err)
 
-	// lender borrows 100 umee
-	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 100000000))
+	// lender borrows 800 umee
+	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 800000000))
 	s.Require().NoError(err)
 }
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -339,20 +339,16 @@ func (s *IntegrationTestSuite) TestBorrowAsset_Invalid() {
 	s.Require().Error(err)
 }
 
-/*
-// TODO: Ready to be commented in once borrowing limits exist.
 func (s *IntegrationTestSuite) TestBorrowAsset_InsufficientCollateral() {
 	_, bumAddr := s.initBorrowScenario() // create initial conditions
-	app, ctx := s.app, s.ctx            // get ctx after init
 
 	// The "bum" user from the init scenario is being used because it
 	// possesses no assets or collateral.
 
 	// bum attempts to borrow 200 umee, fails because of insufficient collateral
-	err := s.app.LeverageKeeper.BorrowAsset(ctx,bumAddr,tCoin("umee",200))
+	err := s.app.LeverageKeeper.BorrowAsset(s.ctx, bumAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
 	s.Require().Error(err)
 }
-*/
 
 func (s *IntegrationTestSuite) TestBorrowAsset_InsufficientLendingPool() {
 	// Any user from the init scenario can perform this test, because it errors on module balance
@@ -382,21 +378,21 @@ func (s *IntegrationTestSuite) TestBorrowAsset_Valid() {
 	// The "lender" user from the init scenario is being used because it
 	// already has 1k u/umee for collateral
 
-	// lender borrows 200 umee
-	err := s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
+	// lender borrows 20 umee
+	err := s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
 	s.Require().NoError(err)
 
-	// verify lender's new loan amount in the correct denom (200 umee)
+	// verify lender's new loan amount in the correct denom (20 umee)
 	loanBalance := s.app.LeverageKeeper.GetBorrow(s.ctx, lenderAddr, umeeapp.BondDenom)
-	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
+	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
 
-	// verify lender's total loan balance (sdk.Coins) is also 200 umee (no other coins present)
-	totalLoanBalance, err := s.app.LeverageKeeper.GetBorrowerBorrows(s.ctx, lenderAddr)
-	s.Require().Equal(totalLoanBalance, sdk.NewCoins(sdk.NewInt64Coin(umeeapp.BondDenom, 200000000)))
+	// verify lender's total loan balance (sdk.Coins) is also 20 umee (no other coins present)
+	totalLoanBalance := s.app.LeverageKeeper.GetBorrowerBorrows(s.ctx, lenderAddr)
+	s.Require().Equal(totalLoanBalance, sdk.NewCoins(sdk.NewInt64Coin(umeeapp.BondDenom, 20000000)))
 
-	// verify lender's new umee balance (10 - 1k from initial + 200 from loan = 9200 umee)
+	// verify lender's new umee balance (10 - 1k from initial + 20 from loan = 9020 umee)
 	tokenBalance := s.app.BankKeeper.GetBalance(s.ctx, lenderAddr, umeeapp.BondDenom)
-	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9200000000))
+	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9020000000))
 
 	// verify lender's uToken balance remains at 0 u/umee from initial conditions
 	uTokenBalance := s.app.BankKeeper.GetBalance(s.ctx, lenderAddr, "u/"+umeeapp.BondDenom)
@@ -412,17 +408,17 @@ func (s *IntegrationTestSuite) TestBorrowAsset_Reserved() {
 	// already has 1k u/umee for collateral.
 	lenderAddr, _ := s.initBorrowScenario()
 
-	// artifically reserve 200 umee
-	err := s.app.LeverageKeeper.IncreaseReserves(s.ctx, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
+	// artifically reserve 900 umee
+	err := s.app.LeverageKeeper.IncreaseReserves(s.ctx, sdk.NewInt64Coin(umeeapp.BondDenom, 900000000))
 	s.Require().NoError(err)
 
-	// Lender tries to borrow 1000 umee, insufficient balance because 200 of the
+	// Lender tries to borrow 200 umee, insufficient balance because 900 of the
 	// module's 1000 umee are reserved.
-	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 1000000000))
+	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
 	s.Require().Error(err)
 
-	// lender borrows 800 umee
-	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 800000000))
+	// lender borrows 100 umee
+	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 100000000))
 	s.Require().NoError(err)
 }
 
@@ -432,22 +428,22 @@ func (s *IntegrationTestSuite) TestRepayAsset_Valid() {
 	lenderAddr, _ := s.initBorrowScenario()
 	app, ctx := s.app, s.ctx
 
-	// lender borrows 200 umee
-	err := s.app.LeverageKeeper.BorrowAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
+	// lender borrows 20 umee
+	err := s.app.LeverageKeeper.BorrowAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
 	s.Require().NoError(err)
 
-	// lender repays 80 umee
-	repaid, err := s.app.LeverageKeeper.RepayAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 80000000))
+	// lender repays 8 umee
+	repaid, err := s.app.LeverageKeeper.RepayAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 8000000))
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewInt(80000000), repaid)
+	s.Require().Equal(sdk.NewInt(8000000), repaid)
 
-	// verify lender's new loan amount (120 umee)
+	// verify lender's new loan amount (12 umee)
 	loanBalance := s.app.LeverageKeeper.GetBorrow(ctx, lenderAddr, umeeapp.BondDenom)
-	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 120000000))
+	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 12000000))
 
-	// verify lender's new umee balance (10 - 1k from initial + 200 from loan - 80 repaid = 9120 umee)
+	// verify lender's new umee balance (10 - 1k from initial + 20 from loan - 8 repaid = 9012 umee)
 	tokenBalance := app.BankKeeper.GetBalance(ctx, lenderAddr, umeeapp.BondDenom)
-	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9120000000))
+	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9012000000))
 
 	// verify lender's uToken balance remains at 0 u/umee from initial conditions
 	uTokenBalance := s.app.BankKeeper.GetBalance(s.ctx, lenderAddr, "u/"+umeeapp.BondDenom)
@@ -457,16 +453,16 @@ func (s *IntegrationTestSuite) TestRepayAsset_Valid() {
 	collateralBalance := s.app.LeverageKeeper.GetCollateralAmount(s.ctx, lenderAddr, "u/"+umeeapp.BondDenom)
 	s.Require().Equal(collateralBalance, sdk.NewInt64Coin("u/"+umeeapp.BondDenom, 1000000000))
 
-	// lender repays 120 umee (loan repaid in full)
-	repaid, err = s.app.LeverageKeeper.RepayAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 120000000))
+	// lender repays 12 umee (loan repaid in full)
+	repaid, err = s.app.LeverageKeeper.RepayAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 12000000))
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewInt(120000000), repaid)
+	s.Require().Equal(sdk.NewInt(12000000), repaid)
 
 	// verify lender's new loan amount in the correct denom (zero)
 	loanBalance = s.app.LeverageKeeper.GetBorrow(ctx, lenderAddr, umeeapp.BondDenom)
 	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 0))
 
-	// verify lender's new umee balance (10 - 1k from initial + 200 from loan - 200 repaid = 9000 umee)
+	// verify lender's new umee balance (10 - 1k from initial + 20 from loan - 20 repaid = 9000 umee)
 	tokenBalance = app.BankKeeper.GetBalance(ctx, lenderAddr, umeeapp.BondDenom)
 	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9000000000))
 
@@ -486,24 +482,24 @@ func (s *IntegrationTestSuite) TestRepayAsset_Overpay() {
 	lenderAddr, _ := s.initBorrowScenario()
 	app, ctx := s.app, s.ctx
 
-	// lender borrows 200 umee
-	err := s.app.LeverageKeeper.BorrowAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 200000000))
+	// lender borrows 20 umee
+	err := s.app.LeverageKeeper.BorrowAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
 	s.Require().NoError(err)
 
-	// lender repays 300 umee - should automatically reduce to 200 (the loan amount) and succeed
-	coinToRepay := sdk.NewInt64Coin(umeeapp.BondDenom, 300000000)
+	// lender repays 30 umee - should automatically reduce to 20 (the loan amount) and succeed
+	coinToRepay := sdk.NewInt64Coin(umeeapp.BondDenom, 30000000)
 	repaid, err := s.app.LeverageKeeper.RepayAsset(ctx, lenderAddr, coinToRepay)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewInt(200000000), repaid)
+	s.Require().Equal(sdk.NewInt(20000000), repaid)
 
 	// verify that coinToRepay has not been modified
-	s.Require().Equal(sdk.NewInt(300000000), coinToRepay.Amount)
+	s.Require().Equal(sdk.NewInt(30000000), coinToRepay.Amount)
 
 	// verify lender's new loan amount is 0 umee
 	loanBalance := s.app.LeverageKeeper.GetBorrow(ctx, lenderAddr, umeeapp.BondDenom)
 	s.Require().Equal(loanBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 0))
 
-	// verify lender's new umee balance (10 - 1k from initial + 200 from loan - 200 repaid = 9000 umee)
+	// verify lender's new umee balance (10 - 1k from initial + 20 from loan - 20 repaid = 9000 umee)
 	tokenBalance := app.BankKeeper.GetBalance(ctx, lenderAddr, umeeapp.BondDenom)
 	s.Require().Equal(tokenBalance, sdk.NewInt64Coin(umeeapp.BondDenom, 9000000000))
 
@@ -699,6 +695,19 @@ func (s *IntegrationTestSuite) TestBorrowUtilizationNoReserves() {
 	s.Require().NoError(err)
 	s.Require().Equal(util, sdk.MustNewDecFromStr("0.05"))
 
+	// Note: Setting umee collateral weight to 1.0 to allow lender to borrow heavily
+	umeeToken := types.Token{
+		BaseDenom:            umeeapp.BondDenom,
+		ReserveFactor:        sdk.MustNewDecFromStr("0.25"),
+		CollateralWeight:     sdk.MustNewDecFromStr("1.0"),
+		BaseBorrowRate:       sdk.MustNewDecFromStr("0.02"),
+		KinkBorrowRate:       sdk.MustNewDecFromStr("0.2"),
+		MaxBorrowRate:        sdk.MustNewDecFromStr("1.0"),
+		KinkUtilizationRate:  sdk.MustNewDecFromStr("0.8"),
+		LiquidationIncentive: sdk.MustNewDecFromStr("0.1"),
+	}
+	s.app.LeverageKeeper.SetRegisteredToken(s.ctx, umeeToken)
+
 	// lender borrows 950 umee, reducing module account to 0 umee
 	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 950000000))
 	s.Require().NoError(err)
@@ -737,6 +746,19 @@ func (s *IntegrationTestSuite) TestBorrowUtilizationWithReserves() {
 	util, err = s.app.LeverageKeeper.GetBorrowUtilization(s.ctx, umeeapp.BondDenom, sdk.NewInt(70000000))
 	s.Require().NoError(err)
 	s.Require().Equal(util, sdk.MustNewDecFromStr("0.10"))
+
+	// Note: Setting umee collateral weight to 1.0 to allow lender to borrow heavily
+	umeeToken := types.Token{
+		BaseDenom:            umeeapp.BondDenom,
+		ReserveFactor:        sdk.MustNewDecFromStr("0.25"),
+		CollateralWeight:     sdk.MustNewDecFromStr("1.0"),
+		BaseBorrowRate:       sdk.MustNewDecFromStr("0.02"),
+		KinkBorrowRate:       sdk.MustNewDecFromStr("0.2"),
+		MaxBorrowRate:        sdk.MustNewDecFromStr("1.0"),
+		KinkUtilizationRate:  sdk.MustNewDecFromStr("0.8"),
+		LiquidationIncentive: sdk.MustNewDecFromStr("0.1"),
+	}
+	s.app.LeverageKeeper.SetRegisteredToken(s.ctx, umeeToken)
 
 	// lender borrows 630 umee
 	err = s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 630000000))


### PR DESCRIPTION
## Description

Adds borrow limit restrictions to `MsgWithdrawAsset`, `MsgBorrowAsset`, and `MsgSetCollateral` (when disabling).

Fix unrelated tests that were borrowing more than `CollateralWeight` = 0.1 for `uumee` would allow.

closes: #213 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
