### PR TITLE
fix: Oracle price feeders add verification of empty subscribed pairs

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -51,7 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-- [#675](https://github.com/umee-network/umee/pull/675) Add verification for subscribe currency pairs with empty parameter.
+- [#675](https://github.com/umee-network/umee/pull/675) Add necessary input validation to SubscribePairs in the price feeder.
 
 ## [v0.1.3](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.3) - 2022-03-21
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - [#607](https://github.com/umee-network/umee/pull/607) Fix kraken provider timestamp unit.
+- [#675](https://github.com/umee-network/umee/pull/675) Add verification for subscribe currency pairs with empty parameter.
 
 ### Refactor
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -49,6 +49,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [#648](https://github.com/umee-network/umee/pull/648) Add Coinbase as a provider.
 
+### Bug Fixes
+
+- [#675](https://github.com/umee-network/umee/pull/675) Add verification for subscribe currency pairs with empty parameter.
+
 ## [v0.1.3](https://github.com/umee-network/umee/releases/tag/price-feeder%2Fv0.1.3) - 2022-03-21
 
 ### Features
@@ -66,7 +70,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - [#607](https://github.com/umee-network/umee/pull/607) Fix kraken provider timestamp unit.
-- [#675](https://github.com/umee-network/umee/pull/675) Add verification for subscribe currency pairs with empty parameter.
 
 ### Refactor
 

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -142,6 +142,10 @@ func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[stri
 
 // SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
 func (p *BinanceProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -73,6 +73,16 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestBinanceProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestBinanceCurrencyPairToBinancePair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	binanceSymbol := currencyPairToBinanceTickerPair(cp)

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -207,9 +207,14 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 
 // SubscribeCurrencyPairs subscribes to websockets for all currency pairs.
 func (p *CoinbaseProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribe(cps...); err != nil {
 		return err
 	}
+
 	p.setSubscribedPairs(cps...)
 	return nil
 }

--- a/price-feeder/oracle/provider/coinbase_test.go
+++ b/price-feeder/oracle/provider/coinbase_test.go
@@ -70,6 +70,16 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestCoinbaseProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewCoinbaseProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestCoinbasePairToCurrencyPair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	currencyPairSymbol := coinbasePairToCurrencyPair("ATOM-USDT")

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -190,6 +190,10 @@ func (p *GateProvider) getCandlePrices(key string) ([]CandlePrice, error) {
 
 // SubscribeCurrencyPairs subscribe to ticker and candle channels for all pairs.
 func (p *GateProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribeTickers(cps...); err != nil {
 		return err
 	}

--- a/price-feeder/oracle/provider/gate_test.go
+++ b/price-feeder/oracle/provider/gate_test.go
@@ -73,6 +73,16 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestGateProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewGateProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestGateCurrencyPairToGatePair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	GateSymbol := currencyPairToGatePair(cp)

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -152,6 +152,10 @@ func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string
 
 // SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
 func (p *HuobiProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}

--- a/price-feeder/oracle/provider/huobi_test.go
+++ b/price-feeder/oracle/provider/huobi_test.go
@@ -80,6 +80,16 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestHuobiProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewHuobiProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestHuobiCurrencyPairToHuobiPair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	binanceSymbol := currencyPairToHuobiTickerPair(cp)

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -163,6 +163,10 @@ func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 
 // SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
 func (p *KrakenProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}

--- a/price-feeder/oracle/provider/kraken_test.go
+++ b/price-feeder/oracle/provider/kraken_test.go
@@ -70,6 +70,16 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestKrakenProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewKrakenProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestKrakenPairToCurrencyPairSymbol(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	currencyPairSymbol := krakenPairToCurrencyPairSymbol("ATOM/USDT")

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -165,6 +165,10 @@ func (p *OkxProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][
 
 // SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
 func (p *OkxProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
 	if err := p.subscribeChannels(cps...); err != nil {
 		return err
 	}

--- a/price-feeder/oracle/provider/okx_test.go
+++ b/price-feeder/oracle/provider/okx_test.go
@@ -79,6 +79,16 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
+func TestOkxProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewOkxProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
 func TestOkxCurrencyPairToOkxPair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	okxSymbol := currencyPairToOkxPair(cp)


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
- Add verification and tests for `SubscribedPairs` with empty parameters

closes: #672 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
