### PR TITLE
fix: use ApproxSqrt instead of math.Sqrt for calculating standard deviation

### DIFF
--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"sort"
-	
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -1,12 +1,8 @@
 package types
 
 import (
-	"fmt"
-	"math"
-	"sort"
-	"strconv"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"sort"
 )
 
 // VoteForTally is a convenience wrapper to reduce redundant lookup cost.
@@ -88,13 +84,8 @@ func (pb ExchangeRateBallot) StandardDeviation() (sdk.Dec, error) {
 
 	variance := sum.QuoInt64(int64(len(pb)))
 
-	floatNum, err := strconv.ParseFloat(variance.String(), 64)
-	if err != nil {
-		return sdk.ZeroDec(), err
-	}
+	standardDeviation, err := variance.ApproxSqrt()
 
-	floatNum = math.Sqrt(floatNum)
-	standardDeviation, err := sdk.NewDecFromStr(fmt.Sprintf("%f", floatNum))
 	if err != nil {
 		return sdk.ZeroDec(), err
 	}

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"sort"
+	
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // VoteForTally is a convenience wrapper to reduce redundant lookup cost.

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"sort"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/oracle/types/ballot_test.go
+++ b/x/oracle/types/ballot_test.go
@@ -177,21 +177,21 @@ func TestPBStandardDeviation(t *testing.T) {
 			[]float64{1.0, 2.0, 10.0, 100000.0},
 			[]int64{1, 1, 100, 1},
 			[]bool{true, true, true, true},
-			sdk.NewDecWithPrec(4999500036300, OracleDecPrecision),
+			sdk.MustNewDecFromStr("49995.000362536252310906"),
 		},
 		{
 			// Adding fake validator doesn't change outcome
 			[]float64{1.0, 2.0, 10.0, 100000.0, 10000000000},
 			[]int64{1, 1, 100, 1, 10000},
 			[]bool{true, true, true, true, false},
-			sdk.NewDecWithPrec(447213595075100600, OracleDecPrecision),
+			sdk.MustNewDecFromStr("4472135950.751005519905537611"),
 		},
 		{
 			// Tie votes
 			[]float64{1.0, 2.0, 3.0, 4.0},
 			[]int64{1, 100, 100, 1},
 			[]bool{true, true, true, true},
-			sdk.NewDecWithPrec(122474500, OracleDecPrecision),
+			sdk.MustNewDecFromStr("1.224744871391589049"),
 		},
 		{
 			// No votes


### PR DESCRIPTION
Keeps the standard deviation calculation from rounding 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
