### PR TITLE
chore: Remove beta + performance improvements to build (packer imaging)

### DIFF
--- a/infra/packer/Dockerfile.build
+++ b/infra/packer/Dockerfile.build
@@ -14,7 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Install go 
-RUN curl -sL https://go.dev/dl/go1.17.5.linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local -xz
+RUN curl -sL https://go.dev/dl/go1.17.8.linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local -xz
 
 # Copy Umee source in
 WORKDIR /tmp/build/umee
@@ -26,17 +26,6 @@ COPY tests/ tests/
 COPY x/ x/
 
 # Build umeed
-RUN make build
-
-# Clone/Build price-feeder
-WORKDIR /tmp/build/price-feeder
-RUN git clone https://github.com/umee-network/umee.git --branch price-feeder/v0.1.2 --single-branch --depth 1 .
-WORKDIR /tmp/build/price-feeder/price-feeder
-RUN make build
-
-# Clone/Build Peggo
-WORKDIR /tmp/build/peggo
-RUN git clone https://github.com/umee-network/peggo.git --branch v0.2.6 --single-branch --depth 1 .
 RUN make build
 
 WORKDIR /root

--- a/infra/packer/Dockerfile.build
+++ b/infra/packer/Dockerfile.build
@@ -25,9 +25,6 @@ COPY cmd/ cmd/
 COPY tests/ tests/
 COPY x/ x/
 
-# Build umeed beta
-RUN UMEE_ENABLE_BETA=true make build
-RUN mv build/umeed build/umeed-beta
 # Build umeed
 RUN make build
 

--- a/infra/packer/bin/build-dist
+++ b/infra/packer/bin/build-dist
@@ -7,7 +7,5 @@ docker build -t $TAG -f Dockerfile.build ../../
 CONTAINER=`docker create $TAG`
 
 docker cp "$CONTAINER:/tmp/build/umee/build/umeed" dist/x86_64/
-docker cp "$CONTAINER:/tmp/build/price-feeder/price-feeder/build/price-feeder" dist/x86_64/
-docker cp "$CONTAINER:/tmp/build/peggo/build/peggo" dist/x86_64/
 
 docker rm -v "$CONTAINER"

--- a/infra/packer/bin/build-dist
+++ b/infra/packer/bin/build-dist
@@ -6,7 +6,6 @@ TAG=umee-build-6ywm7fcu
 docker build -t $TAG -f Dockerfile.build ../../
 CONTAINER=`docker create $TAG`
 
-docker cp "$CONTAINER:/tmp/build/umee/build/umeed-beta" dist/x86_64/
 docker cp "$CONTAINER:/tmp/build/umee/build/umeed" dist/x86_64/
 docker cp "$CONTAINER:/tmp/build/price-feeder/price-feeder/build/price-feeder" dist/x86_64/
 docker cp "$CONTAINER:/tmp/build/peggo/build/peggo" dist/x86_64/

--- a/infra/packer/umee-node-dist.pkr.hcl
+++ b/infra/packer/umee-node-dist.pkr.hcl
@@ -57,6 +57,10 @@ build {
       , "curl -sLf https://github.com/informalsystems/ibc-rs/releases/download/v0.12.0/hermes-v0.12.0-x86_64-unknown-linux-gnu.tar.gz | tar -C /usr/local/bin -xz"
       , "curl -sLf https://github.com/cosmos/gaia/releases/download/v6.0.3/gaiad-v6.0.3-linux-amd64 -o /usr/local/bin/gaiad"
       , "chmod a+x /usr/local/bin/gaiad"
+      , "cd /tmp && curl -sLqf https://github.com/umee-network/umee/releases/download/price-feeder/v0.1.2/price-feeder-v0.1.2-linux-amd64.tar.gz | tar --strip-components 1 -xz"
+      , "cp /tmp/price-feeder /usr/local/bin/"
+      , "cd /tmp && curl -sLqf https://github.com/umee-network/peggo/releases/download/v0.2.6/peggo-v0.2.6-linux-amd64.tar.gz | tar --strip-components 1 -xz"
+      , "cp /tmp/peggo /usr/local/bin/"
     ]
   }
 


### PR DESCRIPTION
# Remove Beta + performance improvements to build

## Packer Image Building Changes
* Remove Beta Build from Image
* Use binary release build for peggo instead of building ourselves
* Use binary release build for price-feeder instead of building ourselves

## Dependency Changes
* Upgrade Golang from `1.17.5` -> `1.17.8`