### PR TITLE
chore: add additional oracle CLI tests

### DIFF
--- a/x/oracle/client/tests/suite.go
+++ b/x/oracle/client/tests/suite.go
@@ -170,6 +170,22 @@ func (s *IntegrationTestSuite) TestQueryExchangeRates() {
 	s.Require().False(res.ExchangeRates[0].Amount.IsZero())
 }
 
+func (s *IntegrationTestSuite) TestQueryParams() {
+	val := s.network.Validators[0]
+	clientCtx := val.ClientCtx
+
+	args := []string{
+		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+	}
+	out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdQueryParams(), args)
+	s.Require().NoError(err)
+
+	var res types.QueryParamsResponse
+	s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &res))
+
+	s.Require().NotEmpty(res.Params.AcceptList)
+}
+
 func (s *IntegrationTestSuite) TestQueryExchangeRate() {
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx


### PR DESCRIPTION
## Description

Add an additional CLI test for the oracle module. This pretty much wraps it up apart from querying pre-votes and votes, which require a price-feeder running.

closes: #266

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
