### PR TITLE
feat: leverage invariants

### DIFF
--- a/x/leverage/keeper/borrows.go
+++ b/x/leverage/keeper/borrows.go
@@ -59,7 +59,7 @@ func (k Keeper) GetTotalBorrows(ctx sdk.Context) sdk.Coins {
 		key, val := iter.Key(), iter.Value()
 
 		// remove prefix | lengthPrefixed(addr) and null-terminator
-		denom := string(key[len(prefix)+int(key[len(prefix)]+1) : len(key)-1])
+		denom := types.DenomFromKeyWithAddress(key, prefix)
 
 		var amount sdk.Int
 		if err := amount.Unmarshal(val); err != nil {

--- a/x/leverage/keeper/borrows.go
+++ b/x/leverage/keeper/borrows.go
@@ -175,23 +175,6 @@ func (k Keeper) SetBadDebtAddress(ctx sdk.Context, denom string, borrowerAddr sd
 	}
 }
 
-// IterateBorrowAPY iterate through all the keys from the Borrow APY prefix
-// and then calls the iterate function with the denom and borrowAPY if this function
-// returns an error, it stops the for loop
-func (k Keeper) IterateBorrowAPY(ctx sdk.Context, iterate func(denom string, borrowAPY sdk.Dec) error) error {
-	prefix := types.CreateBorrowAPYKeyNoDenom()
-	return k.Iterate(ctx, prefix, func(key, val []byte) error {
-		denom := types.DenomFromKey(key, prefix)
-
-		var borrowAPY sdk.Dec
-		if err := borrowAPY.Unmarshal(val); err != nil {
-			return err
-		}
-
-		return iterate(denom, borrowAPY)
-	})
-}
-
 // GetBorrowAPY returns an sdk.Dec of an borrow APY
 // returns sdk.ZeroDec if not found
 func (k Keeper) GetBorrowAPY(ctx sdk.Context, denom string) sdk.Dec {

--- a/x/leverage/keeper/borrows.go
+++ b/x/leverage/keeper/borrows.go
@@ -175,6 +175,23 @@ func (k Keeper) SetBadDebtAddress(ctx sdk.Context, denom string, borrowerAddr sd
 	}
 }
 
+// IterateBorrowAPY iterate through all the keys from the Borrow APY prefix
+// and then calls the iterate function with the denom and borrowAPY if this function
+// returns an error, it stops the for loop
+func (k Keeper) IterateBorrowAPY(ctx sdk.Context, iterate func(denom string, borrowAPY sdk.Dec) error) error {
+	prefix := types.CreateBorrowAPYKeyNoDenom()
+	return k.Iterate(ctx, prefix, func(key, val []byte) error {
+		denom := types.DenomFromKey(key, prefix)
+
+		var borrowAPY sdk.Dec
+		if err := borrowAPY.Unmarshal(val); err != nil {
+			return err
+		}
+
+		return iterate(denom, borrowAPY)
+	})
+}
+
 // GetBorrowAPY returns an sdk.Dec of an borrow APY
 // returns sdk.ZeroDec if not found
 func (k Keeper) GetBorrowAPY(ctx sdk.Context, denom string) sdk.Dec {

--- a/x/leverage/keeper/exchange_rate.go
+++ b/x/leverage/keeper/exchange_rate.go
@@ -105,7 +105,7 @@ func (k Keeper) UpdateExchangeRates(ctx sdk.Context) error {
 		key, _ := iter.Key(), iter.Value()
 
 		// remove exchangeRatePrefix and null-terminator
-		denom := string(key[len(exchangeRatePrefix) : len(key)-1])
+		denom := types.DenomFromKey(key, exchangeRatePrefix)
 
 		// uToken exchange rate is equal to the token supply (including borrowed
 		// tokens yet to be repaid and excluding tokens reserved) divided by total

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -79,7 +79,7 @@ func ExchangeRatesInvariant(k Keeper) sdk.Invariant {
 			amount := sdk.ZeroDec()
 			if err := amount.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s: %+v\n", denom, val)
 				return nil
 			}
 

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -124,7 +124,7 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 			amount := sdk.ZeroInt()
 			if err := amount.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s: %+v\n", denom, val)
 				return nil
 			}
 
@@ -171,7 +171,7 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 			amount := sdk.ZeroInt()
 			if err := amount.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s - %s received an error while Unmarshal the byte %+v\n", denom, address.String(), val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s - %s: %+v\n", denom, address.String(), val)
 				return nil
 			}
 
@@ -218,7 +218,7 @@ func BorrowAmountInvariant(k Keeper) sdk.Invariant {
 			amount := sdk.ZeroInt()
 			if err := amount.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s - %s received an error while Unmarshal the byte %+v\n", denom, address.String(), val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s - %s: %+v\n", denom, address.String(), val)
 				return nil
 			}
 
@@ -262,7 +262,7 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 			var borrowAPY sdk.Dec
 			if err := borrowAPY.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s: %+v\n", denom, val)
 				return nil
 			}
 
@@ -306,7 +306,7 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 			var lendAPY sdk.Dec
 			if err := lendAPY.Unmarshal(val); err != nil {
 				count++
-				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
+				msg += fmt.Sprintf("\tfailed to unmarshal bytes for %s: %+v\n", denom, val)
 				return nil
 			}
 

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -253,7 +253,7 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 		borrowAPYprefix := types.CreateBorrowAPYKeyNoDenom()
 
 		// Iterate through all denoms which have an Borrow APY stored
