### PR TITLE
refactor: remove oracle vote abstaining

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -131,8 +131,7 @@ func Tally(
 	rewardSpread = sdk.MaxDec(rewardSpread, standardDeviation)
 
 	for _, tallyVote := range ballot {
-		// Filter ballot winners. For voters, we
-		// filter out the tally vote iff:
+		// Filter ballot winners. For voters, we filter out the tally vote iff:
 		// (weightedMedian - rewardSpread) <= ExchangeRate <= (weightedMedian + rewardSpread)
 		if (tallyVote.ExchangeRate.GTE(weightedMedian.Sub(rewardSpread)) &&
 			tallyVote.ExchangeRate.LTE(weightedMedian.Add(rewardSpread))) ||

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -60,7 +60,6 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 
 		// Organize votes to ballot by denom
 		// NOTE: **Filter out inactive or jailed validators**
-		// NOTE: **Make abstain votes to have zero vote power**
 		voteMap := k.OrganizeBallotByDenom(ctx, validatorClaimMap)
 
 		ballotDenomSlice := types.BallotMapToSlice(voteMap)
@@ -81,7 +80,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 		voteTargetsLen := len(voteTargets)
 		claimSlice := types.ClaimMapToSlice(validatorClaimMap)
 		for _, claim := range claimSlice {
-			// Skip abstain & valid voters
+			// Skip valid voters
 			if int(claim.WinCount) == voteTargetsLen {
 				continue
 			}
@@ -132,10 +131,9 @@ func Tally(
 	rewardSpread = sdk.MaxDec(rewardSpread, standardDeviation)
 
 	for _, tallyVote := range ballot {
-		// Filter ballot winners and abstain voters. For non-abstain voters, we
+		// Filter ballot winners. For voters, we
 		// filter out the tally vote iff:
 		// (weightedMedian - rewardSpread) <= ExchangeRate <= (weightedMedian + rewardSpread)
-		// or if the exchange rate is negative or zero.
 		if (tallyVote.ExchangeRate.GTE(weightedMedian.Sub(rewardSpread)) &&
 			tallyVote.ExchangeRate.LTE(weightedMedian.Add(rewardSpread))) ||
 			!tallyVote.ExchangeRate.IsPositive() {

--- a/x/oracle/keeper/ballot.go
+++ b/x/oracle/keeper/ballot.go
@@ -25,10 +25,6 @@ func (k Keeper) OrganizeBallotByDenom(
 
 			for _, tuple := range vote.ExchangeRateTuples {
 				tmpPower := power
-				if !tuple.ExchangeRate.IsPositive() {
-					// make the power of abstain vote zero
-					tmpPower = 0
-				}
 
 				votes[tuple.Denom] = append(
 					votes[tuple.Denom],

--- a/x/oracle/keeper/msg_server.go
+++ b/x/oracle/keeper/msg_server.go
@@ -108,13 +108,6 @@ func (ms msgServer) AggregateExchangeRateVote(
 		return nil, sdkerrors.Wrapf(types.ErrVerificationFailed, "must be given %s not %s", aggregatePrevote.Hash, hash)
 	}
 
-	// Verify all exchange rates are positive
-	for _, v := range exchangeRateTuples {
-		if !v.ExchangeRate.IsPositive() {
-			return nil, types.ErrNegativeOrZeroRate
-		}
-	}
-
 	// Move aggregate prevote to aggregate vote with given exchange rates
 	ms.SetAggregateExchangeRateVote(ctx, valAddr, types.NewAggregateExchangeRateVote(exchangeRateTuples, valAddr))
 	ms.DeleteAggregateExchangeRatePrevote(ctx, valAddr)

--- a/x/oracle/keeper/msg_server.go
+++ b/x/oracle/keeper/msg_server.go
@@ -108,6 +108,13 @@ func (ms msgServer) AggregateExchangeRateVote(
 		return nil, sdkerrors.Wrapf(types.ErrVerificationFailed, "must be given %s not %s", aggregatePrevote.Hash, hash)
 	}
 
+	// Verify all exchange rates are positive
+	for _, v := range exchangeRateTuples {
+		if !v.ExchangeRate.IsPositive() {
+			return nil, types.ErrNegativeOrZeroRate
+		}
+	}
+
 	// Move aggregate prevote to aggregate vote with given exchange rates
 	ms.SetAggregateExchangeRateVote(ctx, valAddr, types.NewAggregateExchangeRateVote(exchangeRateTuples, valAddr))
 	ms.DeleteAggregateExchangeRatePrevote(ctx, valAddr)

--- a/x/oracle/types/errors.go
+++ b/x/oracle/types/errors.go
@@ -22,4 +22,5 @@ var (
 	ErrNoAggregatePrevote    = sdkerrors.Register(ModuleName, 11, "no aggregate prevote")
 	ErrNoAggregateVote       = sdkerrors.Register(ModuleName, 12, "no aggregate vote")
 	ErrUnknownDenom          = sdkerrors.Register(ModuleName, 14, "unknown denom")
+	ErrNegativeOrZeroRate    = sdkerrors.Register(ModuleName, 15, "invalid exchange rate; should be positive")
 )

--- a/x/oracle/types/msgs_test.go
+++ b/x/oracle/types/msgs_test.go
@@ -71,7 +71,8 @@ func TestMsgAggregateExchangeRateVote(t *testing.T) {
 
 	invalidExchangeRates := "a,b"
 	exchangeRates := "foo:1.0,bar:1232.123"
-	abstainExchangeRates := "foo:0.0,bar:1232.132"
+	zeroExchangeRates := "foo:0.0,bar:1232.132"
+	negativeExchangeRates := "foo:-1234.5,bar:1232.132"
 	overFlowExchangeRates := "foo:1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0,bar:1232.132"
 
 	tests := []struct {
@@ -82,7 +83,8 @@ func TestMsgAggregateExchangeRateVote(t *testing.T) {
 	}{
 		{addrs[0], "123", exchangeRates, true},
 		{addrs[0], "123", invalidExchangeRates, false},
-		{addrs[0], "123", abstainExchangeRates, true},
+		{addrs[0], "123", zeroExchangeRates, false},
+		{addrs[0], "123", negativeExchangeRates, false},
 		{addrs[0], "123", overFlowExchangeRates, false},
 		{sdk.AccAddress{}, "123", exchangeRates, false},
 		{addrs[0], "", exchangeRates, false},

--- a/x/oracle/types/vote.go
+++ b/x/oracle/types/vote.go
@@ -89,7 +89,7 @@ func ParseExchangeRateTuples(tuplesStr string) (ExchangeRateTuples, error) {
 		if err != nil {
 			return nil, err
 		}
-		if decCoin == sdk.ZeroDec() {
+		if !decCoin.IsPositive() {
 			return nil, types.ErrInvalidOraclePrice
 		}
 

--- a/x/oracle/types/vote.go
+++ b/x/oracle/types/vote.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/umee-network/umee/x/leverage/types"
 	"gopkg.in/yaml.v2"
 )
 
@@ -87,6 +88,9 @@ func ParseExchangeRateTuples(tuplesStr string) (ExchangeRateTuples, error) {
 		decCoin, err := sdk.NewDecFromStr(denomAmountStr[1])
 		if err != nil {
 			return nil, err
+		}
+		if decCoin == sdk.ZeroDec() {
+			return nil, types.ErrInvalidOraclePrice
 		}
 
 		denom := strings.ToUpper(denomAmountStr[0])

--- a/x/oracle/types/vote_test.go
+++ b/x/oracle/types/vote_test.go
@@ -23,7 +23,11 @@ func TestParseExchangeRateTuples(t *testing.T) {
 	_, err = ParseExchangeRateTuples(invalidCoinsWithValid)
 	require.Error(t, err)
 
-	abstainCoinsWithValid := "uumee:0.0,uatom:123.1"
-	_, err = ParseExchangeRateTuples(abstainCoinsWithValid)
-	require.NoError(t, err)
+	zeroCoinsWithValid := "uumee:0.0,uatom:123.1"
+	_, err = ParseExchangeRateTuples(zeroCoinsWithValid)
+	require.Error(t, err)
+
+	negativeCoinsWithValid := "uumee:-1234.5,uatom:123.1"
+	_, err = ParseExchangeRateTuples(negativeCoinsWithValid)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

Removes oracle abstaining logic, adds erroring for votes on non-positive exchange rates

closes: #360

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
