### PR TITLE
feat: price-feeder: force a minimum of three providers

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+- [#536](https://github.com/umee-network/umee/pull/536) Force a minimum of three providers per asset.
 - [#502](https://github.com/umee-network/umee/pull/502) Faulty provider detection: discard prices that are not within 2𝜎 of others.
 
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07

--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -130,16 +130,6 @@ func (c Config) Validate() error {
 	return validate.Struct(c)
 }
 
-// contains checks if a string is present in a slice
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-	return false
-}
-
 // ParseConfig attempts to read and parse configuration from the given file path.
 // An error is returned if reading or parsing the config fails.
 func ParseConfig(configPath string) (Config, error) {
@@ -168,25 +158,25 @@ func ParseConfig(configPath string) (Config, error) {
 		cfg.Server.ReadTimeout = defaultSrvReadTimeout.String()
 	}
 
-	pairs := make(map[string][]string)
+	pairs := make(map[string]map[string]struct{})
 	for _, cp := range cfg.CurrencyPairs {
 		if !strings.Contains(strings.ToUpper(cp.Quote), denomUSD) {
 			return cfg, fmt.Errorf("unsupported pair quote: %s", cp.Quote)
 		}
 		if _, ok := pairs[cp.Base]; !ok {
-			pairs[cp.Base] = []string{}
+			pairs[cp.Base] = make(map[string]struct{})
 		}
 
 		for _, provider := range cp.Providers {
 			if _, ok := SupportedProviders[provider]; !ok {
 				return cfg, fmt.Errorf("unsupported provider: %s", provider)
 			}
-			pairs[cp.Base] = append(pairs[cp.Base], provider)
+			pairs[cp.Base][provider] = struct{}{}
 		}
 	}
 
 	for base, providers := range pairs {
-		if len(providers) < 3 && !contains(providers, "mock") {
+		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
 			return cfg, fmt.Errorf("must have at least three providers for %s", base)
 		}
 	}

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -136,7 +136,8 @@ base = "ATOM"
 quote = "USDT"
 providers = [
 	"kraken",
-	"binance"
+	"binance",
+	"huobi"
 ]
 
 [[currency_pairs]]
@@ -144,7 +145,8 @@ base = "UMEE"
 quote = "USDT"
 providers = [
 	"kraken",
-	"binance"
+	"binance",
+	"huobi"
 ]
 
 [account]
@@ -184,7 +186,7 @@ global_labels = [["chain-id", "umee-local-beta-testnet"]]
 	require.Len(t, cfg.CurrencyPairs, 2)
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
-	require.Len(t, cfg.CurrencyPairs[0].Providers, 2)
+	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
 	require.Equal(t, "kraken", cfg.CurrencyPairs[0].Providers[0])
 	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
 }


### PR DESCRIPTION
## Description

Force a minimum of three providers during the price-feeder's config validation. This errors on all assets, unless a "mock" provider is included.

closes: #451

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