-		// in the keeper. If a token is registered but its borrow APY is
+		// in the keeper. If a borrow APY is registered but it is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
 		err := k.iterate(ctx, borrowAPYprefix, func(key, val []byte) error {
@@ -297,7 +297,7 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 		lendAPYprefix := types.CreateLendAPYKeyNoDenom()
 
 		// Iterate through all denoms which have an lend APY stored
-		// in the keeper. If a token is registered but its lend APY is
+		// in the keeper. If a lend APY is registered but it is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
 		err := k.iterate(ctx, lendAPYprefix, func(key, val []byte) error {

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -72,7 +72,7 @@ func ExchangeRatesInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its exchange rate is
 		// lower than 1.0 or it has some error doing the unmarshal it
 		// adds the denom invariant count and message description
-		err := k.Iterate(ctx, exchangeRatePrefix, func(key, val []byte) error {
+		err := k.iterate(ctx, exchangeRatePrefix, func(key, val []byte) error {
 			// remove exchangeRatePrefix and null-terminator
 			denom := types.DenomFromKey(key, exchangeRatePrefix)
 
@@ -117,7 +117,7 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its reserve amount is
 		// negative or it has some error doing the unmarshal it
 		// adds the denom invariant count and message description
-		err := k.Iterate(ctx, reserveAmountPrefix, func(key, val []byte) error {
+		err := k.iterate(ctx, reserveAmountPrefix, func(key, val []byte) error {
 			// remove reserveAmountPrefix and null-terminator
 			denom := types.DenomFromKey(key, reserveAmountPrefix)
 
@@ -162,7 +162,7 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its borrow amount is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
-		err := k.Iterate(ctx, collateralPrefix, func(key, val []byte) error {
+		err := k.iterate(ctx, collateralPrefix, func(key, val []byte) error {
 			// remove prefix | lengthPrefixed(addr) and null-terminator
 			denom := types.DenomFromKeyWithAddress(key, collateralPrefix)
 			// remove prefix | denom and null-terminator
@@ -209,7 +209,7 @@ func BorrowAmountInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its borrow amount is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
-		err := k.Iterate(ctx, loanKeyPrefix, func(key, val []byte) error {
+		err := k.iterate(ctx, loanKeyPrefix, func(key, val []byte) error {
 			// remove prefix | lengthPrefixed(addr) and null-terminator
 			denom := types.DenomFromKeyWithAddress(key, loanKeyPrefix)
 			// remove prefix | denom and null-terminator
@@ -256,7 +256,7 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its borrow APY is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
-		err := k.Iterate(ctx, borrowAPYprefix, func(key, val []byte) error {
+		err := k.iterate(ctx, borrowAPYprefix, func(key, val []byte) error {
 			denom := types.DenomFromKey(key, borrowAPYprefix)
 
 			var borrowAPY sdk.Dec
@@ -300,7 +300,7 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 		// in the keeper. If a token is registered but its lend APY is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
-		err := k.Iterate(ctx, lendAPYprefix, func(key, val []byte) error {
+		err := k.iterate(ctx, lendAPYprefix, func(key, val []byte) error {
 			denom := types.DenomFromKey(key, lendAPYprefix)
 
 			var lendAPY sdk.Dec

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -1,0 +1,127 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/umee-network/umee/x/leverage/types"
+)
+
+const (
+	routeExchangeRates = "exchange-rates"
+	routeReserveAmount = "reserve-amount"
+)
+
+// RegisterInvariants registers the leverage module invariants
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, routeExchangeRates, ExchangeRatesInvariant(k))
+	ir.RegisterRoute(types.ModuleName, routeReserveAmount, ReserveAmountInvariant(k))
+}
+
+// AllInvariants runs all invariants of the x/leverage module.
+func AllInvariants(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		res, stop := ExchangeRatesInvariant(k)(ctx)
+		if stop {
+			return res, stop
+		}
+
+		return ReserveAmountInvariant(k)(ctx)
+	}
+}
+
+// ExchangeRatesInvariant checks that all exchante rate denom are bigger or equal to 1
+func ExchangeRatesInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var (
+			msg   string
+			count int
+		)
+
+		store := ctx.KVStore(k.storeKey)
+
+		exchangeRatePrefix := types.CreateExchangeRateKeyNoDenom()
+
+		iter := sdk.KVStorePrefixIterator(store, exchangeRatePrefix)
+		defer iter.Close()
+
+		// Iterate throught all denoms which have an exchange rate stored
+		// in the keeper. If a token is registered but its exchange rate is
+		// lower than 1.0 or it has some error doing the unmarshal it
+		// adds the denom invariant count and message description
+		for ; iter.Valid(); iter.Next() {
+			// key is exchangeRatePrefix | denom | 0x00
+			key, bz := iter.Key(), iter.Value()
+
+			// remove exchangeRatePrefix and null-terminator
+			denom := types.DenomFromKey(key, exchangeRatePrefix)
+
+			amount := sdk.ZeroDec()
+			if err := amount.Unmarshal(bz); err != nil {
+				count++
+				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, bz)
+				continue
+			}
+
+			if amount.LT(sdk.OneDec()) {
+				count++
+				msg += fmt.Sprintf("\t%s exchange rate %s is lower than one\n", denom, amount.String())
+			}
+		}
+
+		broken := count != 0
+
+		return sdk.FormatInvariant(
+			types.ModuleName, routeExchangeRates,
+			fmt.Sprintf("amount of exchange rate lower than one %d\n%s", count, msg),
+		), broken
+	}
+}
+
+// ReserveAmountInvariant checks that reserve amounts have non-negative balances
+func ReserveAmountInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var (
+			msg   string
+			count int
+		)
+
+		store := ctx.KVStore(k.storeKey)
+
+		reserveAmountPrefix := types.CreateReserveAmountKeyNoDenom()
+
+		iter := sdk.KVStorePrefixIterator(store, reserveAmountPrefix)
+		defer iter.Close()
+
+		// Iterate throught all denoms which have an reserve amount stored
+		// in the keeper. If a token is registered but its reserve amount is
+		// negative or it has some error doing the unmarshal it
+		// adds the denom invariant count and message description
+		for ; iter.Valid(); iter.Next() {
+			// key is reserveAmountPrefix | denom | 0x00
+			key, bz := iter.Key(), iter.Value()
+
+			// remove reserveAmountPrefix and null-terminator
+			denom := types.DenomFromKey(key, reserveAmountPrefix)
+
+			amount := sdk.ZeroInt()
+			if err := amount.Unmarshal(bz); err != nil {
+				count++
+				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, bz)
+				continue
+			}
+
+			if amount.IsNegative() {
+				count++
+				msg += fmt.Sprintf("\t%s reserve amount %s is negative\n", denom, amount.String())
+			}
+		}
+
+		broken := count != 0
+
+		return sdk.FormatInvariant(
+			types.ModuleName, routeReserveAmount,
+			fmt.Sprintf("number of negative reserve amount found %d\n%s", count, msg),
+		), broken
+	}
+}

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -59,20 +59,13 @@ func ExchangeRatesInvariant(k Keeper) sdk.Invariant {
 			count int
 		)
 
-		store := ctx.KVStore(k.storeKey)
 		exchangeRatePrefix := types.CreateExchangeRateKeyNoDenom()
-
-		iter := sdk.KVStorePrefixIterator(store, exchangeRatePrefix)
-		defer iter.Close()
 
 		// Iterate through all denoms which have an exchange rate stored
 		// in the keeper. If a token is registered but its exchange rate is
 		// lower than 1.0 or it has some error doing the unmarshal it
 		// adds the denom invariant count and message description
-		for ; iter.Valid(); iter.Next() {
-			// key is exchangeRatePrefix | denom | 0x00
-			key, val := iter.Key(), iter.Value()
-
+		err := k.Iterate(ctx, exchangeRatePrefix, func(key, val []byte) error {
 			// remove exchangeRatePrefix and null-terminator
 			denom := types.DenomFromKey(key, exchangeRatePrefix)
 
@@ -80,13 +73,18 @@ func ExchangeRatesInvariant(k Keeper) sdk.Invariant {
 			if err := amount.Unmarshal(val); err != nil {
 				count++
 				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
-				continue
+				return nil
 			}
 
 			if amount.LT(sdk.OneDec()) {
 				count++
 				msg += fmt.Sprintf("\t%s exchange rate %s is lower than one\n", denom, amount.String())
 			}
+			return nil
+		})
+
+		if err != nil {
+			msg += fmt.Sprintf("\tSome error occurred while iterating through the exchange rates %+v\n", err)
 		}
 
 		broken := count != 0
@@ -106,20 +104,13 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 			count int
 		)
 
-		store := ctx.KVStore(k.storeKey)
 		reserveAmountPrefix := types.CreateReserveAmountKeyNoDenom()
-
-		iter := sdk.KVStorePrefixIterator(store, reserveAmountPrefix)
-		defer iter.Close()
 
 		// Iterate through all denoms which have an reserve amount stored
 		// in the keeper. If a token is registered but its reserve amount is
 		// negative or it has some error doing the unmarshal it
 		// adds the denom invariant count and message description
-		for ; iter.Valid(); iter.Next() {
-			// key is reserveAmountPrefix | denom | 0x00
-			key, val := iter.Key(), iter.Value()
-
+		err := k.Iterate(ctx, reserveAmountPrefix, func(key, val []byte) error {
 			// remove reserveAmountPrefix and null-terminator
 			denom := types.DenomFromKey(key, reserveAmountPrefix)
 
@@ -127,13 +118,18 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 			if err := amount.Unmarshal(val); err != nil {
 				count++
 				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
-				continue
+				return nil
 			}
 
 			if amount.IsNegative() {
 				count++
 				msg += fmt.Sprintf("\t%s reserve amount %s is negative\n", denom, amount.String())
 			}
+			return nil
+		})
+
+		if err != nil {
+			msg += fmt.Sprintf("\tSome error occurred while iterating through the reserve amount %+v\n", err)
 		}
 
 		broken := count != 0
@@ -141,55 +137,6 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 		return sdk.FormatInvariant(
 			types.ModuleName, routeReserveAmount,
 			fmt.Sprintf("number of negative reserve amount found %d\n%s", count, msg),
-		), broken
-	}
-}
-
-// BorrowAmountInvariant checks that borrow amounts have all positive values
-func BorrowAmountInvariant(k Keeper) sdk.Invariant {
-	return func(ctx sdk.Context) (string, bool) {
-		var (
-			msg   string
-			count int
-		)
-
-		store := ctx.KVStore(k.storeKey)
-		loanKeyPrefix := types.CreateLoanKeyNoAddress()
-
-		iter := sdk.KVStorePrefixIterator(store, loanKeyPrefix)
-		defer iter.Close()
-
-		// Iterate through all denoms which have an borrow amount stored
-		// in the keeper. If a token is registered but its borrow amount is
-		// not positive or it has some error doing the unmarshal it
-		// adds the denom and address invariant count and message description
-		for ; iter.Valid(); iter.Next() {
-			// key is prefix | lengthPrefixed(borrowerAddr) | denom | 0x00
-			key, val := iter.Key(), iter.Value()
-
-			// remove prefix | lengthPrefixed(addr) and null-terminator
-			denom := types.DenomFromKeyWithAddress(key, loanKeyPrefix)
-			// remove prefix | denom and null-terminator
-			address := types.AddressFromKey(key, loanKeyPrefix)
-
-			amount := sdk.ZeroInt()
-			if err := amount.Unmarshal(val); err != nil {
-				count++
-				msg += fmt.Sprintf("\t%s - %s received an error while Unmarshal the byte %+v\n", denom, address.String(), val)
-				continue
-			}
-
-			if !amount.IsPositive() {
-				count++
-				msg += fmt.Sprintf("\t%s - %s borrow amount %s is not positive\n", denom, address.String(), amount.String())
-			}
-		}
-
-		broken := count != 0
-
-		return sdk.FormatInvariant(
-			types.ModuleName, routeBorrowAmount,
-			fmt.Sprintf("number of not positive borrow amount found %d\n%s", count, msg),
 		), broken
 	}
 }
@@ -202,20 +149,13 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 			count int
 		)
 
-		store := ctx.KVStore(k.storeKey)
 		collateralPrefix := types.CreateCollateralAmountKeyNoAddress()
 
-		iter := sdk.KVStorePrefixIterator(store, collateralPrefix)
-		defer iter.Close()
-
-		// Iterate through all denoms which have an collateral amount stored
+		// Iterate through all denoms which have an borrow amount stored
 		// in the keeper. If a token is registered but its borrow amount is
 		// not positive or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
-		for ; iter.Valid(); iter.Next() {
-			// key is prefix | lengthPrefixed(borrowerAddr) | denom | 0x00
-			key, val := iter.Key(), iter.Value()
-
+		err := k.Iterate(ctx, collateralPrefix, func(key, val []byte) error {
 			// remove prefix | lengthPrefixed(addr) and null-terminator
 			denom := types.DenomFromKeyWithAddress(key, collateralPrefix)
 			// remove prefix | denom and null-terminator
@@ -225,13 +165,18 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 			if err := amount.Unmarshal(val); err != nil {
 				count++
 				msg += fmt.Sprintf("\t%s - %s received an error while Unmarshal the byte %+v\n", denom, address.String(), val)
-				continue
+				return nil
 			}
 
 			if !amount.IsPositive() {
 				count++
 				msg += fmt.Sprintf("\t%s - %s collateral amount %s is not positive\n", denom, address.String(), amount.String())
 			}
+			return nil
+		})
+
+		if err != nil {
+			msg += fmt.Sprintf("\tSome error occurred while iterating through the collateral amount %+v\n", err)
 		}
 
 		broken := count != 0
@@ -239,6 +184,53 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 		return sdk.FormatInvariant(
 			types.ModuleName, routeCollateralAmount,
 			fmt.Sprintf("number of not positive collateral amount found %d\n%s", count, msg),
+		), broken
+	}
+}
+
+// BorrowAmountInvariant checks that borrow amounts have all positive values
+func BorrowAmountInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var (
+			msg   string
+			count int
+		)
+
+		loanKeyPrefix := types.CreateLoanKeyNoAddress()
+
+		// Iterate through all denoms which have an borrow amount stored
+		// in the keeper. If a token is registered but its borrow amount is
+		// not positive or it has some error doing the unmarshal it
+		// adds the denom and address invariant count and message description
+		err := k.Iterate(ctx, loanKeyPrefix, func(key, val []byte) error {
+			// remove prefix | lengthPrefixed(addr) and null-terminator
+			denom := types.DenomFromKeyWithAddress(key, loanKeyPrefix)
+			// remove prefix | denom and null-terminator
+			address := types.AddressFromKey(key, loanKeyPrefix)
+
+			amount := sdk.ZeroInt()
+			if err := amount.Unmarshal(val); err != nil {
+				count++
+				msg += fmt.Sprintf("\t%s - %s received an error while Unmarshal the byte %+v\n", denom, address.String(), val)
+				return nil
+			}
+
+			if !amount.IsPositive() {
+				count++
+				msg += fmt.Sprintf("\t%s - %s borrow amount %s is not positive\n", denom, address.String(), amount.String())
+			}
+			return nil
+		})
+
+		if err != nil {
+			msg += fmt.Sprintf("\tSome error occurred while iterating through the borrow amount %+v\n", err)
+		}
+
+		broken := count != 0
+
+		return sdk.FormatInvariant(
+			types.ModuleName, routeBorrowAmount,
+			fmt.Sprintf("number of not positive borrow amount found %d\n%s", count, msg),
 		), broken
 	}
 }
@@ -251,13 +243,20 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 			count int
 		)
 
-		prefix := types.CreateBorrowAPYKeyNoDenom()
-		err := k.Iterate(ctx, prefix, func(key, val []byte) error {
-			denom := types.DenomFromKey(key, prefix)
+		borrowAPYprefix := types.CreateBorrowAPYKeyNoDenom()
+
+		// Iterate through all denoms which have an Borrow APY stored
+		// in the keeper. If a token is registered but its borrow APY is
+		// not positive or it has some error doing the unmarshal it
+		// adds the denom and address invariant count and message description
+		err := k.Iterate(ctx, borrowAPYprefix, func(key, val []byte) error {
+			denom := types.DenomFromKey(key, borrowAPYprefix)
 
 			var borrowAPY sdk.Dec
 			if err := borrowAPY.Unmarshal(val); err != nil {
-				return err
+				count++
+				msg += fmt.Sprintf("\t%s received an error while Unmarshal the byte %+v\n", denom, val)
+				return nil
 			}
 
 			if !borrowAPY.IsPositive() {

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -254,7 +254,7 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 
 		// Iterate through all denoms which have an Borrow APY stored
 		// in the keeper. If a borrow APY is registered but it is
-		// not positive or it has some error doing the unmarshal it
+		// negative or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
 		err := k.iterate(ctx, borrowAPYprefix, func(key, val []byte) error {
 			denom := types.DenomFromKey(key, borrowAPYprefix)
@@ -266,9 +266,9 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 				return nil
 			}
 
-			if !borrowAPY.IsPositive() {
+			if borrowAPY.IsNegative() {
 				count++
-				msg += fmt.Sprintf("\t%s borrow APY %s is not positive\n", denom, borrowAPY.String())
+				msg += fmt.Sprintf("\t%s borrow APY %s is negative\n", denom, borrowAPY.String())
 			}
 			return nil
 		})
@@ -281,7 +281,7 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 
 		return sdk.FormatInvariant(
 			types.ModuleName, routeBorrowAPY,
-			fmt.Sprintf("number of not positive borrow APY found %d\n%s", count, msg),
+			fmt.Sprintf("number of negative borrow APY found %d\n%s", count, msg),
 		), broken
 	}
 }
@@ -298,7 +298,7 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 
 		// Iterate through all denoms which have an lend APY stored
 		// in the keeper. If a lend APY is registered but it is
-		// not positive or it has some error doing the unmarshal it
+		// negative or it has some error doing the unmarshal it
 		// adds the denom and address invariant count and message description
 		err := k.iterate(ctx, lendAPYprefix, func(key, val []byte) error {
 			denom := types.DenomFromKey(key, lendAPYprefix)
@@ -310,9 +310,9 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 				return nil
 			}
 
-			if !lendAPY.IsPositive() {
+			if lendAPY.IsNegative() {
 				count++
-				msg += fmt.Sprintf("\t%s lend APY %s is not positive\n", denom, lendAPY.String())
+				msg += fmt.Sprintf("\t%s lend APY %s is negative\n", denom, lendAPY.String())
 			}
 			return nil
 		})
@@ -325,7 +325,7 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 
 		return sdk.FormatInvariant(
 			types.ModuleName, routeLendAPY,
-			fmt.Sprintf("number of not positive lend APY found %d\n%s", count, msg),
+			fmt.Sprintf("number of negative lend APY found %d\n%s", count, msg),
 		), broken
 	}
 }

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -588,7 +588,7 @@ func (k Keeper) LiquidationParams(ctx sdk.Context, reward string, borrowed, limi
 // Iterate through all the keys from that prefix and then calls
 // the iterate function with the key and value if this function
 // returns an error, it stops the for loop
-func (k Keeper) Iterate(ctx sdk.Context, prefix []byte, iterate func(key, val []byte) error) error {
+func (k Keeper) Iterate(ctx sdk.Context, prefix []byte, cb func(key, val []byte) error) error {
 	store := ctx.KVStore(k.storeKey)
 
 	iter := sdk.KVStorePrefixIterator(store, prefix)

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -584,3 +584,26 @@ func (k Keeper) LiquidationParams(ctx sdk.Context, reward string, borrowed, limi
 
 	return liquidationIncentive, closeFactor, nil
 }
+
+// Iterate through all the keys from that prefix and then calls
+// the iterate function with the key and value if this function
+// returns an error, it stops the for loop
+func (k Keeper) Iterate(ctx sdk.Context, prefix []byte, iterate func(key, val []byte) error) error {
+	store := ctx.KVStore(k.storeKey)
+
+	iter := sdk.KVStorePrefixIterator(store, prefix)
+	defer iter.Close()
+
+	// Iterate through all keys and values
+	// if any iterate function returns an error
+	// it stops the loop
+	for ; iter.Valid(); iter.Next() {
+		key, val := iter.Key(), iter.Value()
+
+		if err := iterate(key, val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -585,18 +585,15 @@ func (k Keeper) LiquidationParams(ctx sdk.Context, reward string, borrowed, limi
 	return liquidationIncentive, closeFactor, nil
 }
 
-// iterate through all the keys from that prefix and then calls
-// the iterate function with the key and value if this function
-// returns an error, it stops the for loop
+// iterate through all keys with a given prefix using a provided function.
+// If the provided function returns an error, iteration stops and the error
+// is returned.
 func (k Keeper) iterate(ctx sdk.Context, prefix []byte, cb func(key, val []byte) error) error {
 	store := ctx.KVStore(k.storeKey)
 
 	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 
-	// Iterate through all keys and values
-	// if any iterate function returns an error
-	// it stops the loop
 	for ; iter.Valid(); iter.Next() {
 		key, val := iter.Key(), iter.Value()
 

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -585,10 +585,10 @@ func (k Keeper) LiquidationParams(ctx sdk.Context, reward string, borrowed, limi
 	return liquidationIncentive, closeFactor, nil
 }
 
-// Iterate through all the keys from that prefix and then calls
+// iterate through all the keys from that prefix and then calls
 // the iterate function with the key and value if this function
 // returns an error, it stops the for loop
-func (k Keeper) Iterate(ctx sdk.Context, prefix []byte, cb func(key, val []byte) error) error {
+func (k Keeper) iterate(ctx sdk.Context, prefix []byte, cb func(key, val []byte) error) error {
 	store := ctx.KVStore(k.storeKey)
 
 	iter := sdk.KVStorePrefixIterator(store, prefix)
@@ -600,7 +600,7 @@ func (k Keeper) Iterate(ctx sdk.Context, prefix []byte, cb func(key, val []byte)
 	for ; iter.Valid(); iter.Next() {
 		key, val := iter.Key(), iter.Value()
 
-		if err := iterate(key, val); err != nil {
+		if err := cb(key, val); err != nil {
 			return err
 		}
 	}

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1197,6 +1197,27 @@ func (s *IntegrationTestSuite) TestReserveAmountInvariant() {
 	s.Require().False(broken)
 }
 
+func (s *IntegrationTestSuite) TestCollateralAmountInvariant() {
+	lenderAddr, _ := s.initBorrowScenario()
+
+	// The "lender" user from the init scenario is being used because it
+	// already has 1k u/umee for collateral
+
+	// it should not report any invariant
+	_, broken := keeper.CollateralAmountInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	uTokenDenom := types.UTokenFromTokenDenom(umeeapp.BondDenom)
+
+	// withdraw the lended umee in the initBorrowScenario
+	err := s.app.LeverageKeeper.WithdrawAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(uTokenDenom, 1000000000))
+	s.Require().NoError(err)
+
+	// it should not report any invariant
+	_, broken = keeper.CollateralAmountInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+}
+
 func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 	lenderAddr, _ := s.initBorrowScenario()
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1185,6 +1185,18 @@ func (s *IntegrationTestSuite) TestExchangeRatesInvariant() {
 	s.Require().Equal(expectedInvariant, invariant)
 }
 
+func (s *IntegrationTestSuite) TestReserveAmountInvariant() {
+	app, ctx := s.app, s.ctx
+
+	// artificially set reserves
+	err := app.LeverageKeeper.SetReserveAmount(ctx, sdk.NewInt64Coin(umeeapp.BondDenom, 300000000)) // 300 umee
+	s.Require().NoError(err)
+
+	// it should not report any invariant
+	_, broken := keeper.ExchangeRatesInvariant(app.LeverageKeeper)(ctx)
+	s.Require().False(broken)
+}
+
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
 }

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1170,7 +1170,7 @@ func (s *IntegrationTestSuite) TestExchangeRatesInvariant() {
 	err := app.LeverageKeeper.SetExchangeRate(ctx, umeeapp.BondDenom, sdk.MustNewDecFromStr("2.0"))
 	s.Require().NoError(err)
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.ExchangeRatesInvariant(app.LeverageKeeper)(ctx)
 	s.Require().False(broken)
 
@@ -1178,7 +1178,7 @@ func (s *IntegrationTestSuite) TestExchangeRatesInvariant() {
 	err = app.LeverageKeeper.SetExchangeRate(ctx, umeeapp.BondDenom, sdk.MustNewDecFromStr("0.9"))
 	s.Require().NoError(err)
 
-	// it should report one variant
+	// check invariant
 	invariant, broken := keeper.ExchangeRatesInvariant(app.LeverageKeeper)(ctx)
 	s.Require().True(broken)
 
@@ -1193,7 +1193,7 @@ func (s *IntegrationTestSuite) TestReserveAmountInvariant() {
 	err := app.LeverageKeeper.SetReserveAmount(ctx, sdk.NewInt64Coin(umeeapp.BondDenom, 300000000)) // 300 umee
 	s.Require().NoError(err)
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.ReserveAmountInvariant(app.LeverageKeeper)(ctx)
 	s.Require().False(broken)
 }
@@ -1204,7 +1204,7 @@ func (s *IntegrationTestSuite) TestCollateralAmountInvariant() {
 	// The "lender" user from the init scenario is being used because it
 	// already has 1k u/umee for collateral
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.CollateralAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
@@ -1214,7 +1214,7 @@ func (s *IntegrationTestSuite) TestCollateralAmountInvariant() {
 	err := s.app.LeverageKeeper.WithdrawAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(uTokenDenom, 1000000000))
 	s.Require().NoError(err)
 
-	// it should not report any invariant
+	// check invariant
 	_, broken = keeper.CollateralAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 }
@@ -1229,7 +1229,7 @@ func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 	err := s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
 	s.Require().NoError(err)
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.BorrowAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
@@ -1238,7 +1238,7 @@ func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 	_, err = s.app.LeverageKeeper.RepayAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 30000000))
 	s.Require().NoError(err)
 
-	// it should not report any invariant
+	// check invariant
 	_, broken = keeper.BorrowAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 }
@@ -1246,14 +1246,14 @@ func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
 	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
 	// sets the borrow APY to 0
 	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
 
-	// it should report an invariant because the borrow apy is set to 0
+	// check invariant
 	invariant, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 
@@ -1264,14 +1264,14 @@ func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
 func (s *IntegrationTestSuite) TestLendAPYInvariant() {
 	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
 
-	// it should not report any invariant
+	// check invariant
 	_, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
 	// sets the lend APY to 0
 	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
 
-	// it should report an invariant because the lend apy is set to 0
+	// check invariant
 	invariant, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1263,7 +1263,7 @@ func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
 	invariant, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 
-	expectedInvariant := "leverage: borrow-apy invariant\nnumber of not positive borrow APY found 1\n\tuumee borrow APY -1.000000000000000000 is negative\n\n"
+	expectedInvariant := "leverage: borrow-apy invariant\nnumber of negative borrow APY found 1\n\tuumee borrow APY -1.000000000000000000 is negative\n\n"
 	s.Require().Equal(expectedInvariant, invariant)
 }
 
@@ -1288,7 +1288,7 @@ func (s *IntegrationTestSuite) TestLendAPYInvariant() {
 	invariant, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 
-	expectedInvariant := "leverage: lend-apy invariant\nnumber of not positive lend APY found 1\n\tuumee lend APY -1.000000000000000000 is negative\n\n"
+	expectedInvariant := "leverage: lend-apy invariant\nnumber of negative lend APY found 1\n\tuumee lend APY -1.000000000000000000 is negative\n\n"
 	s.Require().Equal(expectedInvariant, invariant)
 }
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1193,7 +1193,31 @@ func (s *IntegrationTestSuite) TestReserveAmountInvariant() {
 	s.Require().NoError(err)
 
 	// it should not report any invariant
-	_, broken := keeper.ExchangeRatesInvariant(app.LeverageKeeper)(ctx)
+	_, broken := keeper.ReserveAmountInvariant(app.LeverageKeeper)(ctx)
+	s.Require().False(broken)
+}
+
+func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
+	lenderAddr, _ := s.initBorrowScenario()
+
+	// The "lender" user from the init scenario is being used because it
+	// already has 1k u/umee for collateral
+
+	// lender borrows 20 umee
+	err := s.app.LeverageKeeper.BorrowAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 20000000))
+	s.Require().NoError(err)
+
+	// it should not report any invariant
+	_, broken := keeper.BorrowAmountInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	// lender repays 30 umee, actually only 20 because is the min between
+	// the amount borrowed and the amount repaid
+	_, err = s.app.LeverageKeeper.RepayAsset(s.ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 30000000))
+	s.Require().NoError(err)
+
+	// it should not report any invariant
+	_, broken = keeper.BorrowAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 }
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -11,7 +11,6 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	"github.com/umee-network/umee/app"
 	umeeapp "github.com/umee-network/umee/app"
 	umeeappbeta "github.com/umee-network/umee/app/beta"
 	"github.com/umee-network/umee/x/leverage"
@@ -1244,14 +1243,14 @@ func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 }
 
 func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
-	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
+	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(2))
 
 	// check invariant
 	_, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
 	// sets the borrow APY to 0
-	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
+	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(0))
 
 	// check invariant
 	invariant, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
@@ -1262,14 +1261,14 @@ func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
 }
 
 func (s *IntegrationTestSuite) TestLendAPYInvariant() {
-	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
+	s.app.LeverageKeeper.SetLendAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(2))
 
 	// check invariant
 	_, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
 
 	// sets the lend APY to 0
-	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
+	s.app.LeverageKeeper.SetLendAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(0))
 
 	// check invariant
 	invariant, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1253,10 +1253,17 @@ func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
 	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(0))
 
 	// check invariant
+	_, broken = keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	// sets the borrow APY to an negative value
+	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(-1))
+
+	// check invariant
 	invariant, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 
-	expectedInvariant := "leverage: borrow-apy invariant\nnumber of not positive borrow APY found 1\n\tuumee borrow APY 0.000000000000000000 is not positive\n\n"
+	expectedInvariant := "leverage: borrow-apy invariant\nnumber of not positive borrow APY found 1\n\tuumee borrow APY -1.000000000000000000 is negative\n\n"
 	s.Require().Equal(expectedInvariant, invariant)
 }
 
@@ -1271,10 +1278,17 @@ func (s *IntegrationTestSuite) TestLendAPYInvariant() {
 	s.app.LeverageKeeper.SetLendAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(0))
 
 	// check invariant
+	_, broken = keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	// sets the lend APY to an negative value
+	s.app.LeverageKeeper.SetLendAPY(s.ctx, umeeapp.BondDenom, sdk.NewDec(-1))
+
+	// check invariant
 	invariant, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().True(broken)
 
-	expectedInvariant := "leverage: lend-apy invariant\nnumber of not positive lend APY found 1\n\tuumee lend APY 0.000000000000000000 is not positive\n\n"
+	expectedInvariant := "leverage: lend-apy invariant\nnumber of not positive lend APY found 1\n\tuumee lend APY -1.000000000000000000 is negative\n\n"
 	s.Require().Equal(expectedInvariant, invariant)
 }
 

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -11,6 +11,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
+	"github.com/umee-network/umee/app"
 	umeeapp "github.com/umee-network/umee/app"
 	umeeappbeta "github.com/umee-network/umee/app/beta"
 	"github.com/umee-network/umee/x/leverage"
@@ -1240,6 +1241,42 @@ func (s *IntegrationTestSuite) TestBorrowAmountInvariant() {
 	// it should not report any invariant
 	_, broken = keeper.BorrowAmountInvariant(s.app.LeverageKeeper)(s.ctx)
 	s.Require().False(broken)
+}
+
+func (s *IntegrationTestSuite) TestBorrowAPYInvariant() {
+	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
+
+	// it should not report any invariant
+	_, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	// sets the borrow APY to 0
+	s.app.LeverageKeeper.SetBorrowAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
+
+	// it should report an invariant because the borrow apy is set to 0
+	invariant, broken := keeper.BorrowAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().True(broken)
+
+	expectedInvariant := "leverage: borrow-apy invariant\nnumber of not positive borrow APY found 1\n\tuumee borrow APY 0.000000000000000000 is not positive\n\n"
+	s.Require().Equal(expectedInvariant, invariant)
+}
+
+func (s *IntegrationTestSuite) TestLendAPYInvariant() {
+	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(2))
+
+	// it should not report any invariant
+	_, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().False(broken)
+
+	// sets the lend APY to 0
+	s.app.LeverageKeeper.SetLendAPY(s.ctx, app.BondDenom, sdk.NewDec(0))
+
+	// it should report an invariant because the lend apy is set to 0
+	invariant, broken := keeper.LendAPYInvariant(s.app.LeverageKeeper)(s.ctx)
+	s.Require().True(broken)
+
+	expectedInvariant := "leverage: lend-apy invariant\nnumber of not positive lend APY found 1\n\tuumee lend APY 0.000000000000000000 is not positive\n\n"
+	s.Require().Equal(expectedInvariant, invariant)
 }
 
 func TestKeeperTestSuite(t *testing.T) {

--- a/x/leverage/module.go
+++ b/x/leverage/module.go
@@ -138,7 +138,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the x/leverage module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	keeper.RegisterInvariants(ir, am.keeper)
+}
 
 // InitGenesis performs the x/leverage module's genesis initialization. It returns
 // no validator updates.

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -112,6 +112,14 @@ func CreateReserveAmountKey(tokenDenom string) []byte {
 	return append(key, 0) // append 0 for null-termination
 }
 
+// CreateReserveAmountKeyNoDenom returns a safe copy of reserveAmountPrefix
+func CreateReserveAmountKeyNoDenom() []byte {
+	// reserveAmountPrefix
+	var key []byte
+	key = append(key, KeyPrefixReserveAmount...)
+	return key
+}
+
 // CreateLastInterestTimeKey returns a KVStore key for getting and setting the amount reserved of a a given token.
 func CreateLastInterestTimeKey() []byte {
 	// lastinterestprefix

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -186,3 +186,9 @@ func DenomFromKeyWithAddress(key []byte, prefix []byte) string {
 	addrLength := int(key[len(prefix)])
 	return string(key[len(prefix)+addrLength+1 : len(key)-1])
 }
+
+// DenomFromKey extracts denom from a key with the form
+// prefix | denom | 0x00
+func DenomFromKey(key []byte, prefix []byte) string {
+	return string(key[len(prefix) : len(key)-1])
+}

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -85,7 +85,7 @@ func CreateCollateralSettingKey(borrowerAddr sdk.AccAddress, uTokenDenom string)
 // CreateCollateralAmountKey returns a KVStore key for getting and setting the amount of
 // collateral stored for a lender in a given denom.
 func CreateCollateralAmountKey(lenderAddr sdk.AccAddress, uTokenDenom string) []byte {
-	// collateralprefix | lengthprefixed(lenderAddr) | denom | 0x00
+	// collateralPrefix | lengthprefixed(lenderAddr) | denom | 0x00
 	var key []byte
 	key = append(key, KeyPrefixCollateralAmount...)
 	key = append(key, address.MustLengthPrefix(lenderAddr)...)
@@ -96,10 +96,18 @@ func CreateCollateralAmountKey(lenderAddr sdk.AccAddress, uTokenDenom string) []
 // CreateCollateralAmountKeyNoDenom returns the common prefix used by all collateral associated
 // with a given lender address.
 func CreateCollateralAmountKeyNoDenom(lenderAddr sdk.AccAddress) []byte {
-	// collateralprefix | lengthprefixed(lenderAddr)
+	// collateralPrefix | lengthprefixed(lenderAddr)
 	var key []byte
 	key = append(key, KeyPrefixCollateralAmount...)
 	key = append(key, address.MustLengthPrefix(lenderAddr)...)
+	return key
+}
+
+// CreateCollateralAmountKeyNoAddress returns a safe copy of collateralPrefix
+func CreateCollateralAmountKeyNoAddress() []byte {
+	// collateralPrefix
+	var key []byte
+	key = append(key, KeyPrefixCollateralAmount...)
 	return key
 }
 

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -197,7 +197,7 @@ func CreateLendAPYKey(tokenDenom string) []byte {
 	return append(key, 0) // append 0 for null-termination
 }
 
-// CreateLendAPYKey returns a safe copy of lend APY prefix
+// CreateLendAPYKeyNoDenom returns a safe copy of lend APY prefix
 func CreateLendAPYKeyNoDenom() []byte {
 	// lendAPYPrefix
 	var key []byte

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -180,6 +180,14 @@ func CreateBorrowAPYKey(tokenDenom string) []byte {
 	return append(key, 0) // append 0 for null-termination
 }
 
+// CreateBorrowAPYKey returns a safe copy of borrow APY prefix
+func CreateBorrowAPYKeyNoDenom() []byte {
+	// borrowAPYPrefix
+	var key []byte
+	key = append(key, KeyPrefixBorrowAPY...)
+	return key
+}
+
 // CreateLendAPYKey returns a KVStore key for getting and setting the lend APY for a given token.
 func CreateLendAPYKey(tokenDenom string) []byte {
 	// lendAPYPrefix | denom | 0x00

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -46,9 +46,7 @@ func CreateRegisteredTokenKey(baseTokenDenom string) []byte {
 // and borrower address.
 func CreateLoanKey(borrowerAddr sdk.AccAddress, tokenDenom string) []byte {
 	// loanprefix | lengthprefixed(borrowerAddr) | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixLoanToken...)
-	key = append(key, address.MustLengthPrefix(borrowerAddr)...)
+	key := CreateLoanKeyNoDenom(borrowerAddr)
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }
@@ -57,8 +55,7 @@ func CreateLoanKey(borrowerAddr sdk.AccAddress, tokenDenom string) []byte {
 // borrower address.
 func CreateLoanKeyNoDenom(borrowerAddr sdk.AccAddress) []byte {
 	// loanprefix | lengthprefixed(borrowerAddr)
-	var key []byte
-	key = append(key, KeyPrefixLoanToken...)
+	key := CreateLoanKeyNoAddress()
 	key = append(key, address.MustLengthPrefix(borrowerAddr)...)
 	return key
 }
@@ -86,9 +83,7 @@ func CreateCollateralSettingKey(borrowerAddr sdk.AccAddress, uTokenDenom string)
 // collateral stored for a lender in a given denom.
 func CreateCollateralAmountKey(lenderAddr sdk.AccAddress, uTokenDenom string) []byte {
 	// collateralPrefix | lengthprefixed(lenderAddr) | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixCollateralAmount...)
-	key = append(key, address.MustLengthPrefix(lenderAddr)...)
+	key := CreateCollateralAmountKeyNoDenom(lenderAddr)
 	key = append(key, []byte(uTokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }
@@ -97,8 +92,7 @@ func CreateCollateralAmountKey(lenderAddr sdk.AccAddress, uTokenDenom string) []
 // with a given lender address.
 func CreateCollateralAmountKeyNoDenom(lenderAddr sdk.AccAddress) []byte {
 	// collateralPrefix | lengthprefixed(lenderAddr)
-	var key []byte
-	key = append(key, KeyPrefixCollateralAmount...)
+	key := CreateCollateralAmountKeyNoAddress()
 	key = append(key, address.MustLengthPrefix(lenderAddr)...)
 	return key
 }
@@ -114,8 +108,7 @@ func CreateCollateralAmountKeyNoAddress() []byte {
 // CreateReserveAmountKey returns a KVStore key for getting and setting the amount reserved of a a given token.
 func CreateReserveAmountKey(tokenDenom string) []byte {
 	// reserveamountprefix | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixReserveAmount...)
+	key := CreateReserveAmountKeyNoDenom()
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }
@@ -139,8 +132,7 @@ func CreateLastInterestTimeKey() []byte {
 // CreateExchangeRateKey returns a KVStore key for getting and setting the token:uToken rate for a a given token.
 func CreateExchangeRateKey(tokenDenom string) []byte {
 	// exchangeRatePrefix | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixExchangeRate...)
+	key := CreateExchangeRateKeyNoDenom()
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }
@@ -156,8 +148,7 @@ func CreateExchangeRateKeyNoDenom() []byte {
 // CreateBadDebtKey returns a KVStore key for tracking an address with unpaid bad debt
 func CreateBadDebtKey(denom string, borrowerAddr sdk.AccAddress) []byte {
 	// badDebtAddrPrefix | lengthprefixed(borrowerAddr) | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixBadDebt...)
+	key := CreateBadDebtKeyNoAddress()
 	key = append(key, address.MustLengthPrefix(borrowerAddr)...)
 	key = append(key, []byte(denom)...)
 	return append(key, 0) // append 0 for null-termination
@@ -174,8 +165,7 @@ func CreateBadDebtKeyNoAddress() []byte {
 // CreateBorrowAPYKey returns a KVStore key for getting and setting the borrow APY for a given token.
 func CreateBorrowAPYKey(tokenDenom string) []byte {
 	// borrowAPYPrefix | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixBorrowAPY...)
+	key := CreateBorrowAPYKeyNoDenom()
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }
@@ -191,8 +181,7 @@ func CreateBorrowAPYKeyNoDenom() []byte {
 // CreateLendAPYKey returns a KVStore key for getting and setting the lend APY for a given token.
 func CreateLendAPYKey(tokenDenom string) []byte {
 	// lendAPYPrefix | denom | 0x00
-	var key []byte
-	key = append(key, KeyPrefixLendAPY...)
+	key := CreateLendAPYKeyNoDenom()
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
 }

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -180,7 +180,7 @@ func CreateBorrowAPYKey(tokenDenom string) []byte {
 	return append(key, 0) // append 0 for null-termination
 }
 
-// CreateBorrowAPYKey returns a safe copy of borrow APY prefix
+// CreateBorrowAPYKeyNoDenom returns a safe copy of borrow APY prefix
 func CreateBorrowAPYKeyNoDenom() []byte {
 	// borrowAPYPrefix
 	var key []byte
@@ -195,6 +195,14 @@ func CreateLendAPYKey(tokenDenom string) []byte {
 	key = append(key, KeyPrefixLendAPY...)
 	key = append(key, []byte(tokenDenom)...)
 	return append(key, 0) // append 0 for null-termination
+}
+
+// CreateLendAPYKey returns a safe copy of lend APY prefix
+func CreateLendAPYKeyNoDenom() []byte {
+	// lendAPYPrefix
+	var key []byte
+	key = append(key, KeyPrefixLendAPY...)
+	return key
 }
 
 // AddressFromKey extracts address from a key with the form

--- a/x/leverage/types/keys_test.go
+++ b/x/leverage/types/keys_test.go
@@ -38,3 +38,17 @@ func TestDenomFromKeyWithAddress(t *testing.T) {
 
 	require.Equal(t, uDenom, expectedDenom)
 }
+
+func TestDenomFromKey(t *testing.T) {
+	denom := app.BondDenom
+	key := types.CreateExchangeRateKey(denom)
+	expectedDenom := types.DenomFromKey(key, types.KeyPrefixExchangeRate)
+
+	require.Equal(t, denom, expectedDenom)
+
+	uDenom := fmt.Sprintf("u%s", denom)
+	key = types.CreateExchangeRateKey(uDenom)
+	expectedDenom = types.DenomFromKey(key, types.KeyPrefixExchangeRate)
+
+	require.Equal(t, uDenom, expectedDenom)
+}


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
- Implemented invariant functions of `x/leverage` module
  - `ExchangeRatesInvariant` checks if the amount is lower than one
  - `ReserveAmountInvariant` checks if the amount is negative
  - `CollateralAmountInvariant` checks if the amount is negative or zero
  - `BorrowAmountInvariant` checks if the amount is negative or zero
  - `BorrowAPYInvariant` checks if the amount is negative
  - `LendAPYInvariant` checks if the amount is negative

ref: #354  

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
