### PR TITLE
feat: faulty provider detection

### DIFF
--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -225,12 +225,12 @@ func (o *Oracle) SetPrices(acceptList oracletypes.DenomList) error {
 		}
 	}
 
-	providerPrices, err := o.filterDeviations(providerPrices)
+	filteredProviderPrices, err := o.filterDeviations(providerPrices)
 	if err != nil {
 		return err
 	}
 
-	vwapPrices, err := ComputeVWAP(providerPrices)
+	vwapPrices, err := ComputeVWAP(filteredProviderPrices)
 	if err != nil {
 		return err
 	}
@@ -301,8 +301,7 @@ func (o *Oracle) getOrSetProvider(providerName string) provider.Provider {
 // all assets, and filter out any providers that are not within 2𝜎 of the mean.
 func (o *Oracle) filterDeviations(
 	prices map[string]map[string]provider.TickerPrice) (
-	map[string]map[string]provider.TickerPrice, error,
-) {
+	map[string]map[string]provider.TickerPrice, error) {
 	var (
 		filteredPrices = make(map[string]map[string]provider.TickerPrice)
 		threshold      = sdk.MustNewDecFromStr("2")

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -225,6 +225,8 @@ func (o *Oracle) SetPrices(acceptList oracletypes.DenomList) error {
 		}
 	}
 
+	providerPrices, err := FilterDeviations(providerPrices)
+
 	vwapPrices, err := ComputeVWAP(providerPrices)
 	if err != nil {
 		return err

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -225,7 +225,7 @@ func (o *Oracle) SetPrices(acceptList oracletypes.DenomList) error {
 		}
 	}
 
-	providerPrices, err := filterDeviations(providerPrices)
+	providerPrices, err := o.filterDeviations(providerPrices)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func (o *Oracle) getOrSetProvider(providerName string) provider.Provider {
 
 // filterDeviations find the standard deviations of the prices of
 // all assets, and filter out any providers that are not within 2𝜎 of the mean.
-func filterDeviations(
+func (o *Oracle) filterDeviations(
 	prices map[string]map[string]provider.TickerPrice) (
 	map[string]map[string]provider.TickerPrice, error,
 ) {
@@ -326,6 +326,11 @@ func filterDeviations(
 					Price:  price.Price,
 					Volume: price.Volume,
 				}
+			} else {
+				telemetry.IncrCounter(1, "failure", "provider")
+				o.logger.Warn().Str("base", base).Str("provider", providerName).Msg(
+					"provider deviating from other prices",
+				)
 			}
 		}
 	}

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -84,6 +84,7 @@ func FilterDeviations(
 }
 
 // StandardDeviation returns maps of the standard deviations and means of assets.
+// Will skip calculating for an asset if there are less than 3 prices.
 func StandardDeviation(
 	prices map[string]map[string]provider.TickerPrice) (
 	map[string]sdk.Dec, map[string]sdk.Dec, error,
@@ -113,7 +114,7 @@ func StandardDeviation(
 	// Calculate standard deviations for each asset
 	for base, sum := range priceSums {
 		// Skip if asset does not have enough prices
-		if len(priceSlice) < 3 {
+		if len(priceSlice[base]) < 3 {
 			continue
 		}
 		if _, ok := deviations[base]; !ok {

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -50,8 +50,7 @@ func ComputeVWAP(prices map[string]map[string]provider.TickerPrice) (map[string]
 // Will skip calculating for an asset if there are less than 3 prices.
 func StandardDeviation(
 	prices map[string]map[string]provider.TickerPrice) (
-	map[string]sdk.Dec, map[string]sdk.Dec, error,
-) {
+	map[string]sdk.Dec, map[string]sdk.Dec, error) {
 	var (
 		deviations = make(map[string]sdk.Dec)
 		means      = make(map[string]sdk.Dec)
@@ -85,19 +84,22 @@ func StandardDeviation(
 			means[base] = sdk.ZeroDec()
 		}
 
-		priceAmount := int64(len(priceSlice))
-		means[base] = sum.QuoInt64(priceAmount)
+		numPrices := int64(len(priceSlice))
+		means[base] = sum.QuoInt64(numPrices)
 		varianceSum := sdk.ZeroDec()
 
 		for _, price := range priceSlice[base] {
 			deviation := price.Sub(means[base])
 			varianceSum = varianceSum.Add(deviation.Mul(deviation))
 		}
-		variance := varianceSum.QuoInt64(priceAmount)
+
+		variance := varianceSum.QuoInt64(numPrices)
+
 		standardDeviation, err := variance.ApproxSqrt()
 		if err != nil {
 			return make(map[string]sdk.Dec), make(map[string]sdk.Dec), err
 		}
+
 		deviations[base] = standardDeviation
 	}
 

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -45,3 +45,78 @@ func ComputeVWAP(prices map[string]map[string]provider.TickerPrice) (map[string]
 
 	return vwap, nil
 }
+
+// FilterDeviations find the standard deviation of the price
+// of an asset, and filter out any providers that are not within
+// two deviations of the mean.
+func FilterDeviations(
+	prices map[string]map[string]provider.TickerPrice) (
+	map[string]map[string]provider.TickerPrice, error,
+) {
+	var (
+		deviations     = make(map[string]sdk.Dec)
+		filteredPrices = make(map[string]map[string]provider.TickerPrice)
+		means          = make(map[string]sdk.Dec)
+		priceSlice     = make(map[string][]sdk.Dec)
+		priceSums      = make(map[string]sdk.Dec)
+		threshold      = sdk.MustNewDecFromStr("2")
+	)
+
+	// Calculate sums, create price slice
+	for _, providerPrices := range prices {
+		for base, tp := range providerPrices {
+			if _, ok := priceSums[base]; !ok {
+				priceSums[base] = sdk.ZeroDec()
+			}
+			if _, ok := priceSlice[base]; !ok {
+				priceSlice[base] = []sdk.Dec{}
+			}
+
+			priceSums[base] = priceSums[base].Add(tp.Price)
+			priceSlice[base] = append(priceSlice[base], tp.Price)
+		}
+	}
+
+	// Calculate standard deviations for each asset
+	for base, sum := range priceSums {
+		if _, ok := deviations[base]; !ok {
+			deviations[base] = sdk.ZeroDec()
+		}
+		if _, ok := means[base]; !ok {
+			means[base] = sdk.ZeroDec()
+		}
+
+		priceAmount := int64(len(priceSlice))
+		means[base] = sum.QuoInt64(priceAmount)
+		varianceSum := sdk.ZeroDec()
+
+		for _, price := range priceSlice[base] {
+			deviation := price.Sub(means[base])
+			varianceSum = varianceSum.Add(deviation.Mul(deviation))
+		}
+		variance := varianceSum.QuoInt64(priceAmount)
+		standardDeviation, err := variance.ApproxSqrt()
+		if err != nil {
+			return make(map[string]map[string]provider.TickerPrice), err
+		}
+		deviations[base] = standardDeviation
+	}
+
+	// Accept any prices that are within 2𝜎
+	for providerName, priceMap := range prices {
+		for base, price := range priceMap {
+			if price.Price.GTE(means[base].Sub(deviations[base].Mul(threshold))) &&
+				price.Price.LTE(means[base].Add(deviations[base].Mul(threshold))) {
+				if _, ok := filteredPrices[providerName]; !ok {
+					filteredPrices[providerName] = make(map[string]provider.TickerPrice)
+				}
+				filteredPrices[providerName][base] = provider.TickerPrice{
+					Price:  price.Price,
+					Volume: price.Volume,
+				}
+			}
+		}
+	}
+
+	return filteredPrices, nil
+}

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -46,43 +46,6 @@ func ComputeVWAP(prices map[string]map[string]provider.TickerPrice) (map[string]
 	return vwap, nil
 }
 
-// FilterDeviations find the standard deviation of the price
-// of an asset, and filter out any providers that are not within
-// two deviations of the mean.
-func FilterDeviations(
-	prices map[string]map[string]provider.TickerPrice) (
-	map[string]map[string]provider.TickerPrice, error,
-) {
-	var (
-		filteredPrices = make(map[string]map[string]provider.TickerPrice)
-		threshold      = sdk.MustNewDecFromStr("2")
-	)
-
-	deviations, means, err := StandardDeviation(prices)
-	if err != nil {
-		return make(map[string]map[string]provider.TickerPrice), nil
-	}
-
-	// Accept any prices that are within 2𝜎, or for which we couldn't get 𝜎
-	for providerName, priceMap := range prices {
-		for base, price := range priceMap {
-			if _, ok := deviations[base]; !ok ||
-				(price.Price.GTE(means[base].Sub(deviations[base].Mul(threshold))) &&
-					price.Price.LTE(means[base].Add(deviations[base].Mul(threshold)))) {
-				if _, ok := filteredPrices[providerName]; !ok {
-					filteredPrices[providerName] = make(map[string]provider.TickerPrice)
-				}
-				filteredPrices[providerName][base] = provider.TickerPrice{
-					Price:  price.Price,
-					Volume: price.Volume,
-				}
-			}
-		}
-	}
-
-	return filteredPrices, nil
-}
-
 // StandardDeviation returns maps of the standard deviations and means of assets.
 // Will skip calculating for an asset if there are less than 3 prices.
 func StandardDeviation(

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -59,7 +59,6 @@ func StandardDeviation(
 		priceSums  = make(map[string]sdk.Dec)
 	)
 
-	// Calculate sums, create price slice
 	for _, providerPrices := range prices {
 		for base, tp := range providerPrices {
 			if _, ok := priceSums[base]; !ok {
@@ -74,9 +73,8 @@ func StandardDeviation(
 		}
 	}
 
-	// Calculate standard deviations for each asset
 	for base, sum := range priceSums {
-		// Skip if asset does not have enough prices
+		// Skip if standard deviation would not be meaningful
 		if len(priceSlice[base]) < 3 {
 			continue
 		}

--- a/price-feeder/oracle/util_test.go
+++ b/price-feeder/oracle/util_test.go
@@ -96,6 +96,78 @@ func TestStandardDeviation(t *testing.T) {
 			prices:   nil,
 			expected: map[string]deviation{},
 		},
+		"not enough prices": {
+			prices: map[string]map[string]provider.TickerPrice{
+				config.ProviderBinance: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.21000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13000000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.87000000"),
+					},
+				},
+				config.ProviderKraken: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.23000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13050000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.85000000"),
+					},
+				},
+			},
+			expected: map[string]deviation{},
+		},
+		"some prices": {
+			prices: map[string]map[string]provider.TickerPrice{
+				config.ProviderBinance: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.21000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13000000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.87000000"),
+					},
+				},
+				config.ProviderKraken: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.23000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13050000"),
+					},
+				},
+				config.ProviderOsmosis: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.40000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.14000000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.10000000"),
+					},
+				},
+			},
+			expected: map[string]deviation{
+				"ATOM": {
+					mean:      sdk.MustNewDecFromStr("28.28"),
+					deviation: sdk.MustNewDecFromStr("0.085244745683629475"),
+				},
+				"UMEE": {
+					mean:      sdk.MustNewDecFromStr("1.1335"),
+					deviation: sdk.MustNewDecFromStr("0.004600724580614015"),
+				},
+			},
+		},
+
 		"non empty prices": {
 			prices: map[string]map[string]provider.TickerPrice{
 				config.ProviderBinance: {

--- a/price-feeder/oracle/util_test.go
+++ b/price-feeder/oracle/util_test.go
@@ -78,3 +78,89 @@ func TestComputeVWAP(t *testing.T) {
 		})
 	}
 }
+
+func TestStandardDeviation(t *testing.T) {
+	type deviation struct {
+		mean      sdk.Dec
+		deviation sdk.Dec
+	}
+	testCases := map[string]struct {
+		prices   map[string]map[string]provider.TickerPrice
+		expected map[string]deviation
+	}{
+		"empty prices": {
+			prices:   make(map[string]map[string]provider.TickerPrice),
+			expected: map[string]deviation{},
+		},
+		"nil prices": {
+			prices:   nil,
+			expected: map[string]deviation{},
+		},
+		"non empty prices": {
+			prices: map[string]map[string]provider.TickerPrice{
+				config.ProviderBinance: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.21000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13000000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.87000000"),
+					},
+				},
+				config.ProviderKraken: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.23000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.13050000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.85000000"),
+					},
+				},
+				config.ProviderOsmosis: {
+					"ATOM": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("28.40000000"),
+					},
+					"UMEE": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("1.14000000"),
+					},
+					"LUNA": provider.TickerPrice{
+						Price: sdk.MustNewDecFromStr("64.10000000"),
+					},
+				},
+			},
+			expected: map[string]deviation{
+				"ATOM": {
+					mean:      sdk.MustNewDecFromStr("28.28"),
+					deviation: sdk.MustNewDecFromStr("0.085244745683629475"),
+				},
+				"UMEE": {
+					mean:      sdk.MustNewDecFromStr("1.1335"),
+					deviation: sdk.MustNewDecFromStr("0.004600724580614015"),
+				},
+				"LUNA": {
+					mean:      sdk.MustNewDecFromStr("64.606666666666666666"),
+					deviation: sdk.MustNewDecFromStr("0.358360464089193609"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			deviation, mean, err := oracle.StandardDeviation(tc.prices)
+			require.NoError(t, err)
+			require.Len(t, deviation, len(tc.expected))
+			require.Len(t, mean, len(tc.expected))
+			for k, v := range tc.expected {
+				require.Equalf(t, v.deviation, deviation[k], "unexpected deviation for %s", k)
+				require.Equalf(t, v.mean, mean[k], "unexpected mean for %s", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Detects faulty providers by computing the standard deviation of prices of an asset, and filtering out any prices reported which are more than `2𝜎` away from the mean. Ignores this logic for assets that do not have at least three providers, which will be an enforced minimum for non-mocked assets in a coming PR.

progress on : #451

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
