### PR TITLE
chore: price-feeder: handle wrong tx response code

### DIFF
--- a/price-feeder/oracle/client/client.go
+++ b/price-feeder/oracle/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -142,6 +143,11 @@ func (oc OracleClient) BroadcastTx(nextBlockHeight int64, timeoutHeight int64, m
 		lastCheckHeight = latestBlockHeight
 
 		resp, err := BroadcastTx(clientCtx, factory, msgs...)
+		if resp != nil {
+			if resp.Code != 0 {
+				err = fmt.Errorf("invalid response code from tx")
+			}
+		}
 		if err != nil {
 			var (
 				code uint32

--- a/price-feeder/oracle/client/client.go
+++ b/price-feeder/oracle/client/client.go
@@ -143,10 +143,8 @@ func (oc OracleClient) BroadcastTx(nextBlockHeight int64, timeoutHeight int64, m
 		lastCheckHeight = latestBlockHeight
 
 		resp, err := BroadcastTx(clientCtx, factory, msgs...)
-		if resp != nil {
-			if resp.Code != 0 {
-				err = fmt.Errorf("invalid response code from tx")
-			}
+		if resp != nil && resp.Code != 0 {
+			err = fmt.Errorf("invalid response code from tx")
 		}
 		if err != nil {
 			var (

--- a/price-feeder/price-feeder.example.toml
+++ b/price-feeder/price-feeder.example.toml
@@ -23,7 +23,7 @@ quote = "USD"
 
 [account]
 address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
-chain_id = "umee-local-testnet"
+chain_id = "umee-local-beta-testnet"
 validator = "umeevaloper12tysz6mzrawenca2t3t7ltym4hfjj8a5upsn2k"
 
 [keyring]


### PR DESCRIPTION
## Description

Handles the edgecase where the tx response code for a prevote is not zero, but doesn't error. Happens when a signature fails, e.g. the wrong chain is in the config.
Also updated the example config with the beta chain name to make it a bit more plug-and-play.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
