### PR TITLE
chore: Upgrade dependencies in built packer images

### DIFF
--- a/infra/packer/Dockerfile.build
+++ b/infra/packer/Dockerfile.build
@@ -14,7 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Install go 
-RUN curl -sL https://go.dev/dl/go1.17.8.linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local -xz
+RUN curl -sL https://go.dev/dl/go1.18.linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local -xz
 
 # Copy Umee source in
 WORKDIR /tmp/build/umee

--- a/infra/packer/umee-node-dist.pkr.hcl
+++ b/infra/packer/umee-node-dist.pkr.hcl
@@ -63,9 +63,9 @@ build {
       , "chmod a+x /usr/local/bin/osmosisd"
       , "curl -sLf https://github.com/CosmosContracts/juno/releases/download/v2.1.0/junod -o /usr/local/bin/junod"
       , "chmod a+x /usr/local/bin/junod"
-      , "cd /tmp && curl -sLqf https://github.com/umee-network/umee/releases/download/price-feeder/v0.1.2/price-feeder-v0.1.2-linux-amd64.tar.gz | tar --strip-components 1 -xz"
+      , "cd /tmp && curl -sLqf https://github.com/umee-network/umee/releases/download/price-feeder/v0.1.4/price-feeder-v0.1.4-linux-amd64.tar.gz | tar --strip-components 1 -xz"
       , "cp /tmp/price-feeder /usr/local/bin/"
-      , "cd /tmp && curl -sLqf https://github.com/umee-network/peggo/releases/download/v0.2.6/peggo-v0.2.6-linux-amd64.tar.gz | tar --strip-components 1 -xz"
+      , "cd /tmp && curl -sLqf https://github.com/umee-network/peggo/releases/download/v0.2.7/peggo-v0.2.7-linux-amd64.tar.gz | tar --strip-components 1 -xz"
       , "cp /tmp/peggo /usr/local/bin/"
     ]
   }


### PR DESCRIPTION
# Upgrade dependencies in images
* Golang (used to build umee) `0.17.8 -> 0.18`
* Price Feeder `0.1.2 -> 0.1.4`
* Peggo `0.2.6 -> 0.2.7`