### PR TITLE
fix: stop requiring telemetry during config validation

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -52,6 +52,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#536](https://github.com/umee-network/umee/pull/536) Force a minimum of three providers per asset.
 - [#502](https://github.com/umee-network/umee/pull/502) Faulty provider detection: discard prices that are not within 2𝜎 of others.
 
+### Bug Fixes
+
+- [#552](https://github.com/umee-network/umee/pull/552) Stop requiring telemetry during config validation.
+
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07
 
 ### Features

--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -97,37 +97,52 @@ type (
 	// Telemetry defines the configuration options for application telemetry.
 	Telemetry struct {
 		// Prefixed with keys to separate services
-		ServiceName string `toml:"service_name" validate:"required"`
+		ServiceName string `toml:"service_name"`
 
 		// Enabled enables the application telemetry functionality. When enabled,
 		// an in-memory sink is also enabled by default. Operators may also enabled
 		// other sinks such as Prometheus.
-		Enabled bool `toml:"enabled" validate:"required"`
+		Enabled bool `toml:"enabled"`
 
 		// Enable prefixing gauge values with hostname
-		EnableHostname bool `toml:"enable_hostname" validate:"required"`
+		EnableHostname bool `toml:"enable_hostname"`
 
 		// Enable adding hostname to labels
-		EnableHostnameLabel bool `toml:"enable_hostname_label" validate:"required"`
+		EnableHostnameLabel bool `toml:"enable_hostname_label"`
 
 		// Enable adding service to labels
-		EnableServiceLabel bool `toml:"enable_service_label" validate:"required"`
+		EnableServiceLabel bool `toml:"enable_service_label"`
 
 		// GlobalLabels defines a global set of name/value label tuples applied to all
 		// metrics emitted using the wrapper functions defined in telemetry package.
 		//
 		// Example:
 		// [["chain_id", "cosmoshub-1"]]
-		GlobalLabels [][]string `toml:"global_labels" validate:"required"`
+		GlobalLabels [][]string `toml:"global_labels""`
 
 		// Type determines which type of telemetry to use
 		// Valid values are "prometheus" or "generic"
-		Type string `toml:"type" validate:"required"`
+		Type string `toml:"type"`
 	}
 )
 
+// telemetryValidation is custom validation for the Telemetry struct
+func telemetryValidation(sl validator.StructLevel) {
+	tel := sl.Current().Interface().(Telemetry)
+
+	if tel.Enabled && (len(tel.GlobalLabels) == 0 || len(tel.ServiceName) == 0 ||
+		len(tel.Type) == 0) {
+		sl.ReportError(tel.Enabled, "enabled", "Enabled", "enabledNoOptions", "")
+	} else if tel.Enabled &&
+		(len(tel.Type) == 0 ||
+			(tel.Type != "prometheus" && tel.Type != "generic")) {
+		sl.ReportError(tel.Enabled, "type", "Type", "unsupportedTelemetryType", "")
+	}
+}
+
 // Validate returns an error if the Config object is invalid.
 func (c Config) Validate() error {
+	validate.RegisterStructValidation(telemetryValidation, Telemetry{})
 	return validate.Struct(c)
 }
 
@@ -180,11 +195,6 @@ func ParseConfig(configPath string) (Config, error) {
 		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
 			return cfg, fmt.Errorf("must have at least three providers for %s", base)
 		}
-	}
-
-	if len(cfg.Telemetry.Type) == 0 ||
-		(cfg.Telemetry.Type != "prometheus" && cfg.Telemetry.Type != "generic") {
-		return cfg, fmt.Errorf("unsupported telemetry type: %s", cfg.Telemetry.Type)
 	}
 
 	return cfg, cfg.Validate()

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -47,7 +47,7 @@ func TestValidate(t *testing.T) {
 					EnableHostnameLabel: true,
 					EnableServiceLabel:  true,
 					GlobalLabels:        make([][]string, 1),
-					Type:                "genesis",
+					Type:                "generic",
 				},
 				GasAdjustment: 1.5,
 			},

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -190,6 +190,75 @@ global_labels = [["chain-id", "umee-local-beta-testnet"]]
 	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
 }
 
+func TestParseConfig_Valid_NoTelemetry(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "price-feeder.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	content := []byte(`
+gas_adjustment = 1.5
+
+[server]
+listen_addr = "0.0.0.0:99999"
+read_timeout = "20s"
+verbose_cors = true
+write_timeout = "20s"
+
+[[currency_pairs]]
+base = "ATOM"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[[currency_pairs]]
+base = "UMEE"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[account]
+address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "umee-local-testnet"
+
+[keyring]
+backend = "test"
+dir = "/Users/username/.umee"
+pass = "keyringPassword"
+
+[rpc]
+tmrpc_endpoint = "http://localhost:26657"
+grpc_endpoint = "localhost:9090"
+rpc_timeout = "100ms"
+
+[telemetry]
+enabled = false
+`)
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+
+	cfg, err := config.ParseConfig(tmpFile.Name())
+	require.NoError(t, err)
+
+	require.Equal(t, "0.0.0.0:99999", cfg.Server.ListenAddr)
+	require.Equal(t, "20s", cfg.Server.WriteTimeout)
+	require.Equal(t, "20s", cfg.Server.ReadTimeout)
+	require.True(t, cfg.Server.VerboseCORS)
+	require.Len(t, cfg.CurrencyPairs, 2)
+	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
+	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
+	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
+	require.Equal(t, "kraken", cfg.CurrencyPairs[0].Providers[0])
+	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
+	require.Equal(t, cfg.Telemetry.Enabled, false)
+}
+
 func TestParseConfig_InvalidProvider(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "price-feeder.toml")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Fixes our config validation so that telemetry is no longer required 

closes: #544

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
