### PR TITLE
fix: remove hard-coded usd rate

### DIFF
--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -89,10 +89,6 @@ func (k Keeper) GetExchangeRate(ctx sdk.Context, symbol string) (sdk.Dec, error)
 // GetExchangeRateBase gets the consensus exchange rate of an asset
 // in the base denom (e.g. ATOM -> uatom)
 func (k Keeper) GetExchangeRateBase(ctx sdk.Context, denom string) (sdk.Dec, error) {
-	if strings.Contains(strings.ToUpper(denom), types.USDDenom) {
-		return sdk.OneDec(), nil
-	}
-
 	var symbol string
 
 	// Translate the base denom -> symbol

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -198,14 +198,6 @@ func (s *IntegrationTestSuite) TestSetExchangeRateWithEvent() {
 	s.Require().Equal(rate, sdk.OneDec())
 }
 
-func (s *IntegrationTestSuite) TestGetExchangeRate_USD() {
-	app, ctx := s.app, s.ctx
-
-	rate, err := app.OracleKeeper.GetExchangeRateBase(ctx, "uusd")
-	s.Require().NoError(err)
-	s.Require().Equal(rate, sdk.OneDec())
-}
-
 func (s *IntegrationTestSuite) TestGetExchangeRate_InvalidDenom() {
 	app, ctx := s.app, s.ctx
 


### PR DESCRIPTION
## Description

Removes the hard-coded usd rate & its test, so we can support stablecoins : 

```go
 if strings.Contains(strings.ToUpper(denom), types.USDDenom) { 
 	return sdk.OneDec(), nil 
 } 
```

closes: #435

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
