### PR TITLE
fix: price-feeder : return an error if we can't get the block height

### DIFF
--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -315,10 +315,10 @@ func (o *Oracle) tick() error {
 
 	blockHeight, err := rpcclient.GetChainHeight(clientCtx)
 	if err != nil {
-		return nil
+		return err
 	}
-	if blockHeight == 0 {
-		return fmt.Errorf("expected non-zero block height")
+	if blockHeight < 1 {
+		return fmt.Errorf("expected positive block height")
 	}
 
 	// Get oracle vote period, next block height, current vote period, and index


### PR DESCRIPTION
## Description

Fixes an issue where if we can't get the block height (e.g., if the `tmrpc_endpoint` in the config is unreachable), we'd be stuck in a loop without any error messages. 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
