### PR TITLE
feat: update Binance provider to use WebSocket

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#522](https://github.com/umee-network/umee/pull/522) Add Okx as a provider.
 - [#536](https://github.com/umee-network/umee/pull/536) Force a minimum of three providers per asset.
 - [#502](https://github.com/umee-network/umee/pull/502) Faulty provider detection: discard prices that are not within 2𝜎 of others.
+- [#551](https://github.com/umee-network/umee/pull/551) Update Binance provider to use WebSocket.
 
 ### Bug Fixes
 

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -279,7 +279,7 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 	if !ok {
 		switch providerName {
 		case config.ProviderBinance:
-			binanceProvider, err := provider.NewBinanceProvider(ctx, o.logger, o.providerPairs[config.ProviderOkx]...)
+			binanceProvider, err := provider.NewBinanceProvider(ctx, o.logger, o.providerPairs[config.ProviderBinance]...)
 			if err != nil {
 				return nil, err
 			}

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -279,7 +279,11 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 	if !ok {
 		switch providerName {
 		case config.ProviderBinance:
-			priceProvider = provider.NewBinanceProvider()
+			binanceProvider, err := provider.NewBinanceProvider(ctx, o.logger, o.providerPairs[config.ProviderOkx]...)
+			if err != nil {
+				return nil, err
+			}
+			priceProvider = binanceProvider
 
 		case config.ProviderKraken:
 			priceProvider = provider.NewKrakenProvider()

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -27,12 +27,11 @@ type (
 	//
 	// REF: https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams
 	BinanceProvider struct {
-		wsURL            url.URL
-		wsClient         *websocket.Conn
-		logger           zerolog.Logger
-		mu               sync.Mutex
-		tickers          map[string]BinanceTicker // Symbol => BinanceTicker
-		msReadNewMessage uint16
+		wsURL    url.URL
+		wsClient *websocket.Conn
+		logger   zerolog.Logger
+		mu       sync.Mutex
+		tickers  map[string]BinanceTicker // Symbol => BinanceTicker
 	}
 
 	// BinanceTicker defines the response structure of a Binance ticker
@@ -68,11 +67,10 @@ func NewBinanceProvider(ctx context.Context, logger zerolog.Logger, pairs ...typ
 	}
 
 	provider := &BinanceProvider{
-		wsURL:            wsURL,
-		wsClient:         wsConn,
-		logger:           logger.With().Str("module", "oracle").Logger(),
-		tickers:          map[string]BinanceTicker{},
-		msReadNewMessage: msReadNewMessage,
+		wsURL:    wsURL,
+		wsClient: wsConn,
+		logger:   logger.With().Str("module", "oracle").Logger(),
+		tickers:  map[string]BinanceTicker{},
 	}
 
 	if err := provider.subscribeTickers(pairs...); err != nil {
@@ -154,7 +152,7 @@ func (p *BinanceProvider) handleReceivedTickers(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Duration(p.msReadNewMessage) * time.Millisecond):
+		case <-time.After(defaultReadNewMessage):
 			// time after to avoid asking for prices too frequently
 			messageType, bz, err := p.wsClient.ReadMessage()
 			if err != nil {

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -1,18 +1,22 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 const (
+	binanceHost           = "stream.binance.com:9443"
+	binancePath           = "/ws/umeestream"
 	binanceBaseURL        = "https://api.binance.com"
 	binanceTickerEndpoint = "/api/v3/ticker/24hr"
 )
@@ -23,96 +27,145 @@ type (
 	// BinanceProvider defines an Oracle provider implemented by the Binance public
 	// API.
 	//
-	// REF: https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md
+	// REF: https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams
 	BinanceProvider struct {
-		baseURL string
-		client  *http.Client
+		wsURL            url.URL
+		wsClient         *websocket.Conn
+		logger           zerolog.Logger
+		mu               sync.Mutex
+		tickers          map[string]BinanceTicker // Symbol => BinanceTicker
+		msReadNewMessage uint16
 	}
 
-	// BinanceTickerResponse defines the response structure of a Binance ticker
+	// BinanceTicker defines the response structure of a Binance ticker
 	// request.
-	BinanceTickerResponse struct {
-		Symbol    string `json:"symbol"`
-		LastPrice string `json:"lastPrice"`
-		Volume    string `json:"volume"`
+	BinanceTicker struct {
+		Symbol    string `json:"s"` // Symbol ex.: BTCUSDT
+		LastPrice string `json:"c"` // Last price ex.: 0.0025
+		Volume    string `json:"v"` // Total traded base asset volume ex.: 1000
+	}
 
-		// Code and Msg are populated on failed requests
-		Code int    `json:"code"`
-		Msg  string `json:"msg"`
+	BinanceSubscribeMsg struct {
+		Method string   `json:"method"`
+		Params []string `json:"params"`
+		Id     uint16   `json:"id"`
 	}
 )
 
-func NewBinanceProvider() *BinanceProvider {
-	return &BinanceProvider{
-		baseURL: binanceBaseURL,
-		client:  newDefaultHTTPClient(),
+func NewBinanceProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.CurrencyPair) (*BinanceProvider, error) {
+	wsURL := url.URL{
+		Scheme: "wss",
+		Host:   binanceHost,
+		Path:   binancePath,
 	}
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to Binance websocket: %w", err)
+	}
+
+	provider := &BinanceProvider{
+		wsURL:            wsURL,
+		wsClient:         wsConn,
+		logger:           logger.With().Str("module", "oracle").Logger(),
+		tickers:          map[string]BinanceTicker{},
+		msReadNewMessage: msReadNewMessage,
+	}
+
+	if err := provider.subscribeTickers(pairs...); err != nil {
+		return nil, err
+	}
+
+	go provider.handleReceivedTickers(ctx)
+
+	return provider, nil
 }
 
-func NewBinanceProviderWithTimeout(timeout time.Duration) *BinanceProvider {
-	return &BinanceProvider{
-		baseURL: binanceBaseURL,
-		client:  newHTTPClientWithTimeout(timeout),
-	}
-}
-
-func (p BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
 	tickerPrices := make(map[string]TickerPrice, len(pairs))
+
 	for _, cp := range pairs {
-		price, err := p.getTickerPrice(cp.String())
+		key := cp.String()
+		price, err := p.getTickerPrice(key)
 		if err != nil {
 			return nil, err
 		}
-
-		tickerPrices[cp.String()] = price
+		tickerPrices[key] = price
 	}
 
 	return tickerPrices, nil
 }
 
-func (p BinanceProvider) getTickerPrice(ticker string) (TickerPrice, error) {
-	path := fmt.Sprintf("%s%s?symbol=%s", p.baseURL, binanceTickerEndpoint, ticker)
-
-	resp, err := p.client.Get(path)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to make Binance request: %w", err)
+func (p *BinanceProvider) getTickerPrice(key string) (TickerPrice, error) {
+	ticker, ok := p.tickers[key]
+	if !ok {
+		return TickerPrice{}, fmt.Errorf("failed to get %s", key)
 	}
 
-	defer resp.Body.Close()
+	return ticker.toTickerPrice()
+}
 
-	bz, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to read Binance response body: %w", err)
+func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
+	if messageType != websocket.TextMessage {
+		return
 	}
 
-	var tickerResp BinanceTickerResponse
-	if err := json.Unmarshal(bz, &tickerResp); err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to unmarshal Binance response body: %w", err)
+	var tickerRespWS BinanceTicker
+	if err := json.Unmarshal(bz, &tickerRespWS); err != nil {
+		// sometimes it returns other messages which are not tickerResponses
+		p.logger.Err(err).Msg("Binance provider could not unmarshal")
+		return
 	}
 
-	if tickerResp.Code != 0 {
-		return TickerPrice{}, fmt.Errorf(
-			"received unexpected error from Binance response: %v (%d)",
-			tickerResp.Msg, tickerResp.Code,
-		)
+	p.setTickerPair(tickerRespWS)
+}
+
+func (p *BinanceProvider) setTickerPair(ticker BinanceTicker) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tickers[ticker.Symbol] = ticker
+}
+
+func (ticker BinanceTicker) toTickerPrice() (TickerPrice, error) {
+	return toTickerPrice("Binance", ticker.Symbol, ticker.LastPrice, ticker.Volume)
+}
+
+// subscribeTickers subscribe to all currency pairs
+func (p *BinanceProvider) subscribeTickers(cps ...types.CurrencyPair) error {
+	params := make([]string, len(cps))
+
+	for i, cp := range cps {
+		params[i] = strings.ToLower(cp.Base + cp.Quote + "@ticker")
 	}
 
-	if !strings.EqualFold(tickerResp.Symbol, ticker) {
-		return TickerPrice{}, fmt.Errorf(
-			"received unexpected symbol from Binance response; expected: %s, got: %s",
-			ticker, tickerResp.Symbol,
-		)
-	}
+	subsMsg := newBinanceSubscriptionMsg(params...)
+	return p.wsClient.WriteJSON(subsMsg)
+}
 
-	price, err := sdk.NewDecFromStr(tickerResp.LastPrice)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse Binance price (%s) for %s", tickerResp.LastPrice, ticker)
-	}
+func (p *BinanceProvider) handleReceivedTickers(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(p.msReadNewMessage) * time.Millisecond):
+			// time after to avoid asking for prices too frequently
+			messageType, bz, err := p.wsClient.ReadMessage()
+			if err != nil {
+				// if some error occurs continue to try to read the next message
+				p.logger.Err(err).Msg("Binance provider could not read message")
+				continue
+			}
 
-	volume, err := sdk.NewDecFromStr(tickerResp.Volume)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse Binance volume (%s) for %s", tickerResp.Volume, ticker)
+			p.messageReceived(messageType, bz)
+		}
 	}
+}
 
-	return TickerPrice{Price: price, Volume: volume}, nil
+// newSubscriptionMsg returns a new subscription Msg
+func newBinanceSubscriptionMsg(params ...string) BinanceSubscribeMsg {
+	return BinanceSubscribeMsg{
+		Method: "SUBSCRIBE",
+		Params: params,
+		Id:     1,
+	}
 }

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -38,11 +38,16 @@ type (
 	}
 
 	// BinanceTicker defines the response structure of a Binance ticker
-	// request.
+	// request. https://pkg.go.dev/encoding/json#Unmarshal
+	// Unmarshal matches incoming object keys to the keys
+	// used by Marshal (either the struct field name or its tag),
+	// preferring an exact match but also accepting a case-insensitive match
+	// C is not used, but it avoids to implement specific UnmarshalJSON
 	BinanceTicker struct {
 		Symbol    string `json:"s"` // Symbol ex.: BTCUSDT
 		LastPrice string `json:"c"` // Last price ex.: 0.0025
 		Volume    string `json:"v"` // Total traded base asset volume ex.: 1000
+		C         uint64 `json:"C"` // Statistics close time
 	}
 
 	BinanceSubscribeMsg struct {
@@ -114,6 +119,10 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 	if err := json.Unmarshal(bz, &tickerRespWS); err != nil {
 		// sometimes it returns other messages which are not tickerResponses
 		p.logger.Err(err).Msg("Binance provider could not unmarshal")
+		return
+	}
+
+	if len(tickerRespWS.LastPrice) == 0 {
 		return
 	}
 

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -50,7 +50,7 @@ type (
 	}
 
 	// BinanceSubscribeMsg Msg to subscribe all the tickers channels
-	BinanceSubscribeMsg struct {
+	BinanceSubscriptionMsg struct {
 		Method string   `json:"method"` // SUBSCRIBE/UNSUBSCRIBE
 		Params []string `json:"params"` // streams to subscribe ex.: usdtatom@ticker
 		ID     uint16   `json:"id"`     // identify messages going back and forth
@@ -115,7 +115,7 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 		return
 	}
 
-	var tickerRespWS BinanceTicker
+	var tickerResp BinanceTicker
 	if err := json.Unmarshal(bz, &tickerRespWS); err != nil {
 		// sometimes it returns other messages which are not ticker responses
 		p.logger.Err(err).Msg("Binance provider could not unmarshal")

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -15,10 +15,8 @@ import (
 )
 
 const (
-	binanceHost           = "stream.binance.com:9443"
-	binancePath           = "/ws/umeestream"
-	binanceBaseURL        = "https://api.binance.com"
-	binanceTickerEndpoint = "/api/v3/ticker/24hr"
+	binanceHost = "stream.binance.com:9443"
+	binancePath = "/ws/umeestream"
 )
 
 var _ Provider = (*BinanceProvider)(nil)
@@ -117,7 +115,7 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 
 	var tickerRespWS BinanceTicker
 	if err := json.Unmarshal(bz, &tickerRespWS); err != nil {
-		// sometimes it returns other messages which are not tickerResponses
+		// sometimes it returns other messages which are not ticker responses
 		p.logger.Err(err).Msg("Binance provider could not unmarshal")
 		return
 	}
@@ -136,7 +134,7 @@ func (p *BinanceProvider) setTickerPair(ticker BinanceTicker) {
 }
 
 func (ticker BinanceTicker) toTickerPrice() (TickerPrice, error) {
-	return toTickerPrice("Binance", ticker.Symbol, ticker.LastPrice, ticker.Volume)
+	return newTickerPrice("Binance", ticker.Symbol, ticker.LastPrice, ticker.Volume)
 }
 
 // subscribeTickers subscribe to all currency pairs

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -53,7 +53,7 @@ type (
 	BinanceSubscribeMsg struct {
 		Method string   `json:"method"`
 		Params []string `json:"params"`
-		Id     uint16   `json:"id"`
+		ID     uint16   `json:"id"`
 	}
 )
 
@@ -153,6 +153,9 @@ func (p *BinanceProvider) subscribeTickers(cps ...types.CurrencyPair) error {
 }
 
 func (p *BinanceProvider) handleReceivedTickers(ctx context.Context) {
+	reconnectTicker := time.NewTicker(binanceReconnectTime)
+	defer reconnectTicker.Stop()
+	
 	for {
 		select {
 		case <-ctx.Done():

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -1,130 +1,74 @@
 package provider
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestBinanceProvider_GetTickerPrices(t *testing.T) {
-	p := NewBinanceProvider()
+	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/api/v3/ticker/24hr?symbol=ATOMUSDT", req.URL.String())
-			resp := `{
-				"symbol": "ATOMUSDT",
-				"lastPrice": "34.69000000",
-				"volume": "2396974.02000000"
-			}
-			`
-			rw.Write([]byte(resp))
-		}))
-		defer server.Close()
+		lastPrice := "34.69000000"
+		volume := "2396974.02000000"
 
-		p.client = server.Client()
-		p.baseURL = server.URL
+		tickerMap := map[string]BinanceTicker{}
+		tickerMap["ATOMUSDT"] = BinanceTicker{
+			Symbol:    "ATOMUSDT",
+			LastPrice: lastPrice,
+			Volume:    volume,
+		}
+
+		p.tickers = tickerMap
 
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
 		require.NoError(t, err)
 		require.Len(t, prices, 1)
-		require.Equal(t, sdk.MustNewDecFromStr("34.69000000"), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr("2396974.02000000"), prices["ATOMUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPrice), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		var count int
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if count == 0 {
-				require.Equal(t, "/api/v3/ticker/24hr?symbol=ATOMUSDT", req.URL.String())
-				resp := `{
-					"symbol": "ATOMUSDT",
-					"lastPrice": "34.69000000",
-					"volume": "2396974.02000000"
-				}
-				`
-				rw.Write([]byte(resp))
-			} else {
-				require.Equal(t, "/api/v3/ticker/24hr?symbol=LUNAUSDT", req.URL.String())
-				resp := `{
-					"symbol": "LUNAUSDT",
-					"lastPrice": "41.35000000",
-					"volume": "2396974.02000000"
-				}
-				`
-				rw.Write([]byte(resp))
-			}
+		lastPriceAtom := "34.69000000"
+		lastPriceLuna := "41.35000000"
+		volume := "2396974.02000000"
 
-			count++
-		}))
-		defer server.Close()
+		tickerMap := map[string]BinanceTicker{}
+		tickerMap["ATOMUSDT"] = BinanceTicker{
+			Symbol:    "ATOMUSDT",
+			LastPrice: lastPriceAtom,
+			Volume:    volume,
+		}
 
-		p.client = server.Client()
-		p.baseURL = server.URL
+		tickerMap["LUNAUSDT"] = BinanceTicker{
+			Symbol:    "LUNAUSDT",
+			LastPrice: lastPriceLuna,
+			Volume:    volume,
+		}
 
+		p.tickers = tickerMap
 		prices, err := p.GetTickerPrices(
 			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
 		)
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
-		require.Equal(t, sdk.MustNewDecFromStr("34.69000000"), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr("2396974.02000000"), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr("41.35000000"), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr("2396974.02000000"), prices["LUNAUSDT"].Volume)
-	})
-
-	t.Run("invalid_request_bad_response", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/api/v3/ticker/24hr?symbol=ATOMUSDT", req.URL.String())
-			rw.Write([]byte(`FOO`))
-		}))
-		defer server.Close()
-
-		p.client = server.Client()
-		p.baseURL = server.URL
-
-		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
-		require.Error(t, err)
-		require.Nil(t, prices)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceLuna), prices["LUNAUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/api/v3/ticker/24hr?symbol=FOOBAR", req.URL.String())
-			resp := `{
-				"code": -1121,
-				"msg": "Invalid symbol."
-			}
-			`
-			rw.Write([]byte(resp))
-		}))
-		defer server.Close()
-
-		p.client = server.Client()
-		p.baseURL = server.URL
-
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
 		require.Error(t, err)
-		require.Nil(t, prices)
-	})
-
-	t.Run("check_redirect", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			http.Redirect(rw, r, p.baseURL, http.StatusTemporaryRedirect)
-		}))
-		defer server.Close()
-
-		server.Client().CheckRedirect = preventRedirect
-		p.client = server.Client()
-		p.baseURL = server.URL
-
-		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
-		require.Error(t, err)
+		require.Equal(t, "failed to get FOOBAR", err.Error())
 		require.Nil(t, prices)
 	})
 }

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBinanceProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -193,6 +193,7 @@ func (p *OkxProvider) resetReconnectTimer() {
 	p.reconnectTimer.Reset(okxPingCheck)
 }
 
