### PR TITLE
refactor: split subscribe ticker and candle channels

### DIFF
--- a/networks/umee-1/README.md
+++ b/networks/umee-1/README.md
@@ -8,7 +8,8 @@
 
 ## Snapshot Providers (Quick Sync)
 
-- https://snapshots.stake2.me/umee/
+- https://snapshots.stake2.me/umee
+- https://polkachu.com/tendermint_snapshots/umee
 
 ## Umee Archival Nodes
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -67,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Refactor
 
 - [#587](https://github.com/umee-network/umee/pull/587) Clean up logs from price feeder providers.
+- [#610](https://github.com/umee-network/umee/pull/610) Split subscribtion of ticker and candle channels.
 
 ## [v0.1.0](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.0) - 2022-02-07
 

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -178,14 +178,7 @@ func (p *BinanceProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	currencyPairs := make([]types.CurrencyPair, len(p.subscribedPairs))
-	iterator := 0
-	for _, cp := range p.subscribedPairs {
-		currencyPairs[iterator] = cp
-		iterator++
-	}
-
-	return currencyPairs
+	return subscribedPairsToSlice(p.subscribedPairs)
 }
 
 func (p *BinanceProvider) getTickerPrice(key string) (TickerPrice, error) {

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -132,7 +132,7 @@ func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[stri
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
+// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
 func (p *BinanceProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
@@ -178,7 +178,7 @@ func (p *BinanceProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	return subscribedPairsToSlice(p.subscribedPairs)
+	return mapPairsToSlice(p.subscribedPairs)
 }
 
 func (p *BinanceProvider) getTickerPrice(key string) (TickerPrice, error) {

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -98,7 +98,7 @@ func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, pairs ...types
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeCurrencyPais(pairs...); err != nil {
+	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
 		return nil, err
 	}
 
@@ -137,8 +137,8 @@ func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
-func (p *HuobiProvider) SubscribeCurrencyPais(cps ...types.CurrencyPair) error {
+// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
+func (p *HuobiProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (p *HuobiProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	return subscribedPairsToSlice(p.subscribedPairs)
+	return mapPairsToSlice(p.subscribedPairs)
 }
 
 func (p *HuobiProvider) handleWebSocketMsgs(ctx context.Context) {

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -98,7 +98,7 @@ func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, pairs ...types
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeTickers(pairs...); err != nil {
+	if err := provider.SubscribeCurrencyPais(pairs...); err != nil {
 		return nil, err
 	}
 
@@ -137,19 +137,60 @@ func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string
 	return candlePrices, nil
 }
 
-// SubscribeTickers subscribe all currency pairs into ticker and candle channels.
-func (p *HuobiProvider) SubscribeTickers(cps ...types.CurrencyPair) error {
+// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
+func (p *HuobiProvider) SubscribeCurrencyPais(cps ...types.CurrencyPair) error {
+	if err := p.subscribeChannels(cps...); err != nil {
+		return err
+	}
+
+	p.setSubscribedPairs(cps...)
+	return nil
+}
+
+// subscribeChannels subscribe all currency pairs into ticker and candle channels.
+func (p *HuobiProvider) subscribeChannels(cps ...types.CurrencyPair) error {
+	if err := p.subscribeTickers(cps...); err != nil {
+		return err
+	}
+
+	return p.subscribeCandles(cps...)
+}
+
+// subscribeTickers subscribe all currency pairs into ticker channel.
+func (p *HuobiProvider) subscribeTickers(cps ...types.CurrencyPair) error {
 	for _, cp := range cps {
 		if err := p.subscribeTickerPair(cp); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// subscribeCandles subscribe all currency pairs into candle channel.
+func (p *HuobiProvider) subscribeCandles(cps ...types.CurrencyPair) error {
+	for _, cp := range cps {
 		if err := p.subscribeCandlePair(cp); err != nil {
 			return err
 		}
 	}
 
-	p.setSubscribedPairs(cps...)
 	return nil
+}
+
+// subscribedPairsToSlice returns the map of subscribed pairs as slice
+func (p *HuobiProvider) subscribedPairsToSlice() []types.CurrencyPair {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	currencyPairs := make([]types.CurrencyPair, len(p.subscribedPairs))
+	iterator := 0
+	for _, cp := range p.subscribedPairs {
+		currencyPairs[iterator] = cp
+		iterator++
+	}
+
+	return currencyPairs
 }
 
 func (p *HuobiProvider) handleWebSocketMsgs(ctx context.Context) {
@@ -292,16 +333,8 @@ func (p *HuobiProvider) reconnect() error {
 	}
 	p.wsClient = wsConn
 
-	for _, cp := range p.subscribedPairs {
-		if err := p.subscribeTickerPair(cp); err != nil {
-			return err
-		}
-		if err := p.subscribeCandlePair(cp); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	currencyPairs := p.subscribedPairsToSlice()
+	return p.subscribeChannels(currencyPairs...)
 }
 
 // subscribeTickerPair write the subscription ticker msg to the provider.

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -183,14 +183,7 @@ func (p *HuobiProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	currencyPairs := make([]types.CurrencyPair, len(p.subscribedPairs))
-	iterator := 0
-	for _, cp := range p.subscribedPairs {
-		currencyPairs[iterator] = cp
-		iterator++
-	}
-
-	return currencyPairs
+	return subscribedPairsToSlice(p.subscribedPairs)
 }
 
 func (p *HuobiProvider) handleWebSocketMsgs(ctx context.Context) {

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -105,7 +105,7 @@ func NewKrakenProvider(ctx context.Context, logger zerolog.Logger, pairs ...type
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeCurrencyPais(pairs...); err != nil {
+	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
 		return nil, err
 	}
 
@@ -149,8 +149,8 @@ func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
-func (p *KrakenProvider) SubscribeCurrencyPais(cps ...types.CurrencyPair) error {
+// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
+func (p *KrakenProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (p *KrakenProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	return subscribedPairsToSlice(p.subscribedPairs)
+	return mapPairsToSlice(p.subscribedPairs)
 }
 
 func (candle KrakenCandle) toCandlePrice() (CandlePrice, error) {

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -109,7 +109,7 @@ func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.C
 	}
 	provider.wsClient.SetPongHandler(provider.pongHandler)
 
-	if err := provider.SubscribeTickers(pairs...); err != nil {
+	if err := provider.SubscribeCurrencyPais(pairs...); err != nil {
 		return nil, err
 	}
 
@@ -150,25 +150,53 @@ func (p *OkxProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][
 	return candlePrices, nil
 }
 
-// SubscribeTickers subscribe all currency pairs into ticker and candle channels.
-func (p *OkxProvider) SubscribeTickers(cps ...types.CurrencyPair) error {
-	topics := make([]OkxSubscriptionTopic, len(cps)*2)
-
-	iterator := 0
-	for _, cp := range cps {
-		instId := currencyPairToOkxPair(cp)
-		topics[iterator] = newOkxSubscriptionTopic(instId)
-		iterator++
-		topics[iterator] = newOkxCandleSubscriptionTopic(instId)
-		iterator++
-	}
-
-	if err := p.subscribePairs(topics...); err != nil {
+// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
+func (p *OkxProvider) SubscribeCurrencyPais(cps ...types.CurrencyPair) error {
+	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}
 
 	p.setSubscribedPairs(cps...)
 	return nil
+}
+
+// subscribeChannels subscribe all currency pairs into ticker and candle channels.
+func (p *OkxProvider) subscribeChannels(cps ...types.CurrencyPair) error {
+	if err := p.subscribeTickers(cps...); err != nil {
+		return err
+	}
+
+	return p.subscribeCandles(cps...)
+}
+
+// subscribeTickers subscribe all currency pairs into ticker channel.
+func (p *OkxProvider) subscribeTickers(cps ...types.CurrencyPair) error {
+	topics := make([]OkxSubscriptionTopic, len(cps))
+
+	for i, cp := range cps {
+		topics[i] = newOkxTickerSubscriptionTopic(currencyPairToOkxPair(cp))
+	}
+
+	return p.subscribePairs(topics...)
+}
+
+// subscribeCandles subscribe all currency pairs into candle channel.
+func (p *OkxProvider) subscribeCandles(cps ...types.CurrencyPair) error {
+	topics := make([]OkxSubscriptionTopic, len(cps))
+
+	for i, cp := range cps {
+		topics[i] = newOkxCandleSubscriptionTopic(currencyPairToOkxPair(cp))
+	}
+
+	return p.subscribePairs(topics...)
+}
+
+// subscribedPairsToSlice returns the map of subscribed pairs as slice
+func (p *OkxProvider) subscribedPairsToSlice() []types.CurrencyPair {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	return subscribedPairsToSlice(p.subscribedPairs)
 }
 
 func (p *OkxProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
@@ -342,17 +370,8 @@ func (p *OkxProvider) reconnect() error {
 	wsConn.SetPongHandler(p.pongHandler)
 	p.wsClient = wsConn
 
-	topics := make([]OkxSubscriptionTopic, len(p.subscribedPairs)*2)
-	iterator := 0
-	for _, cp := range p.subscribedPairs {
-		instId := currencyPairToOkxPair(cp)
-		topics[iterator] = newOkxSubscriptionTopic(instId)
-		iterator++
-		topics[iterator] = newOkxCandleSubscriptionTopic(instId)
-		iterator++
-	}
-
-	return p.subscribePairs(topics...)
+	currencyPairs := p.subscribedPairsToSlice()
+	return p.subscribeChannels(currencyPairs...)
 }
 
 // ping to check websocket connection.
@@ -379,8 +398,8 @@ func currencyPairToOkxPair(pair types.CurrencyPair) string {
 	return pair.Base + "-" + pair.Quote
 }
 
-// newOkxSubscriptionTopic returns a new subscription topic.
-func newOkxSubscriptionTopic(instId string) OkxSubscriptionTopic {
+// newOkxTickerSubscriptionTopic returns a new subscription topic.
+func newOkxTickerSubscriptionTopic(instId string) OkxSubscriptionTopic {
 	return OkxSubscriptionTopic{
 		Channel: "tickers",
 		InstId:  instId,

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -109,7 +109,7 @@ func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.C
 	}
 	provider.wsClient.SetPongHandler(provider.pongHandler)
 
-	if err := provider.SubscribeCurrencyPais(pairs...); err != nil {
+	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
 		return nil, err
 	}
 
@@ -150,8 +150,8 @@ func (p *OkxProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPais subscribe all currency pairs into ticker and candle channels.
-func (p *OkxProvider) SubscribeCurrencyPais(cps ...types.CurrencyPair) error {
+// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
+func (p *OkxProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (p *OkxProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	return subscribedPairsToSlice(p.subscribedPairs)
+	return mapPairsToSlice(p.subscribedPairs)
 }
 
 func (p *OkxProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -92,11 +92,11 @@ func PastUnixTime(t time.Duration) int64 {
 	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
 }
 
-// subscribedPairsToSlice returns the map of subscribed pairs as slice
-func subscribedPairsToSlice(subscribedPairs map[string]types.CurrencyPair) []types.CurrencyPair {
+// mapPairsToSlice returns the map of currency pairs as slice.
+func mapPairsToSlice(mapPairs map[string]types.CurrencyPair) []types.CurrencyPair {
 	var currencyPairs []types.CurrencyPair
-	
-	for _, cp := range subscribedPairs {
+
+	for _, cp := range mapPairs {
 		currencyPairs = append(currencyPairs, cp)
 	}
 

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -91,3 +91,16 @@ func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64)
 func PastUnixTime(t time.Duration) int64 {
 	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
 }
+
+// subscribedPairsToSlice returns the map of subscribed pairs as slice
+func subscribedPairsToSlice(subscribedPairs map[string]types.CurrencyPair) []types.CurrencyPair {
+	currencyPairs := make([]types.CurrencyPair, len(subscribedPairs))
+
+	iterator := 0
+	for _, cp := range subscribedPairs {
+		currencyPairs[iterator] = cp
+		iterator++
+	}
+
+	return currencyPairs
+}

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -94,7 +94,7 @@ func PastUnixTime(t time.Duration) int64 {
 
 // mapPairsToSlice returns the map of currency pairs as slice.
 func mapPairsToSlice(mapPairs map[string]types.CurrencyPair) []types.CurrencyPair {
-	var currencyPairs []types.CurrencyPair
+	currencyPairs := make([]types.CurrencyPair, len(mapPairs))
 
 	for _, cp := range mapPairs {
 		currencyPairs = append(currencyPairs, cp)

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -96,8 +96,10 @@ func PastUnixTime(t time.Duration) int64 {
 func mapPairsToSlice(mapPairs map[string]types.CurrencyPair) []types.CurrencyPair {
 	currencyPairs := make([]types.CurrencyPair, len(mapPairs))
 
+	iterator := 0
 	for _, cp := range mapPairs {
-		currencyPairs = append(currencyPairs, cp)
+		currencyPairs[iterator] = cp
+		iterator++
 	}
 
 	return currencyPairs


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
- Split subscription of ticker and candle channels for the following providers: Okx, Binance, Huobi, and Kraken
- Add error check for `websocket.CloseAbnormalClosure` to Kraken when EOF occurs to avoid having the following 
![image](https://user-images.githubusercontent.com/17556614/156950343-7c92ccfc-b2c0-4185-96c4-9da4dc3f35ae.png)

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
