### PR TITLE
fix: WithdrawAsset - move error check to before coins.Sub to prevent panic

### DIFF
--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -153,8 +153,13 @@ func (k Keeper) WithdrawAsset(ctx sdk.Context, lenderAddr sdk.AccAddress, uToken
 				return err
 			}
 
-			// Calculate what borrow limit will be AFTER this withdrawal
+			// Check for sufficient collateral
 			collateral := k.GetBorrowerCollateral(ctx, lenderAddr)
+			if collateral.AmountOf(uToken.Denom).LT(amountFromCollateral) {
+				return sdkerrors.Wrap(types.ErrInsufficientBalance, uToken.String())
+			}
+
+			// Calculate what borrow limit will be AFTER this withdrawal
 			collateralToWithdraw := sdk.NewCoins(sdk.NewCoin(uToken.Denom, amountFromCollateral))
 			newBorrowLimit, err := k.CalculateBorrowLimit(ctx, collateral.Sub(collateralToWithdraw))
 			if err != nil {
@@ -167,12 +172,7 @@ func (k Keeper) WithdrawAsset(ctx sdk.Context, lenderAddr sdk.AccAddress, uToken
 			}
 
 			// reduce the lender's collateral by amountFromCollateral
-			currentCollateral := k.GetCollateralAmount(ctx, lenderAddr, uToken.Denom)
-			if currentCollateral.Amount.LT(amountFromCollateral) {
-				return sdkerrors.Wrap(types.ErrInsufficientBalance, uToken.String())
-			}
-
-			newCollateral := sdk.NewCoin(uToken.Denom, currentCollateral.Amount.Sub(amountFromCollateral))
+			newCollateral := sdk.NewCoin(uToken.Denom, collateral.AmountOf(uToken.Denom).Sub(amountFromCollateral))
 			if err = k.SetCollateralAmount(ctx, lenderAddr, newCollateral); err != nil {
 				return err
 			}

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1306,3 +1306,40 @@ func (s *IntegrationTestSuite) TestLendAPYInvariant() {
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
 }
+
+func (s *IntegrationTestSuite) TestWithdrawAsset_InsufficientCollateral() {
+	app, ctx := s.app, s.ctx
+
+	lenderAddr := sdk.AccAddress([]byte("addr________________"))
+	lenderAcc := app.AccountKeeper.NewAccountWithAddress(ctx, lenderAddr)
+	app.AccountKeeper.SetAccount(ctx, lenderAcc)
+
+	// mint and send coins
+	s.Require().NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, initCoins))
+	s.Require().NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, lenderAddr, initCoins))
+
+	// mint additional coins for just the leverage module; this way it will have available reserve
+	// to meet conditions in the withdrawal logic
+	s.Require().NoError(app.BankKeeper.MintCoins(ctx, types.ModuleName, initCoins))
+
+	// set collateral setting for the account
+	uTokenDenom := types.UTokenFromTokenDenom(umeeapp.BondDenom)
+	err := s.app.LeverageKeeper.SetCollateralSetting(ctx, lenderAddr, uTokenDenom, true)
+	s.Require().NoError(err)
+
+	// lend asset
+	err = s.app.LeverageKeeper.LendAsset(ctx, lenderAddr, sdk.NewInt64Coin(umeeapp.BondDenom, 1000000000)) // 1k umee
+	s.Require().NoError(err)
+
+	// verify collateral amount and total supply of minted uTokens
+	collateral := s.app.LeverageKeeper.GetCollateralAmount(ctx, lenderAddr, uTokenDenom)
+	expected := sdk.NewInt64Coin(uTokenDenom, 1000000000) // 1k u/umee
+	s.Require().Equal(collateral, expected)
+	supply := s.app.LeverageKeeper.TotalUTokenSupply(ctx, uTokenDenom)
+	s.Require().Equal(expected, supply)
+
+	// withdraw more collateral than having
+	uToken := collateral.Add(sdk.NewInt64Coin(uTokenDenom, 1))
+	err = s.app.LeverageKeeper.WithdrawAsset(ctx, lenderAddr, uToken)
+	s.Require().EqualError(err, "1000000001u/uumee: insufficient balance")
+}

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -1338,7 +1338,7 @@ func (s *IntegrationTestSuite) TestWithdrawAsset_InsufficientCollateral() {
 	supply := s.app.LeverageKeeper.TotalUTokenSupply(ctx, uTokenDenom)
 	s.Require().Equal(expected, supply)
 
-	// withdraw more collateral than having
+	// withdraw more collateral than available
 	uToken := collateral.Add(sdk.NewInt64Coin(uTokenDenom, 1))
 	err = s.app.LeverageKeeper.WithdrawAsset(ctx, lenderAddr, uToken)
 	s.Require().EqualError(err, "1000000001u/uumee: insufficient balance")


### PR DESCRIPTION
## Description

See issue for problem symptoms and discussion of solution

closes: #490

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