+// reconnect closes the last WS connection and create a new one
 // If there’s a network problem, the system will automatically disable the connection.
 // The connection will break automatically if the subscription is not established or
 // data has not been pushed for more than 30 seconds.

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -157,15 +157,15 @@ func (p *OkxProvider) messageReceived(messageType int, bz []byte) {
 		return
 	}
 
-	var tickerRespWS OkxTickerResponse
-	if err := json.Unmarshal(bz, &tickerRespWS); err != nil {
+	var tickerResp OkxTickerResponse
+	if err := json.Unmarshal(bz, &tickerResp); err != nil {
 		// sometimes it returns other messages which are not tickerResponses
 		p.logger.Err(err).Msg("Okx provider could not unmarshal")
 		return
 	}
 
 	p.resetReconnectTimer()
-	for _, tickerPair := range tickerRespWS.Data {
+	for _, tickerPair := range tickerResp.Data {
 		p.setTickerPair(tickerPair)
 	}
 }

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -173,7 +173,7 @@ func (p *OkxProvider) subscribeTickers(cps ...types.CurrencyPair) error {
 }
 
 func (ticker OkxTickerPair) toTickerPrice() (TickerPrice, error) {
-	return toTickerPrice("Okx", ticker.InstId, ticker.Last, ticker.Vol24h)
+	return newTickerPrice("Okx", ticker.InstId, ticker.Last, ticker.Vol24h)
 }
 
 // getInstrumentId returns the expected pair instrument ID for Okx ex.: BTC-USDT

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -132,7 +132,7 @@ func (p *OkxProvider) handleReceivedTickers(ctx context.Context) {
 			if err != nil {
 				// if some error occurs continue to try to read the next message
 				p.logger.Err(err).Msg("Okx provider could not read message")
-				if err := p.ping(); err != nil { // send ping to check connection
+				if err := p.ping(); err != nil {
 					p.logger.Err(err).Msg("Okx provider could not send ping")
 				}
 				continue
@@ -144,7 +144,7 @@ func (p *OkxProvider) handleReceivedTickers(ctx context.Context) {
 
 			p.messageReceived(messageType, bz)
 
-		case <-p.reconnectTimer.C: // reseted by the pongHandler
+		case <-p.reconnectTimer.C: // reset by the pongHandler
 			if err := p.reconnect(); err != nil {
 				p.logger.Err(err).Msg("Okx provider error reconnecting")
 			}
@@ -193,7 +193,7 @@ func (p *OkxProvider) resetReconnectTimer() {
 	p.reconnectTimer.Reset(okxPingCheck)
 }
 
-// reconnect closes the last WS connection and create a new one
+// reconnect closes the last WS connection and creates a new one.
 // If there’s a network problem, the system will automatically disable the connection.
 // The connection will break automatically if the subscription is not established or
 // data has not been pushed for more than 30 seconds.
@@ -207,7 +207,7 @@ func (p *OkxProvider) reconnect() error {
 	p.logger.Debug().Msg("Okx reconnecting websocket")
 	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
 	if err != nil {
-		return fmt.Errorf("error reconnect to Okx websocket: %w", err)
+		return fmt.Errorf("error reconnecting to Okx websocket: %w", err)
 	}
 	wsConn.SetPongHandler(p.pongHandler)
 	p.wsClient = wsConn

--- a/price-feeder/oracle/provider/okx_test.go
+++ b/price-feeder/oracle/provider/okx_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestOkxProvider_GetTickerPrices(t *testing.T) {
-	ctx := context.TODO()
-	p, err := NewOkxProvider(ctx, zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	p, err := NewOkxProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -39,4 +40,18 @@ func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 		Timeout:       timeout,
 		CheckRedirect: preventRedirect,
 	}
+}
+
+func toTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
+	price, err := sdk.NewDecFromStr(lastPrice)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)
+	}
+
+	volumeDec, err := sdk.NewDecFromStr(volume)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s", provider, volume, symbol)
+	}
+
+	return TickerPrice{Price: price, Volume: volumeDec}, nil
 }

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -42,7 +42,7 @@ func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 	}
 }
 
-func toTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
+func newTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
 	price, err := sdk.NewDecFromStr(lastPrice)
 	if err != nil {
 		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	defaultTimeout = 10 * time.Second
+	defaultTimeout        = 10 * time.Second
+	defaultReadNewMessage = 50 * time.Millisecond
 )
 
 // Provider defines an interface an exchange price provider must implement.


### PR DESCRIPTION
## Description

- Modified Binance provider to use [WebSocket](https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams) connection instead of `http.client`
- Modified unit tests for checking the map
- Add reconnect logic to Okx provider

ref: #509

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
