### PR TITLE
fix: strengthen price-feeder cors settings

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -53,11 +53,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#502](https://github.com/umee-network/umee/pull/502) Faulty provider detection: discard prices that are not within 2𝜎 of others.
 - [#551](https://github.com/umee-network/umee/pull/551) Update Binance provider to use WebSocket.
 - [#569](https://github.com/umee-network/umee/pull/569) Update Huobi provider to use WebSocket.
-- [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
 
 ### Bug Fixes
 
 - [#552](https://github.com/umee-network/umee/pull/552) Stop requiring telemetry during config validation.
+- [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
 
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#502](https://github.com/umee-network/umee/pull/502) Faulty provider detection: discard prices that are not within 2𝜎 of others.
 - [#551](https://github.com/umee-network/umee/pull/551) Update Binance provider to use WebSocket.
 - [#569](https://github.com/umee-network/umee/pull/569) Update Huobi provider to use WebSocket.
+- [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
 
 ### Bug Fixes
 

--- a/price-feeder/router/middleware/middleware.go
+++ b/price-feeder/router/middleware/middleware.go
@@ -46,17 +46,17 @@ func AddRequestLoggingMiddleware(mChain alice.Chain, logger zerolog.Logger) alic
 func AddCORSMiddleware(mChain alice.Chain, logger zerolog.Logger, cfg config.Config) alice.Chain {
 	opts := cors.Options{
 		AllowedMethods: []string{
-			http.MethodHead,
 			http.MethodGet,
-			http.MethodPost,
-			http.MethodPut,
-			http.MethodPatch,
-			http.MethodDelete,
 			http.MethodOptions,
 		},
 		AllowCredentials: true,
-		AllowedHeaders:   []string{"*"},
-		AllowedOrigins:   cfg.Server.AllowedOrigins,
+		AllowedHeaders: []string{
+			"Content-Type",
+			"Access-Control-Allow-Headers",
+			"Authorization",
+			"X-Requested-With",
+		},
+		AllowedOrigins: cfg.Server.AllowedOrigins,
 	}
 
 	if cfg.Server.VerboseCORS {

--- a/price-feeder/router/v1/router.go
+++ b/price-feeder/router/v1/router.go
@@ -43,9 +43,14 @@ func (r *Router) RegisterRoutes(rtr *mux.Router, prefix string) {
 	mChain := middleware.Build(r.logger, r.cfg)
 
 	// handle all preflight request
-	v1Router.Methods("OPTIONS").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
-		w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS")
+	v1Router.Methods("OPTIONS").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		for _, origin := range r.cfg.Server.AllowedOrigins {
+			if origin == req.Header.Get("Origin") {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+		}
+
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Description

Updates our cors settings to only allow GET and OPTIONS requests, and updates the options preflight handler to echo back the `Origin` header in `Access-Control-Allow-Origin` if it's in the config.

closes: #515

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
