### PR TITLE
fix: only register metrics endpoint with tel enabled

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -57,6 +57,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - [#552](https://github.com/umee-network/umee/pull/552) Stop requiring telemetry during config validation.
+- [#574](https://github.com/umee-network/umee/pull/574) Stop registering metrics endpoint if telemetry is disabled.
 
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07
 

--- a/price-feeder/router/v1/router.go
+++ b/price-feeder/router/v1/router.go
@@ -61,10 +61,12 @@ func (r *Router) RegisterRoutes(rtr *mux.Router, prefix string) {
 		mChain.ThenFunc(r.pricesHandler()),
 	).Methods(httputil.MethodGET)
 
-	v1Router.Handle(
-		"/metrics",
-		mChain.ThenFunc(r.metricsHandler()),
-	).Methods(httputil.MethodGET)
+	if r.cfg.Telemetry.Enabled {
+		v1Router.Handle(
+			"/metrics",
+			mChain.ThenFunc(r.metricsHandler()),
+		).Methods(httputil.MethodGET)
+	}
 }
 
 func (r *Router) healthzHandler() http.HandlerFunc {


### PR DESCRIPTION
## Description

Only register metrics endpoint if telemetry is enabled 

closes: #572

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
