### PR TITLE
fix: wait for cloud init during packer gcp build to avoid apt race condition

### DIFF
--- a/infra/packer/umee-node-dist.pkr.hcl
+++ b/infra/packer/umee-node-dist.pkr.hcl
@@ -34,10 +34,16 @@ source "googlecompute" "final" {
 
 build {
   name = "umee-node"
+
   sources = [
     "source.docker.final",
     "source.googlecompute.final"
   ]
+
+  provisioner "shell" {
+    inline = [ "/usr/bin/cloud-init status --wait" ]
+    only = ["googlecompute.final"]
+  }
 
   provisioner "shell" {
     inline = [ "sed -i 's/http:\\/\\/.\\+\\/ubuntu/http:\\/\\/mirrors.edge.kernel.org\\/ubuntu/g' /etc/apt/sources.list"


### PR DESCRIPTION
## Description
There is a race condition between cloud-init and the packer code which is causing the intermittent apt failures (hypothesis).

## Research on this issue:

https://askubuntu.com/questions/663296/intermittent-apt-get-install-issues-when-creating-an-ami-using-packer

https://github.com/hashicorp/packer/issues/2639

suggested fix:
```
provisioners:
  - type: shell
    inline:
    - /usr/bin/cloud-init status --wait
```