### PR TITLE
chore: double cpu cores in packer build to reduce failure

### DIFF
--- a/infra/packer/umee-node-dist.pkr.hcl
+++ b/infra/packer/umee-node-dist.pkr.hcl
@@ -29,7 +29,7 @@ source "googlecompute" "final" {
   ssh_username = "root"
   zone         = "us-central1-a"
   image_name   = "umee-node-${var.git_sha}"
-  machine_type = "n1-standard-2"
+  machine_type = "n2-standard-2"
 }
 
 build {

--- a/infra/packer/umee-node-dist.pkr.hcl
+++ b/infra/packer/umee-node-dist.pkr.hcl
@@ -29,6 +29,7 @@ source "googlecompute" "final" {
   ssh_username = "root"
   zone         = "us-central1-a"
   image_name   = "umee-node-${var.git_sha}"
+  machine_type = "n1-standard-2"
 }
 
 build {


### PR DESCRIPTION
## Description

Double the cpu cores available to packer for building to reduce failure rate (was 1 core, now is 2); this will also provide more memory and network to the gcp instance during image building.

## Justification

1. The docker image build (running on github actions runners) does not ever fail -- well, the github runner has 2 cpus.
2. The packer (gcp) image builder defaults to using a 1 core machine to do the work, and I believe this is why it is so flaky right now, it is resource starved.