### PR TITLE
feat: add prevent redirect check on http.client

### DIFF
--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -45,18 +45,14 @@ type (
 func NewBinanceProvider() *BinanceProvider {
 	return &BinanceProvider{
 		baseURL: binanceBaseURL,
-		client: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		client:  newDefaultHTTPClient(),
 	}
 }
 
 func NewBinanceProviderWithTimeout(timeout time.Duration) *BinanceProvider {
 	return &BinanceProvider{
 		baseURL: binanceBaseURL,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:  newHTTPClientWithTimeout(timeout),
 	}
 }
 
@@ -101,7 +97,7 @@ func (p BinanceProvider) getTickerPrice(ticker string) (TickerPrice, error) {
 		)
 	}
 
-	if strings.ToUpper(tickerResp.Symbol) != strings.ToUpper(ticker) {
+	if !strings.EqualFold(tickerResp.Symbol, ticker) {
 		return TickerPrice{}, fmt.Errorf(
 			"received unexpected symbol from Binance response; expected: %s, got: %s",
 			ticker, tickerResp.Symbol,

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -20,7 +20,7 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 				"symbol": "ATOMUSDT",
 				"lastPrice": "34.69000000",
 				"volume": "2396974.02000000"
-			}			
+			}
 			`
 			rw.Write([]byte(resp))
 		}))
@@ -45,7 +45,7 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 					"symbol": "ATOMUSDT",
 					"lastPrice": "34.69000000",
 					"volume": "2396974.02000000"
-				}			
+				}
 				`
 				rw.Write([]byte(resp))
 			} else {
@@ -54,7 +54,7 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 					"symbol": "LUNAUSDT",
 					"lastPrice": "41.35000000",
 					"volume": "2396974.02000000"
-				}			
+				}
 				`
 				rw.Write([]byte(resp))
 			}
@@ -99,7 +99,7 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 			resp := `{
 				"code": -1121,
 				"msg": "Invalid symbol."
-			}			
+			}
 			`
 			rw.Write([]byte(resp))
 		}))
@@ -109,6 +109,21 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 		p.baseURL = server.URL
 
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
+
+	t.Run("check_redirect", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			http.Redirect(rw, r, p.baseURL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+
+		server.Client().CheckRedirect = preventRedirect
+		p.client = server.Client()
+		p.baseURL = server.URL
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
 		require.Error(t, err)
 		require.Nil(t, prices)
 	})

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -57,18 +57,14 @@ type (
 func NewHuobiProvider() *HuobiProvider {
 	return &HuobiProvider{
 		baseURL: huobiBaseURL,
-		client: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		client:  newDefaultHTTPClient(),
 	}
 }
 
 func NewHuobiProviderWithTimeout(timeout time.Duration) *HuobiProvider {
 	return &HuobiProvider{
 		baseURL: huobiBaseURL,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:  newHTTPClientWithTimeout(timeout),
 	}
 }
 

--- a/price-feeder/oracle/provider/huobi_test.go
+++ b/price-feeder/oracle/provider/huobi_test.go
@@ -27,7 +27,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 							}
 						]
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 			} else {
@@ -37,7 +37,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 					"tick": {
 						"vol": 16511168.890881622
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 			}
@@ -71,7 +71,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 							}
 						]
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 
@@ -82,7 +82,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 					"tick": {
 						"vol": 16511168.890881622
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 
@@ -97,7 +97,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 							}
 						]
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 
@@ -108,7 +108,7 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 					"tick": {
 						"vol": 162129738.74087432
 					}
-				}		
+				}
 				`
 				rw.Write([]byte(resp))
 			}
@@ -164,6 +164,21 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 		p.baseURL = server.URL
 
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
+
+	t.Run("check_redirect", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			http.Redirect(rw, r, p.baseURL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+
+		server.Client().CheckRedirect = preventRedirect
+		p.client = server.Client()
+		p.baseURL = server.URL
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
 		require.Error(t, err)
 		require.Nil(t, prices)
 	})

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -49,18 +49,14 @@ type (
 func NewKrakenProvider() *KrakenProvider {
 	return &KrakenProvider{
 		baseURL: krakenBaseURL,
-		client: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		client:  newDefaultHTTPClient(),
 	}
 }
 
 func NewKrakenProviderWithTimeout(timeout time.Duration) *KrakenProvider {
 	return &KrakenProvider{
 		baseURL: krakenBaseURL,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:  newHTTPClientWithTimeout(timeout),
 	}
 }
 

--- a/price-feeder/oracle/provider/kraken_test.go
+++ b/price-feeder/oracle/provider/kraken_test.go
@@ -109,4 +109,19 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, prices)
 	})
+
+	t.Run("check_redirect", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			http.Redirect(rw, r, p.baseURL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+
+		server.Client().CheckRedirect = preventRedirect
+		p.client = server.Client()
+		p.baseURL = server.URL
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
 }

--- a/price-feeder/oracle/provider/mock.go
+++ b/price-feeder/oracle/provider/mock.go
@@ -33,6 +33,8 @@ func NewMockProvider() *MockProvider {
 		baseURL: mockBaseURL,
 		client: &http.Client{
 			Timeout: defaultTimeout,
+			// the mock provider is the only one which allows redirects
+			// because it gets prices from a google spreadsheet, which redirects
 		},
 	}
 }

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -42,18 +42,14 @@ type (
 func NewOsmosisProvider() *OsmosisProvider {
 	return &OsmosisProvider{
 		baseURL: osmosisBaseURL,
-		client: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		client:  newDefaultHTTPClient(),
 	}
 }
 
 func NewOsmosisProviderWithTimeout(timeout time.Duration) *OsmosisProvider {
 	return &OsmosisProvider{
 		baseURL: osmosisBaseURL,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:  newHTTPClientWithTimeout(timeout),
 	}
 }
 

--- a/price-feeder/oracle/provider/osmosis_test.go
+++ b/price-feeder/oracle/provider/osmosis_test.go
@@ -138,4 +138,19 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, prices)
 	})
+
+	t.Run("check_redirect", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			http.Redirect(rw, r, p.baseURL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+
+		server.Client().CheckRedirect = preventRedirect
+		p.client = server.Client()
+		p.baseURL = server.URL
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.Error(t, err)
+		require.Nil(t, prices)
+	})
 }

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"net/http"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,4 +22,21 @@ type Provider interface {
 type TickerPrice struct {
 	Price  sdk.Dec // last trade price
 	Volume sdk.Dec // 24h volume
+}
+
+// preventRedirect avoid any redirect in the http.Client the request call
+// will not return an error, but a valid response with redirect response code.
+func preventRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+func newDefaultHTTPClient() *http.Client {
+	return newHTTPClientWithTimeout(defaultTimeout)
+}
+
+func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:       timeout,
+		CheckRedirect: preventRedirect,
+	}
 }


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- Add prevent redirect calls to all the new `http.Client` 
- Add unit test to check for redirect calls
- The mock price-feeder provider doesn't have the `preventRedirect` because it grabs the spreadsheet from the google link which uses the redirect headers

closes: #453
ref old PR: #469 
----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
