### PR TITLE
fix: x/oracle: parse tuples more strictly

### DIFF
--- a/x/oracle/types/vote.go
+++ b/x/oracle/types/vote.go
@@ -70,7 +70,6 @@ func (tuples ExchangeRateTuples) String() string {
 
 // ParseExchangeRateTuples ExchangeRateTuple parser
 func ParseExchangeRateTuples(tuplesStr string) (ExchangeRateTuples, error) {
-	tuplesStr = strings.TrimSpace(tuplesStr)
 	if len(tuplesStr) == 0 {
 		return nil, nil
 	}
@@ -81,7 +80,7 @@ func ParseExchangeRateTuples(tuplesStr string) (ExchangeRateTuples, error) {
 	duplicateCheckMap := make(map[string]bool)
 	for i, tupleStr := range tupleStrs {
 		denomAmountStr := strings.Split(tupleStr, ":")
-		if len(denomAmountStr) < 2 {
+		if len(denomAmountStr) != 2 {
 			return nil, fmt.Errorf("invalid exchange rate %s", tupleStr)
 		}
 

--- a/x/oracle/types/vote_test.go
+++ b/x/oracle/types/vote_test.go
@@ -30,4 +30,8 @@ func TestParseExchangeRateTuples(t *testing.T) {
 	negativeCoinsWithValid := "uumee:-1234.5,uatom:123.1"
 	_, err = ParseExchangeRateTuples(negativeCoinsWithValid)
 	require.Error(t, err)
+
+	multiplePricesPerRate := "uumee:123: uumee:456,uusdc:789"
+	_, err = ParseExchangeRateTuples(multiplePricesPerRate)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

Parses tuples more strictly. Resolves one of the concerns found in ToB audit. 

progress on: #416

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
