### PR TITLE
feat: add SubscribeTickers func to providers

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -61,6 +61,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#574](https://github.com/umee-network/umee/pull/574) Stop registering metrics endpoint if telemetry is disabled.
 - [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
 
+### Refactor
+
+- [#587](https://github.com/umee-network/umee/pull/587) Clean up logs from price feeder providers.
+
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07
 
 ### Features

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#551](https://github.com/umee-network/umee/pull/551) Update Binance provider to use WebSocket.
 - [#569](https://github.com/umee-network/umee/pull/569) Update Huobi provider to use WebSocket.
 - [#580](https://github.com/umee-network/umee/pull/580) Update Kraken provider to use WebSocket.
+- [#592](https://github.com/umee-network/umee/pull/592) Add subscribe ticker function to the following providers: Binance, Huobi, Kraken, and Okx.
 
 ### Bug Fixes
 

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -71,7 +71,7 @@ func NewBinanceProvider(ctx context.Context, logger zerolog.Logger, pairs ...typ
 	provider := &BinanceProvider{
 		wsURL:           wsURL,
 		wsClient:        wsConn,
-		logger:          logger.With().Str("module", "oracle").Logger(),
+		logger:          logger.With().Str("provider", "binance").Logger(),
 		tickers:         map[string]BinanceTicker{},
 		subscribedPairs: pairs,
 	}
@@ -118,7 +118,7 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 	var tickerResp BinanceTicker
 	if err := json.Unmarshal(bz, &tickerResp); err != nil {
 		// sometimes it returns other messages which are not ticker responses
-		p.logger.Err(err).Msg("Binance provider could not unmarshal")
+		p.logger.Err(err).Msg("could not unmarshal ticker")
 		return
 	}
 
@@ -163,7 +163,7 @@ func (p *BinanceProvider) handleWebSocketMsgs(ctx context.Context) {
 			messageType, bz, err := p.wsClient.ReadMessage()
 			if err != nil {
 				// if some error occurs continue to try to read the next message
-				p.logger.Err(err).Msg("Binance provider could not read message")
+				p.logger.Err(err).Msg("could not read message")
 				continue
 			}
 
@@ -175,7 +175,7 @@ func (p *BinanceProvider) handleWebSocketMsgs(ctx context.Context) {
 
 		case <-reconnectTicker.C:
 			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("binance provider error reconnecting")
+				p.logger.Err(err).Msg("error reconnecting")
 				p.keepReconnecting()
 			}
 		}
@@ -192,7 +192,7 @@ func (p *BinanceProvider) handleWebSocketMsgs(ctx context.Context) {
 func (p *BinanceProvider) reconnect() error {
 	p.wsClient.Close()
 
-	p.logger.Debug().Msg("binance reconnecting websocket")
+	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("error reconnect to binance websocket: %w", err)
@@ -210,12 +210,12 @@ func (p *BinanceProvider) keepReconnecting() {
 
 	for time := range reconnectTicker.C {
 		if err := p.reconnect(); err != nil {
-			p.logger.Err(err).Msgf("binance provider attempted to reconnect %d times at %s", connectionTries, time.String())
+			p.logger.Err(err).Msgf("attempted to reconnect %d times at %s", connectionTries, time.String())
 			continue
 		}
 
 		if connectionTries > maxReconnectionTries {
-			p.logger.Warn().Msgf("binance provider failed to reconnect %d times", connectionTries)
+			p.logger.Warn().Msgf("failed to reconnect %d times", connectionTries)
 		}
 		connectionTries++
 		return

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -72,3 +72,9 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 		require.Nil(t, prices)
 	})
 }
+
+func TestBinanceCurrencyPairToBinancePair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	binanceSymbol := currencyPairToBinancePair(cp)
+	require.Equal(t, binanceSymbol, "atomusdt@ticker")
+}

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -250,7 +250,7 @@ func (p *HuobiProvider) subscribePair(cp types.CurrencyPair) error {
 }
 
 func (p *HuobiProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
-	ticker, ok := p.tickers[getChannelTicker(cp)]
+	ticker, ok := p.tickers[currencyPairToHuobiPair(cp)]
 	if !ok {
 		return TickerPrice{}, fmt.Errorf("huobi provider failed to get ticker price for %s", cp.String())
 	}
@@ -292,11 +292,11 @@ func (ticker HuobiTicker) toTickerPrice() (TickerPrice, error) {
 // newHuobiSubscriptionMsg returns a new subscription Msg
 func newHuobiSubscriptionMsg(cp types.CurrencyPair) HuobiSubscriptionMsg {
 	return HuobiSubscriptionMsg{
-		Sub: getChannelTicker(cp),
+		Sub: currencyPairToHuobiPair(cp),
 	}
 }
 
-// getChannelTicker returns the channel name in the Format：market.$symbol.ticker
-func getChannelTicker(cp types.CurrencyPair) string {
+// currencyPairToHuobiPair returns the channel name in the Format：market.$symbol.ticker
+func currencyPairToHuobiPair(cp types.CurrencyPair) string {
 	return strings.ToLower("market." + cp.String() + ".ticker")
 }

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -31,7 +31,7 @@ type (
 	// API.
 	//
 	// REF: https://huobiapi.github.io/docs/spot/v1/en/#market-ticker
-	// REF : https://huobiapi.github.io/docs/spot/v1/en/#get-klines-candles
+	// REF: https://huobiapi.github.io/docs/spot/v1/en/#get-klines-candles
 	HuobiProvider struct {
 		wsURL           url.URL
 		wsClient        *websocket.Conn
@@ -42,22 +42,22 @@ type (
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	// HuobiTicker defines the response type for the channel and
-	// the tick object for a given ticker/symbol.
+	// HuobiTicker defines the response type for the channel and the tick object for a
+	// given ticker/symbol.
 	HuobiTicker struct {
 		CH   string    `json:"ch"` // Channel name. Format：market.$symbol.ticker
 		Tick HuobiTick `json:"tick"`
 	}
 
-	// HuobiTick defines the response type for the last 24h market summary
-	// and the last traded price for a given ticker/symbol.
+	// HuobiTick defines the response type for the last 24h market summary and the last
+	// traded price for a given ticker/symbol.
 	HuobiTick struct {
 		Vol       float64 `json:"vol"`       // Accumulated trading value of last 24 hours
 		LastPrice float64 `json:"lastPrice"` // Last traded price
 	}
 
-	// HuobiCandle defines the response type for the channel and
-	// the tick object for a given ticker/symbol.
+	// HuobiCandle defines the response type for the channel and the tick object for a
+	// given ticker/symbol.
 	HuobiCandle struct {
 		CH   string          `json:"ch"` // Channel name. Format：market.$symbol.kline.$period
 		Tick HuobiCandleTick `json:"tick"`
@@ -70,7 +70,7 @@ type (
 		Volume    float64 `json:"volume"` // Volume during this period
 	}
 
-	// HuobiSubscriptionMsg Msg to subscribe to one ticker channel at time
+	// HuobiSubscriptionMsg Msg to subscribe to one ticker channel at time.
 	HuobiSubscriptionMsg struct {
 		Sub string `json:"sub"` // channel to subscribe market.$symbol.ticker
 	}
@@ -122,8 +122,7 @@ func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string
 	return tickerPrices, nil
 }
 
-// SubscribeTickers subscribe to all currency pairs and
-// add the new ones into the provider subscribed pairs.
+// SubscribeTickers subscribe all currency pairs into ticker and candle channels.
 func (p *HuobiProvider) SubscribeTickers(cps ...types.CurrencyPair) error {
 	for _, cp := range cps {
 		if err := p.subscribeTickerPair(cp); err != nil {
@@ -173,9 +172,9 @@ func (p *HuobiProvider) handleWebSocketMsgs(ctx context.Context) {
 	}
 }
 
-// messageReceived handles the received data from the Huobi websocket.
-// All return data of websocket Market APIs are compressed with
-// GZIP so they need to be decompressed.
+// messageReceived handles the received data from the Huobi websocket. All return
+// data of websocket Market APIs are compressed with GZIP so they need to be
+// decompressed.
 func (p *HuobiProvider) messageReceived(messageType int, bz []byte, reconnectTicker *time.Ticker) {
 	if messageType != websocket.BinaryMessage {
 		return
@@ -215,14 +214,12 @@ func (p *HuobiProvider) messageReceived(messageType int, bz []byte, reconnectTic
 	}
 }
 
-// pong return a heartbeat message when a "ping" is received
-// and reset the recconnect ticker because the connection is alive
-// After connected to Huobi's Websocket server,
-// the server will send heartbeat periodically (5s interval).
-// When client receives an heartbeat message, it should respond
-// with a matching "pong" message which has the same integer in it, e.g.
-// {"ping": 1492420473027} and the return should be
-// {"pong": 1492420473027}
+// pong return a heartbeat message when a "ping" is received and reset the
+// recconnect ticker because the connection is alive. After connected to Huobi's
+// Websocket server, the server will send heartbeat periodically (5s interval).
+// When client receives an heartbeat message, it should respond with a matching
+// "pong" message which has the same integer in it, e.g. {"ping": 1492420473027}
+// and then the return pong message should be {"pong": 1492420473027}.
 func (p *HuobiProvider) pong(bz []byte, reconnectTicker *time.Ticker) {
 	reconnectTicker.Reset(huobiReconnectTime)
 	var heartbeat struct {
@@ -258,7 +255,7 @@ func (p *HuobiProvider) setCandlePair(candle HuobiCandle) {
 	p.candles[candle.CH] = candle
 }
 
-// reconnect closes the last WS connection and create a new one
+// reconnect closes the last WS connection and create a new one.
 func (p *HuobiProvider) reconnect() error {
 	p.wsClient.Close()
 
@@ -312,9 +309,8 @@ func (p *HuobiProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
 	}
 }
 
-// decompressGzip uncompress gzip compressed messages
-// All data returned from the websocket Market APIs is compressed
-// with GZIP, so it needs to be unzipped.
+// decompressGzip uncompress gzip compressed messages. All data returned from the
+// websocket Market APIs is compressed with GZIP, so it needs to be unzipped.
 func decompressGzip(bz []byte) ([]byte, error) {
 	r, err := gzip.NewReader(bytes.NewReader(bz))
 	if err != nil {
@@ -324,6 +320,7 @@ func decompressGzip(bz []byte) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
+// toTickerPrice converts current HuobiTicker to TickerPrice.
 func (ticker HuobiTicker) toTickerPrice() (TickerPrice, error) {
 	return newTickerPrice(
 		"Huobi",
@@ -333,26 +330,28 @@ func (ticker HuobiTicker) toTickerPrice() (TickerPrice, error) {
 	)
 }
 
-// newHuobiTickerSubscriptionMsg returns a new subscription Msg
+// newHuobiTickerSubscriptionMsg returns a new ticker subscription Msg.
 func newHuobiTickerSubscriptionMsg(cp types.CurrencyPair) HuobiSubscriptionMsg {
 	return HuobiSubscriptionMsg{
 		Sub: currencyPairToHuobiTickerPair(cp),
 	}
 }
 
-// currencyPairToHuobiTickerPair returns the channel name in the Format：market.$symbol.ticker
+// currencyPairToHuobiTickerPair returns the channel name in the following format:
+// "market.$symbol.ticker".
 func currencyPairToHuobiTickerPair(cp types.CurrencyPair) string {
 	return strings.ToLower("market." + cp.String() + ".ticker")
 }
 
-// newHuobiSubscriptionMsg returns a new subscription Msg
+// newHuobiSubscriptionMsg returns a new candle subscription Msg.
 func newHuobiCandleSubscriptionMsg(cp types.CurrencyPair) HuobiSubscriptionMsg {
 	return HuobiSubscriptionMsg{
 		Sub: currencyPairToHuobiCandlePair(cp),
 	}
 }
 
-// currencyPairToHuobiCandlePair returns the channel name in the Format：market.$symbol.line.$period
+// currencyPairToHuobiCandlePair returns the channel name in the following format:
+// "market.$symbol.line.$period".
 func currencyPairToHuobiCandlePair(cp types.CurrencyPair) string {
 	return strings.ToLower("market." + cp.String() + ".kline.1min")
 }

--- a/price-feeder/oracle/provider/huobi_test.go
+++ b/price-feeder/oracle/provider/huobi_test.go
@@ -79,3 +79,9 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 		require.Nil(t, prices)
 	})
 }
+
+func TestHuobiCurrencyPairToHuobiPair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	binanceSymbol := currencyPairToHuobiPair(cp)
+	require.Equal(t, binanceSymbol, "market.atomusdt.ticker")
+}

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -82,13 +82,13 @@ func NewKrakenProvider(ctx context.Context, logger zerolog.Logger, pairs ...type
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to Kraken websocket: %w", err)
+		return nil, fmt.Errorf("error connecting to websocket: %w", err)
 	}
 
 	provider := &KrakenProvider{
 		wsURL:           wsURL,
 		wsClient:        wsConn,
-		logger:          logger.With().Str("module", "oracle").Logger(),
+		logger:          logger.With().Str("provider", "kraken").Logger(),
 		tickers:         map[string]TickerPrice{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
@@ -149,7 +149,7 @@ func (p *KrakenProvider) handleWebSocketMsgs(ctx context.Context) {
 			messageType, bz, err := p.wsClient.ReadMessage()
 			if err != nil {
 				// if some error occurs continue to try to read the next message
-				p.logger.Err(err).Msg("kraken provider could not read message")
+				p.logger.Err(err).Msg("could not read message")
 				if err := p.ping(); err != nil {
 					p.logger.Err(err).Msg("failed to send ping")
 					p.keepReconnecting()
@@ -165,7 +165,7 @@ func (p *KrakenProvider) handleWebSocketMsgs(ctx context.Context) {
 
 		case <-reconnectTicker.C:
 			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("kraken provider attempted to reconnect")
+				p.logger.Err(err).Msg("attempted to reconnect")
 				p.keepReconnecting()
 			}
 		}
@@ -180,7 +180,7 @@ func (p *KrakenProvider) messageReceived(messageType int, bz []byte) {
 
 	var krakenEvent KrakenEvent
 	if err := json.Unmarshal(bz, &krakenEvent); err != nil {
-		p.logger.Debug().Msg("kraken provider received a message that is not an event")
+		p.logger.Debug().Msg("received a message that is not an event")
 		// msg is not an event, it will try to marshal to ticker message
 		p.messageReceivedTickerPrice(bz)
 		return
@@ -202,36 +202,36 @@ func (p *KrakenProvider) messageReceivedTickerPrice(bz []byte) {
 	// kraken documentation https://docs.kraken.com/websockets/#message-ticker
 	var tickerMessage []interface{}
 	if err := json.Unmarshal(bz, &tickerMessage); err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not unmarshal")
+		p.logger.Err(err).Msg("could not unmarshal ticker")
 		return
 	}
 
 	if len(tickerMessage) != 4 {
-		p.logger.Debug().Msg("Kraken provider sent something different than ticker")
+		p.logger.Debug().Msg("sent an unexpected structure")
 		return
 	}
 
 	channelName, ok := tickerMessage[2].(string)
 	if !ok || channelName != "ticker" {
-		p.logger.Debug().Msg("Kraken provider sent an unexpected channel name")
+		p.logger.Debug().Msg("sent an unexpected channel name")
 		return
 	}
 
 	tickerBz, err := json.Marshal(tickerMessage[1])
 	if err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not marshal ticker message")
+		p.logger.Err(err).Msg("could not marshal ticker message")
 		return
 	}
 
 	var krakenTicker KrakenTicker
 	if err := json.Unmarshal(tickerBz, &krakenTicker); err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not unmarshal ticker")
+		p.logger.Err(err).Msg("could not unmarshal ticker")
 		return
 	}
 
 	krakenPair, ok := tickerMessage[3].(string)
 	if !ok {
-		p.logger.Debug().Msg("Kraken provider sent an unexpected pair")
+		p.logger.Debug().Msg("sent an unexpected pair")
 		return
 	}
 
@@ -240,7 +240,7 @@ func (p *KrakenProvider) messageReceivedTickerPrice(bz []byte) {
 
 	tickerPrice, err := krakenTicker.toTickerPrice(currencyPairSymbol)
 	if err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not parse kraken ticker to ticker price")
+		p.logger.Err(err).Msg("could not parse kraken ticker to ticker price")
 		return
 	}
 
@@ -275,12 +275,12 @@ func (p *KrakenProvider) keepReconnecting() {
 
 	for time := range reconnectTicker.C {
 		if err := p.reconnect(); err != nil {
-			p.logger.Err(err).Msgf("kraken provider attempted to reconnect %d times at %s", connectionTries, time.String())
+			p.logger.Err(err).Msgf("attempted to reconnect %d times at %s", connectionTries, time.String())
 			continue
 		}
 
 		if connectionTries > maxReconnectionTries {
-			p.logger.Warn().Msgf("kraken provider failed to reconnect %d times", connectionTries)
+			p.logger.Warn().Msgf("failed to reconnect %d times", connectionTries)
 		}
 		connectionTries++
 		return
@@ -292,7 +292,7 @@ func (p *KrakenProvider) keepReconnecting() {
 func (p *KrakenProvider) messageReceivedSubscriptionStatus(bz []byte) {
 	var subscriptionStatus KrakenEventSubscriptionStatus
 	if err := json.Unmarshal(bz, &subscriptionStatus); err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not unmarshal KrakenEventSubscriptionStatus")
+		p.logger.Err(err).Msg("provider could not unmarshal KrakenEventSubscriptionStatus")
 		return
 	}
 
@@ -312,7 +312,7 @@ func (p *KrakenProvider) messageReceivedSubscriptionStatus(bz []byte) {
 func (p *KrakenProvider) messageReceivedSystemStatus(bz []byte) {
 	var systemStatus KrakenEventSystemStatus
 	if err := json.Unmarshal(bz, &systemStatus); err != nil {
-		p.logger.Err(err).Msg("Kraken provider could not unmarshal KrakenEventSystemStatus")
+		p.logger.Err(err).Msg("could not unmarshal event system status")
 		return
 	}
 

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -106,9 +106,6 @@ func NewKrakenProvider(ctx context.Context, logger zerolog.Logger, pairs ...type
 	if err := provider.SubscribeTickers(pairs...); err != nil {
 		return nil, err
 	}
-	if err := provider.SubscribeCandles(pairs...); err != nil {
-		return nil, err
-	}
 
 	go provider.handleWebSocketMsgs(ctx)
 
@@ -438,7 +435,7 @@ func (p *KrakenProvider) ping() error {
 
 // subscribeTickerPairs write the subscription msg to the provider.
 func (p *KrakenProvider) subscribeTickerPairs(pairs ...string) error {
-	subsMsg := newKrakenSubscriptionMsg(pairs...)
+	subsMsg := newKrakenTickerSubscriptionMsg(pairs...)
 	return p.wsClient.WriteJSON(subsMsg)
 }
 
@@ -478,8 +475,8 @@ func (ticker KrakenTicker) toTickerPrice(symbol string) (TickerPrice, error) {
 	return newTickerPrice("Kraken", symbol, ticker.C[0], ticker.V[1])
 }
 
-// newKrakenSubscriptionMsg returns a new subscription Msg.
-func newKrakenSubscriptionMsg(pairs ...string) KrakenSubscriptionMsg {
+// newKrakenTickerSubscriptionMsg returns a new subscription Msg.
+func newKrakenTickerSubscriptionMsg(pairs ...string) KrakenSubscriptionMsg {
 	return KrakenSubscriptionMsg{
 		Event: "subscribe",
 		Pair:  pairs,

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -38,14 +38,14 @@ type (
 	}
 
 	// KrakenTicker ticker price response from Kraken ticker channel.
-	// https://docs.kraken.com/websockets/#message-ticker
+	// REF: https://docs.kraken.com/websockets/#message-ticker
 	KrakenTicker struct {
 		C []string `json:"c"` // Close with Price in the first position
 		V []string `json:"v"` // Volume with the value over last 24 hours in the second position
 	}
 
 	// KrakenCandle candle response from Kraken candle channel.
-	// REF : https://docs.kraken.com/websockets/#message-ohlc
+	// REF: https://docs.kraken.com/websockets/#message-ohlc
 	KrakenCandle struct {
 		Close     string // Close price during this period
 		TimeStamp int64  // Linux epoch timestamp
@@ -128,8 +128,7 @@ func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 	return tickerPrices, nil
 }
 
-// SubscribeTickers subscribe to all currency pairs and
-// add the new ones into the provider subscribed pairs.
+// SubscribeTickers subscribe all currency pairs into ticker and candle channels.
 func (p *KrakenProvider) SubscribeTickers(cps ...types.CurrencyPair) error {
 	pairs := make([]string, len(cps))
 
@@ -148,8 +147,8 @@ func (p *KrakenProvider) SubscribeTickers(cps ...types.CurrencyPair) error {
 	return nil
 }
 
-// handleWebSocketMsgs receive all the messages from the provider
-// and controls to reconnect the web socket.
+// handleWebSocketMsgs receive all the messages from the provider and controls the
+// reconnect function to the web socket.
 func (p *KrakenProvider) handleWebSocketMsgs(ctx context.Context) {
 	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
 	defer reconnectTicker.Stop()
@@ -161,7 +160,7 @@ func (p *KrakenProvider) handleWebSocketMsgs(ctx context.Context) {
 		case <-time.After(defaultReadNewWSMessage):
 			messageType, bz, err := p.wsClient.ReadMessage()
 			if err != nil {
-				// if some error occurs continue to try to read the next message
+				// if some error occurs continue to try to read the next message.
 				p.logger.Err(err).Msg("could not read message")
 				if err := p.ping(); err != nil {
 					p.logger.Err(err).Msg("failed to send ping")
@@ -193,7 +192,7 @@ func (p *KrakenProvider) messageReceived(messageType int, bz []byte) {
 
 	var krakenEvent KrakenEvent
 	if err := json.Unmarshal(bz, &krakenEvent); err != nil {
-		// msg is not an event, it will try to marshal to ticker message
+		// msg is not an event, it will try to marshal to ticker message.
 		p.logger.Debug().Msg("received a message that is not an event")
 	} else {
 		switch krakenEvent.Event {
@@ -207,7 +206,7 @@ func (p *KrakenProvider) messageReceived(messageType int, bz []byte) {
 	}
 
 	if err := p.messageReceivedTickerPrice(bz); err != nil {
-		// msg is not a ticker, it will try to marshal to candle message
+		// msg is not a ticker, it will try to marshal to candle message.
 		p.logger.Debug().Err(err).Msg("unable to unmarshal ticker")
 	} else {
 		return
@@ -400,7 +399,8 @@ func (p *KrakenProvider) messageReceivedSubscriptionStatus(bz []byte) {
 	}
 }
 
-// messageReceivedSystemStatus handle the system status and try to reconnect if it is not online.
+// messageReceivedSystemStatus handle the system status and try to reconnect if it
+// is not online.
 func (p *KrakenProvider) messageReceivedSystemStatus(bz []byte) {
 	var systemStatus KrakenEventSystemStatus
 	if err := json.Unmarshal(bz, &systemStatus); err != nil {
@@ -470,8 +470,8 @@ func (ticker KrakenTicker) toTickerPrice(symbol string) (TickerPrice, error) {
 	if len(ticker.C) != 2 || len(ticker.V) != 2 {
 		return TickerPrice{}, fmt.Errorf("error converting KrakenTicker to TickerPrice")
 	}
-	// ticker.C has the Price in the first position
-	// ticker.V has the totla	Value over last 24 hours in the second position
+	// ticker.C has the Price in the first position.
+	// ticker.V has the totla	Value over last 24 hours in the second position.
 	return newTickerPrice("Kraken", symbol, ticker.C[0], ticker.V[1])
 }
 
@@ -510,7 +510,7 @@ func currencyPairToKrakenPair(cp types.CurrencyPair) string {
 }
 
 // normalizeKrakenBTCPair changes XBT pairs to BTC,
-// since other providers list bitcoin as BTC
+// since other providers list bitcoin as BTC.
 func normalizeKrakenBTCPair(ticker string) string {
 	return strings.Replace(ticker, "XBT", "BTC", 1)
 }

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -79,7 +79,7 @@ func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.C
 	provider := &OkxProvider{
 		wsURL:           wsURL,
 		wsClient:        wsConn,
-		logger:          logger.With().Str("module", "oracle").Logger(),
+		logger:          logger.With().Str("provider", "okx").Logger(),
 		tickers:         map[string]OkxTickerPair{},
 		reconnectTimer:  time.NewTicker(okxPingCheck),
 		subscribedPairs: pairs,
@@ -130,9 +130,9 @@ func (p *OkxProvider) handleReceivedTickers(ctx context.Context) {
 			messageType, bz, err := p.wsClient.ReadMessage()
 			if err != nil {
 				// if some error occurs continue to try to read the next message
-				p.logger.Err(err).Msg("Okx provider could not read message")
+				p.logger.Err(err).Msg("could not read message")
 				if err := p.ping(); err != nil {
-					p.logger.Err(err).Msg("Okx provider could not send ping")
+					p.logger.Err(err).Msg("could not send ping")
 				}
 				continue
 			}
@@ -146,7 +146,7 @@ func (p *OkxProvider) handleReceivedTickers(ctx context.Context) {
 
 		case <-p.reconnectTimer.C: // reset by the pongHandler
 			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("Okx provider error reconnecting")
+				p.logger.Err(err).Msg("error reconnecting")
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func (p *OkxProvider) messageReceived(messageType int, bz []byte) {
 	var tickerResp OkxTickerResponse
 	if err := json.Unmarshal(bz, &tickerResp); err != nil {
 		// sometimes it returns other messages which are not tickerResponses
-		p.logger.Err(err).Msg("Okx provider could not unmarshal")
+		p.logger.Err(err).Msg("could not unmarshal")
 		return
 	}
 
@@ -203,7 +203,7 @@ func (p *OkxProvider) resetReconnectTimer() {
 func (p *OkxProvider) reconnect() error {
 	p.wsClient.Close()
 
-	p.logger.Debug().Msg("Okx reconnecting websocket")
+	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("error reconnecting to Okx websocket: %w", err)

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -104,9 +104,9 @@ func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.C
 		wsURL:           wsURL,
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "okx").Logger(),
+		reconnectTimer:  time.NewTicker(okxPingCheck),
 		tickers:         map[string]OkxTickerPair{},
 		candles:         map[string]OkxCandlePair{},
-		reconnectTimer:  time.NewTicker(okxPingCheck),
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 	provider.wsClient.SetPongHandler(provider.pongHandler)
@@ -292,7 +292,7 @@ func (p *OkxProvider) reconnect() error {
 	wsConn.SetPongHandler(p.pongHandler)
 	p.wsClient = wsConn
 
-	topics := make([]OkxSubscriptionTopic, len(p.subscribedPairs))
+	topics := make([]OkxSubscriptionTopic, len(p.subscribedPairs)*2)
 	iterator := 0
 	for _, cp := range p.subscribedPairs {
 		instId := currencyPairToOkxPair(cp)

--- a/price-feeder/oracle/provider/okx_test.go
+++ b/price-feeder/oracle/provider/okx_test.go
@@ -72,3 +72,9 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 		require.Nil(t, prices)
 	})
 }
+
+func TestOkxCurrencyPairToOkxPair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	okxSymbol := currencyPairToOkxPair(cp)
+	require.Equal(t, okxSymbol, "ATOM-USDT")
+}


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- Add SubscribeTickers function to the following providers: (Okx, Huobi, Kraken, Binance)
```go
// SubscribeTickers subscribe all currency pairs into ticker and candle channels.
func (p *provider) SubscribeTickers(cps ...types.CurrencyPair) error {
....
}
```

ref: [#181](https://github.com/umee-network/peggo/issues/181)

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
