### PR TITLE
fix: price-feeder: correct kraken timestamp unit

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -63,6 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#574](https://github.com/umee-network/umee/pull/574) Stop registering metrics endpoint if telemetry is disabled.
 - [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
 - [#607](https://github.com/umee-network/umee/pull/607) Fix kraken provider timestamp unit.
+
 ### Refactor
 
 - [#587](https://github.com/umee-network/umee/pull/587) Clean up logs from price feeder providers.

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -62,7 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#552](https://github.com/umee-network/umee/pull/552) Stop requiring telemetry during config validation.
 - [#574](https://github.com/umee-network/umee/pull/574) Stop registering metrics endpoint if telemetry is disabled.
 - [#573](https://github.com/umee-network/umee/pull/573) Strengthen CORS settings.
-
+- [#607](https://github.com/umee-network/umee/pull/607) Fix kraken provider timestamp unit.
 ### Refactor
 
 - [#587](https://github.com/umee-network/umee/pull/587) Clean up logs from price feeder providers.

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -268,7 +268,7 @@ func (p *HuobiProvider) setCandlePair(candle HuobiCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert huobi timestamp seconds -> milliseconds
-	candle.Tick.TimeStamp = candle.Tick.TimeStamp * int64(time.Millisecond)
+	candle.Tick.TimeStamp = candle.Tick.TimeStamp * int64(time.Second/time.Millisecond)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []HuobiCandle{}
 	candleList = append(candleList, candle)

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -267,7 +267,7 @@ func (p *HuobiProvider) setTickerPair(ticker HuobiTicker) {
 func (p *HuobiProvider) setCandlePair(candle HuobiCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	// huobi time period comes in seconds
+	// convert huobi timestamp seconds -> milliseconds
 	candle.Tick.TimeStamp = candle.Tick.TimeStamp * 1000
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []HuobiCandle{}

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -268,7 +268,7 @@ func (p *HuobiProvider) setCandlePair(candle HuobiCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert huobi timestamp seconds -> milliseconds
-	candle.Tick.TimeStamp = candle.Tick.TimeStamp * 1000
+	candle.Tick.TimeStamp = candle.Tick.TimeStamp * int64(time.Millisecond)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []HuobiCandle{}
 	candleList = append(candleList, candle)

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -482,6 +482,8 @@ func (p *KrakenProvider) setTickerPair(symbol string, ticker TickerPrice) {
 func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
+	// convert kraken timestamp seconds -> milliseconds
+	candle.TimeStamp = candle.TimeStamp * 1000
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []KrakenCandle{}
 

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -483,7 +483,7 @@ func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert kraken timestamp seconds -> milliseconds
-	candle.TimeStamp = candle.TimeStamp * int64(time.Millisecond)
+	candle.TimeStamp = candle.TimeStamp * int64(time.Second/time.Millisecond)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []KrakenCandle{}
 

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -483,7 +483,7 @@ func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert kraken timestamp seconds -> milliseconds
-	candle.TimeStamp = candle.TimeStamp * 1000
+	candle.TimeStamp = candle.TimeStamp * int64(time.Millisecond)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []KrakenCandle{}
 

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -89,5 +89,5 @@ func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64)
 // PastUnixTime returns a millisecond timestamp that represents the unix time
 // minus t.
 func PastUnixTime(t time.Duration) int64 {
-	return time.Now().Add(t*-1).Unix() * int64(time.Millisecond)
+	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
 }

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -89,5 +89,5 @@ func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64)
 // PastUnixTime returns a millisecond timestamp that represents the unix time
 // minus t.
 func PastUnixTime(t time.Duration) int64 {
-	return time.Now().Add(t*-1).Unix() * 1000
+	return time.Now().Add(t*-1).Unix() * int64(time.Millisecond)
 }


### PR DESCRIPTION
## Description

Kraken's candle timestamps come in as seconds, not milliseconds, so we need to convert it like we do with huobi. 

Fixes an issue where kraken's candle history was being shortened to the most recent one, making tvwap inaccurate. 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
