### PR TITLE
chore: pin peggo v0.2.1 in image build

### DIFF
--- a/infra/packer/Dockerfile.build
+++ b/infra/packer/Dockerfile.build
@@ -38,7 +38,7 @@ RUN make build
 
 # Clone/Build Peggo
 WORKDIR /tmp/build/peggo
-RUN git clone https://github.com/umee-network/peggo.git --branch main --single-branch --depth 1 .
+RUN git clone https://github.com/umee-network/peggo.git --branch v0.2.1 --single-branch --depth 1 .
 RUN make build
 
 WORKDIR /root


### PR DESCRIPTION
## Description

Pin peggo to version 0.2.1 in image build

