### PR TITLE
chore: bump hermes to 0.10.0 for e2e tests

### DIFF
--- a/tests/e2e/docker/hermes.Dockerfile
+++ b/tests/e2e/docker/hermes.Dockerfile
@@ -1,4 +1,4 @@
-FROM informalsystems/hermes:0.9.0 AS hermes-builder
+FROM informalsystems/hermes:0.10.0 AS hermes-builder
 
 FROM debian:buster-slim
 USER root


### PR DESCRIPTION
## Description

⬆️ Upgrade Hermes `0.9.0` -> `0.10.0` in end to end test

This is a simple change which updates the source dockerfile for the hermes build in the end-to-end test. It updates the version.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
