### PR TITLE
fix: ensure safety against empty exchange rates

### DIFF
--- a/x/leverage/keeper/oracle.go
+++ b/x/leverage/keeper/oracle.go
@@ -15,7 +15,6 @@ import (
 // This function will not panic or return non-positive exchange rates, preferring
 // to error instead.
 func (k Keeper) TokenPrice(ctx sdk.Context, denom string) (price sdk.Dec, err error) {
-
 	if !k.IsAcceptedToken(ctx, denom) {
 		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrInvalidAsset, denom)
 	}

--- a/x/leverage/keeper/oracle.go
+++ b/x/leverage/keeper/oracle.go
@@ -12,23 +12,14 @@ import (
 // the base and display/symbol denominations for each exchange pair. E.g. it must
 // know about the UMEE/USD exchange rate along with the uumee base denomination
 // and the exponent.
-// This function will not panic or return non-positive exchange rates, preferring
+// This function will not return non-positive exchange rates, preferring
 // to error instead.
-func (k Keeper) TokenPrice(ctx sdk.Context, denom string) (price sdk.Dec, err error) {
+func (k Keeper) TokenPrice(ctx sdk.Context, denom string) (sdk.Dec, error) {
 	if !k.IsAcceptedToken(ctx, denom) {
 		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrInvalidAsset, denom)
 	}
 
-	defer func() {
-		// This will catch panics from the function body
-		// and instead return a general error.
-		if pan := recover(); pan != nil {
-			price = sdk.ZeroDec()
-			err = sdkerrors.Wrap(types.ErrOraclePanic, denom)
-		}
-	}()
-
-	price, err = k.oracleKeeper.GetExchangeRateBase(ctx, denom)
+	price, err := k.oracleKeeper.GetExchangeRateBase(ctx, denom)
 	if err != nil {
 		return sdk.ZeroDec(), err
 	}

--- a/x/leverage/keeper/oracle.go
+++ b/x/leverage/keeper/oracle.go
@@ -12,12 +12,33 @@ import (
 // the base and display/symbol denominations for each exchange pair. E.g. it must
 // know about the UMEE/USD exchange rate along with the uumee base denomination
 // and the exponent.
-func (k Keeper) TokenPrice(ctx sdk.Context, denom string) (sdk.Dec, error) {
+// This function will not panic or return non-positive exchange rates, preferring
+// to error instead.
+func (k Keeper) TokenPrice(ctx sdk.Context, denom string) (price sdk.Dec, err error) {
+
 	if !k.IsAcceptedToken(ctx, denom) {
 		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrInvalidAsset, denom)
 	}
 
-	return k.oracleKeeper.GetExchangeRateBase(ctx, denom)
+	defer func() {
+		// This will catch panics from the function body
+		// and instead return a general error.
+		if pan := recover(); pan != nil {
+			price = sdk.ZeroDec()
+			err = sdkerrors.Wrap(types.ErrOraclePanic, denom)
+		}
+	}()
+
+	price, err = k.oracleKeeper.GetExchangeRateBase(ctx, denom)
+	if err != nil {
+		return sdk.ZeroDec(), err
+	}
+
+	if price.IsNil() || !price.IsPositive() {
+		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrInvalidOraclePrice, denom)
+	}
+
+	return price, nil
 }
 
 // TokenValue returns the total token value given a Coin. An error is

--- a/x/leverage/types/errors.go
+++ b/x/leverage/types/errors.go
@@ -20,5 +20,4 @@ var (
 	ErrLiquidatorBalanceZero   = sdkerrors.Register(ModuleName, 1110, "liquidator base asset balance is zero")
 	ErrNegativeTimeElapsed     = sdkerrors.Register(ModuleName, 1111, "negative time elapsed since last interest time")
 	ErrInvalidOraclePrice      = sdkerrors.Register(ModuleName, 1112, "invalid oracle price")
-	ErrOraclePanic             = sdkerrors.Register(ModuleName, 1113, "oracle module panicked")
 )

--- a/x/leverage/types/errors.go
+++ b/x/leverage/types/errors.go
@@ -19,4 +19,6 @@ var (
 	ErrBadValue                = sdkerrors.Register(ModuleName, 1109, "bad USD value")
 	ErrLiquidatorBalanceZero   = sdkerrors.Register(ModuleName, 1110, "liquidator base asset balance is zero")
 	ErrNegativeTimeElapsed     = sdkerrors.Register(ModuleName, 1111, "negative time elapsed since last interest time")
+	ErrInvalidOraclePrice      = sdkerrors.Register(ModuleName, 1112, "invalid oracle price")
+	ErrOraclePanic             = sdkerrors.Register(ModuleName, 1113, "oracle module panicked")
 )


### PR DESCRIPTION
## Description

`TokenPrice`, which is the leverage module's single path to `x/oracle`, is not protected against nil/negative/zero exchange rates, and oracle panics. 

It will return errors in those cases.

closes: #329

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
