### PR TITLE
chore: tweak default interest epoch

### DIFF
--- a/x/leverage/spec/07_params.md
+++ b/x/leverage/spec/07_params.md
@@ -4,7 +4,7 @@ The leverage module contains the following parameters:
 
 | Key                          | Type    | Example |
 | -----------------------------| ------- | ------- |
-| InterestEpoch                | int64   | 100     |
+| InterestEpoch                | int64   | 1000    |
 | CompleteLiquidationThreshold | sdk.Dec | 0.1     |
 | MinimumCloseFactor           | sdk.Dec | 0.01    |
 | OracleRewardFactor           | sdk.Dec | 0.01    |

--- a/x/leverage/types/params.go
+++ b/x/leverage/types/params.go
@@ -18,7 +18,7 @@ var (
 )
 
 var (
-	defaultInterestEpoch                = int64(100)
+	defaultInterestEpoch                = int64(1000)
 	defaultCompleteLiquidationThreshold = sdk.MustNewDecFromStr("0.1")
 	defaultMinimumCloseFactor           = sdk.MustNewDecFromStr("0.01")
 	defaultOracleRewardFactor           = sdk.MustNewDecFromStr("0.01")


### PR DESCRIPTION
## Description

Changes default interest epoch to 1000 blocks, which is 1-2 hours when block time is 3-5 seconds.

The other default params should be fine where they are - closes: #276

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
