### PR TITLE
chore: add empty request test to oracle grpc

### DIFF
--- a/x/oracle/keeper/grpc_query_test.go
+++ b/x/oracle/keeper/grpc_query_test.go
@@ -3,11 +3,14 @@ package keeper_test
 import (
 	"context"
 	"math/rand"
+	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 
 	umeeapp "github.com/umee-network/umee/v2/app"
+	"github.com/umee-network/umee/v2/x/oracle/keeper"
 	"github.com/umee-network/umee/v2/x/oracle/types"
 )
 
@@ -141,4 +144,41 @@ func (s *IntegrationTestSuite) TestQuerier_Params() {
 	res, err := s.queryClient.Params(context.Background(), &types.QueryParamsRequest{})
 	s.Require().NoError(err)
 	s.Require().Equal(types.DefaultGenesisState().Params, res.Params)
+}
+
+func TestEmptyRequest(t *testing.T) {
+	q := keeper.NewQuerier(keeper.Keeper{})
+	emptyRequestErrorMsg := "empty request"
+
+	resParams, err := q.Params(context.Background(), nil)
+	require.Nil(t, resParams)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resExchangeRate, err := q.ExchangeRates(context.Background(), nil)
+	require.Nil(t, resExchangeRate)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resActiveExchangeRates, err := q.ActiveExchangeRates(context.Background(), nil)
+	require.Nil(t, resActiveExchangeRates)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resFeederDelegation, err := q.FeederDelegation(context.Background(), nil)
+	require.Nil(t, resFeederDelegation)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resMissCounter, err := q.MissCounter(context.Background(), nil)
+	require.Nil(t, resMissCounter)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resAggregatePrevote, err := q.AggregatePrevote(context.Background(), nil)
+	require.Nil(t, resAggregatePrevote)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resAggregateVote, err := q.AggregateVote(context.Background(), nil)
+	require.Nil(t, resAggregateVote)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
+
+	resAggregateVotes, err := q.AggregateVotes(context.Background(), nil)
+	require.Nil(t, resAggregateVotes)
+	require.ErrorContains(t, err, emptyRequestErrorMsg)
 }


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- Add unit test cover to `x/oracle/keeper/grpc_query.go`

helps: #661

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
