### PR TITLE
fix: only allow delegated addresses to submit votes

### DIFF
--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -388,11 +388,9 @@ func (k Keeper) IterateAggregateExchangeRateVotes(
 
 // ValidateFeeder returns the given feeder is allowed to feed the message or not.
 func (k Keeper) ValidateFeeder(ctx sdk.Context, feederAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
-	if !feederAddr.Equals(valAddr) {
-		delegate := k.GetFeederDelegation(ctx, valAddr)
-		if !delegate.Equals(feederAddr) {
-			return sdkerrors.Wrap(types.ErrNoVotingPermission, feederAddr.String())
-		}
+	delegate := k.GetFeederDelegation(ctx, valAddr)
+	if !delegate.Equals(feederAddr) {
+		return sdkerrors.Wrap(types.ErrNoVotingPermission, feederAddr.String())
 	}
 
 	// check that the given validator exists

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -99,11 +99,15 @@ func (s *IntegrationTestSuite) TestSetFeederDelegation() {
 	feederAcc := app.AccountKeeper.NewAccountWithAddress(ctx, feederAddr)
 	app.AccountKeeper.SetAccount(ctx, feederAcc)
 
-	err := s.app.OracleKeeper.ValidateFeeder(ctx, feederAddr, valAddr)
+	err := s.app.OracleKeeper.ValidateFeeder(ctx, addr, valAddr)
+	s.Require().NoError(err)
+	err = s.app.OracleKeeper.ValidateFeeder(ctx, feederAddr, valAddr)
 	s.Require().Error(err)
 
 	s.app.OracleKeeper.SetFeederDelegation(ctx, valAddr, feederAddr)
 
+	err = s.app.OracleKeeper.ValidateFeeder(ctx, addr, valAddr)
+	s.Require().Error(err)
 	err = s.app.OracleKeeper.ValidateFeeder(ctx, feederAddr, valAddr)
 	s.Require().NoError(err)
 }


### PR DESCRIPTION
## Description

Updates `ValidateFeeder` so that if a validator has delegated to a different address, only accept votes from that address

closes: #322

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
