### PR TITLE
feat: interest epoch and fund oracle events

### DIFF
--- a/x/leverage/keeper/interest.go
+++ b/x/leverage/keeper/interest.go
@@ -177,6 +177,7 @@ func (k Keeper) AccrueAllInterest(ctx sdk.Context) error {
 	if err != nil {
 		return err
 	}
+
 	store.Set(timeKey, bz)
 
 	// Because this action is not caused by a message, logging and

--- a/x/leverage/keeper/interest.go
+++ b/x/leverage/keeper/interest.go
@@ -181,8 +181,8 @@ func (k Keeper) AccrueAllInterest(ctx sdk.Context) error {
 	// events are here instead of msg_server.go
 	k.Logger(ctx).Debug(
 		"interest epoch",
-		"block height", fmt.Sprintf("%d", ctx.BlockHeight()),
-		"unix time", fmt.Sprintf("%d", currentTime),
+		"block_height", fmt.Sprintf("%d", ctx.BlockHeight()),
+		"unix_time", fmt.Sprintf("%d", currentTime),
 		"interest", totalInterest.String(),
 		"reserved", newReserves.String(),
 	)

--- a/x/leverage/keeper/interest.go
+++ b/x/leverage/keeper/interest.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -110,6 +112,7 @@ func (k Keeper) AccrueAllInterest(ctx sdk.Context) error {
 
 	oracleRewards := sdk.NewCoins()
 	newReserves := sdk.NewCoins()
+	totalInterest := sdk.NewCoins()
 	borrowPrefix := types.CreateLoanKeyNoAddress()
 
 	iter := sdk.KVStorePrefixIterator(store, borrowPrefix)
@@ -138,6 +141,9 @@ func (k Keeper) AccrueAllInterest(ctx sdk.Context) error {
 		}
 
 		store.Set(key, bz)
+
+		// Track total interest across all borrowers for logging
+		totalInterest = totalBorrowed.Add(sdk.NewCoin(denom, amountToAccrue))
 
 		// A portion of amountToAccrue defined by the denom's reserve factor will be
 		// set aside as reserves.
@@ -171,8 +177,28 @@ func (k Keeper) AccrueAllInterest(ctx sdk.Context) error {
 	if err != nil {
 		return err
 	}
-
 	store.Set(timeKey, bz)
+
+	// Because this action is not caused by a message, logging and
+	// events are here instead of msg_server.go
+	k.Logger(ctx).Debug(
+		"interest epoch",
+		"block height", fmt.Sprintf("%d", ctx.BlockHeight()),
+		"unix time", fmt.Sprintf("%d", currentTime),
+		"interest", totalInterest.String(),
+		"reserved", newReserves.String(),
+	)
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeInterestEpoch,
+			sdk.NewAttribute(types.EventAttrBlockHeight, fmt.Sprintf("%d", ctx.BlockHeight())),
+			sdk.NewAttribute(types.EventAttrUnixTime, fmt.Sprintf("%d", currentTime)),
+			sdk.NewAttribute(types.EventAttrInterest, totalInterest.String()),
+			sdk.NewAttribute(types.EventAttrReserved, newReserves.String()),
+		),
+	})
+
 	return nil
 }
 

--- a/x/leverage/spec/06_events.md
+++ b/x/leverage/spec/06_events.md
@@ -72,7 +72,26 @@ The leverage module emits the following events:
 
 ## Keeper events
 
-In addition to handlers events, the leverage keeper will produce events from the following functions.
+In addition to handlers events, the leverage keeper will produce events from the following functions which may occur during `EndBlock`.
+
+### AccrueAllInterest
+
+| Type           | Attribute Key  | Attribute Value        |
+| -------------- | -------------- | ---------------------- |
+| interest_epoch | block_height   | {ctx.BlockHeight}      |
+| interest_epoch | unix_time      | {ctx.BlockTime.Unix()} |
+| interest_epoch | total_interest | {totalInterest}        |
+| interest_epoch | reserved       | {newReserves}          |
+
+Interest epochs emit an event with their current block height and time, as well as total interest accrued across all borrows and the amount of each token added to reserves. Occurs every `InterestEpoch`.
+
+### FundOracle
+
+| Type        | Attribute Key | Attribute Value |
+| ----------- | ------------- | --------------- |
+| fund_oracle | amount        | {reward}        |
+
+Oracle rewards sent from the leverage module are tracked at the moment of transfer. Occurs every `InterestEpoch`.
 
 ### RepayBadDebt
 

--- a/x/leverage/types/events.go
+++ b/x/leverage/types/events.go
@@ -10,13 +10,19 @@ const (
 	EventTypeLiquidate            = "liquidate_borrow_position"
 	EventTypeRepayBadDebt         = "repay_bad_debt"
 	EventTypeReservesExhausted    = "reserves_exhausted"
+	EventTypeInterestEpoch        = "interest_epoch"
+	EventTypeFundOracle           = "fund_oracle"
 
-	EventAttrModule     = ModuleName
-	EventAttrLender     = "lender"
-	EventAttrBorrower   = "borrower"
-	EventAttrLiquidator = "liquidator"
-	EventAttrDenom      = "denom"
-	EventAttrEnable     = "enabled"
-	EventAttrAttempted  = "attempted"
-	EventAttrReward     = "reward"
+	EventAttrModule      = ModuleName
+	EventAttrLender      = "lender"
+	EventAttrBorrower    = "borrower"
+	EventAttrLiquidator  = "liquidator"
+	EventAttrDenom       = "denom"
+	EventAttrEnable      = "enabled"
+	EventAttrAttempted   = "attempted"
+	EventAttrReward      = "reward"
+	EventAttrInterest    = "total_interest"
+	EventAttrBlockHeight = "block_height"
+	EventAttrUnixTime    = "unix_time"
+	EventAttrReserved    = "reserved"
 )


### PR DESCRIPTION
## Description

Add events and logging when interest accrues, reserves are added, or oracle rewards are funded.

Interest epoch event also records block height and unix time.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
