### PR TITLE
fix: validate genesis command

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -126,7 +126,7 @@ var (
 	// and genesis verification.
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},
-		genutil.AppModuleBasic{},
+		GenutilModule{},
 		BankModule{},
 		capability.AppModuleBasic{},
 		StakingModule{},

--- a/app/beta/app.go
+++ b/app/beta/app.go
@@ -112,7 +112,7 @@ var (
 	// and genesis verification.
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},
-		genutil.AppModuleBasic{},
+		umeeapp.GenutilModule{},
 		umeeapp.BankModule{},
 		capability.AppModuleBasic{},
 		umeeapp.StakingModule{},

--- a/app/modules.go
+++ b/app/modules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	gravitytypes "github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -162,15 +163,26 @@ func (GenutilModule) ValidateGenesis(
 		}
 
 		msgs := tx.GetMsgs()
-		// if len(msgs) != 1 {
-		// 	return errors.New(
-		// 		"must provide genesis Tx with exactly 1 CreateValidator message")
-		// }
+		if n := len(msgs); n != 2 {
+			return fmt.Errorf(
+				"gentx %d contains invalid number of messages; expected: 2; got: %d",
+				i, n,
+			)
+		}
 
-		// if _, ok := msgs[0].(*stakingtypes.MsgCreateValidator); !ok {
-		// 	return fmt.Errorf(
-		// 		"genesis transaction %v does not contain a MsgCreateValidator", i)
-		// }
+		if _, ok := msgs[0].(*stakingtypes.MsgCreateValidator); !ok {
+			return fmt.Errorf(
+				"gentx %d contains invalid message at index 0; expected: %T; got: %T",
+				i, &stakingtypes.MsgCreateValidator{}, msgs[0],
+			)
+		}
+
+		if _, ok := msgs[1].(*gravitytypes.MsgSetOrchestratorAddress); !ok {
+			return fmt.Errorf(
+				"gentx %d contains invalid message at index 1; expected: %T; got: %T",
+				i, &gravitytypes.MsgSetOrchestratorAddress{}, msgs[0],
+			)
+		}
 	}
 
 	return nil

--- a/app/modules.go
+++ b/app/modules.go
@@ -180,7 +180,7 @@ func (GenutilModule) ValidateGenesis(
 		if _, ok := msgs[1].(*gravitytypes.MsgSetOrchestratorAddress); !ok {
 			return fmt.Errorf(
 				"gentx %d contains invalid message at index 1; expected: %T; got: %T",
-				i, &gravitytypes.MsgSetOrchestratorAddress{}, msgs[0],
+				i, &gravitytypes.MsgSetOrchestratorAddress{}, msgs[1],
 			)
 		}
 	}


### PR DESCRIPTION
## Description

Override `ValidateGenesis` for the `x/genutil` module so we can have `validate-genesis` pass for gentxs that contain delegate key messages.

closes: #409

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
