### PR TITLE
refactor: SpendableCoins replaces GetBalance for non-module accounts

### DIFF
--- a/x/leverage/types/expected_types.go
+++ b/x/leverage/types/expected_types.go
@@ -2,14 +2,10 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 // BankKeeper defines the expected x/bank keeper interface.
 type BankKeeper interface {
-	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
-	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
-	IterateAllDenomMetaData(ctx sdk.Context, cb func(banktypes.Metadata) bool)
 	GetSupply(ctx sdk.Context, denom string) sdk.Coin
 	MintCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error
@@ -23,9 +19,8 @@ type BankKeeper interface {
 		ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins,
 	) error
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
-	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
-	HasBalance(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin) bool
+	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 }
 
 // OracleKeeper defines the expected x/oracle keeper interface.


### PR DESCRIPTION
## Description

`bankkeeper.SpendableCoins` gets an account's balances, minus locked coins.

Context from the [sdk](https://github.com/cosmos/cosmos-sdk/blob/master/x/bank/keeper/view.go#L169)

> LockedCoins returns all the coins that are not spendable (i.e. locked) for an account by address. For standard accounts, the result will always be no coins. For vesting accounts, LockedCoins is delegated to the concrete vesting account type.

While it has not been explicitly discussed whether we are using vesting accounts, this PR ensures that they would be bug-free when interacting with `x/leverage` by replacing calls to `bankkeeper.GetBalance(denom)` for non-module accounts with `bankkeeper.SpendableCoins.AmountOf(denom)` or similar code.

It also cleans up some unused functions in `expected_types.go`

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
