### PR TITLE
chore: format once with gofumpt

### DIFF
--- a/ante/ante_test.go
+++ b/ante/ante_test.go
@@ -46,7 +46,7 @@ func (s *IntegrationTestSuite) SetupTest() {
 }
 
 // CreateTestTx is a helper function to create a tx given multiple inputs.
-func (suite *IntegrationTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums []uint64, accSeqs []uint64, chainID string) (xauthsigning.Tx, error) {
+func (suite *IntegrationTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums, accSeqs []uint64, chainID string) (xauthsigning.Tx, error) {
 	var sigsV2 []signing.SignatureV2
 	for i, priv := range privs {
 		sigV2 := signing.SignatureV2{

--- a/app/export.go
+++ b/app/export.go
@@ -18,7 +18,6 @@ func (app *UmeeApp) ExportAppStateAndValidators(
 	forZeroHeight bool,
 	jailAllowedAddrs []string,
 ) (servertypes.ExportedApp, error) {
-
 	// as if they could withdraw from the start of the next block
 	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 

--- a/app/modules.go
+++ b/app/modules.go
@@ -146,7 +146,6 @@ func (GenutilModule) ValidateGenesis(
 	encCfg client.TxEncodingConfig,
 	bz json.RawMessage,
 ) error {
-
 	var genState genutiltypes.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", genutiltypes.ModuleName, err)

--- a/cmd/umeed/cmd/app_creator.go
+++ b/cmd/umeed/cmd/app_creator.go
@@ -33,7 +33,6 @@ func (ac appCreator) newApp(
 	traceStore io.Writer,
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
-
 	var cache sdk.MultiStorePersistentCache
 
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
@@ -99,7 +98,6 @@ func (ac appCreator) appExport(
 	jailAllowedAddrs []string,
 	appOpts servertypes.AppOptions,
 ) (servertypes.ExportedApp, error) {
-
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {
 		return servertypes.ExportedApp{}, errors.New("application home is not set")

--- a/price-feeder/oracle/client/client.go
+++ b/price-feeder/oracle/client/client.go
@@ -109,7 +109,7 @@ func (r *passReader) Read(p []byte) (n int, err error) {
 // BroadcastTx attempts to broadcast a signed transaction. If it fails, a few re-attempts
 // will be made until the transaction succeeds or ultimately times out or fails.
 // Ref: https://github.com/terra-money/oracle-feeder/blob/baef2a4a02f57a2ffeaa207932b2e03d7fb0fb25/feeder/src/vote.ts#L230
-func (oc OracleClient) BroadcastTx(nextBlockHeight int64, timeoutHeight int64, msgs ...sdk.Msg) error {
+func (oc OracleClient) BroadcastTx(nextBlockHeight, timeoutHeight int64, msgs ...sdk.Msg) error {
 	maxBlockHeight := nextBlockHeight + timeoutHeight
 	lastCheckHeight := nextBlockHeight - 1
 

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -9,9 +9,7 @@ import (
 	"github.com/umee-network/umee/price-feeder/oracle/provider"
 )
 
-var (
-	minimumTimeWeight = sdk.MustNewDecFromStr("0.2")
-)
+var minimumTimeWeight = sdk.MustNewDecFromStr("0.2")
 
 const (
 	// tvwapCandlePeriod represents the time period we use for tvwap in minutes

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -17,7 +17,7 @@ const (
 )
 
 // compute VWAP for each base by dividing the Σ {P * V} by Σ {V}
-func vwap(weightedPrices map[string]sdk.Dec, volumeSum map[string]sdk.Dec) (map[string]sdk.Dec, error) {
+func vwap(weightedPrices, volumeSum map[string]sdk.Dec) (map[string]sdk.Dec, error) {
 	vwap := make(map[string]sdk.Dec)
 
 	for base, p := range weightedPrices {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -428,7 +428,6 @@ func (s *IntegrationTestSuite) runGanacheContainer() {
 	// Wait for Ganache to start running.
 	s.Require().Eventually(
 		func() bool {
-
 			err := s.dkrPool.Client.Logs(
 				docker.LogsOptions{
 					Container:    s.ethResource.Container.ID,
@@ -585,7 +584,7 @@ func (s *IntegrationTestSuite) runGaiaNetwork() {
 	gaiaVal := s.chain.gaiaValidators[0]
 
 	gaiaCfgPath := path.Join(tmpDir, "cfg")
-	s.Require().NoError(os.MkdirAll(gaiaCfgPath, 0755))
+	s.Require().NoError(os.MkdirAll(gaiaCfgPath, 0o755))
 
 	_, err = copyFile(
 		filepath.Join("./scripts/", "gaia_bootstrap.sh"),
@@ -662,7 +661,7 @@ func (s *IntegrationTestSuite) runIBCRelayer() {
 	umeeVal := s.chain.validators[0]
 	hermesCfgPath := path.Join(tmpDir, "hermes")
 
-	s.Require().NoError(os.MkdirAll(hermesCfgPath, 0755))
+	s.Require().NoError(os.MkdirAll(hermesCfgPath, 0o755))
 	_, err = copyFile(
 		filepath.Join("./scripts/", "hermes_bootstrap.sh"),
 		filepath.Join(hermesCfgPath, "hermes_bootstrap.sh"),
@@ -922,7 +921,7 @@ func (s *IntegrationTestSuite) runPriceFeeder() {
 
 	priceFeederCfgPath := path.Join(tmpDir, "price-feeder")
 
-	s.Require().NoError(os.MkdirAll(priceFeederCfgPath, 0755))
+	s.Require().NoError(os.MkdirAll(priceFeederCfgPath, 0o755))
 	_, err = copyFile(
 		filepath.Join("./scripts/", "price_feeder_bootstrap.sh"),
 		filepath.Join(priceFeederCfgPath, "price_feeder_bootstrap.sh"),

--- a/tests/e2e/io.go
+++ b/tests/e2e/io.go
@@ -39,5 +39,5 @@ func writeFile(path string, body []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, body, 0600)
+	return ioutil.WriteFile(path, body, 0o600)
 }

--- a/tests/e2e/validator.go
+++ b/tests/e2e/validator.go
@@ -50,7 +50,7 @@ func (v *validator) configDir() string {
 
 func (v *validator) createConfig() error {
 	p := path.Join(v.configDir(), "config")
-	return os.MkdirAll(p, 0755)
+	return os.MkdirAll(p, 0o755)
 }
 
 func (v *validator) init() error {
@@ -110,12 +110,12 @@ func (v *validator) createConsensusKey() error {
 	config.Moniker = v.moniker
 
 	pvKeyFile := config.PrivValidatorKeyFile()
-	if err := tmos.EnsureDir(filepath.Dir(pvKeyFile), 0777); err != nil {
+	if err := tmos.EnsureDir(filepath.Dir(pvKeyFile), 0o777); err != nil {
 		return err
 	}
 
 	pvStateFile := config.PrivValidatorStateFile()
-	if err := tmos.EnsureDir(filepath.Dir(pvStateFile), 0777); err != nil {
+	if err := tmos.EnsureDir(filepath.Dir(pvStateFile), 0o777); err != nil {
 		return err
 	}
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // This file uses the recommended method for tracking developer tools in a Go

--- a/x/ibctransfer/keeper/keeper.go
+++ b/x/ibctransfer/keeper/keeper.go
@@ -42,7 +42,6 @@ func (k Keeper) SendTransfer(
 	timeoutHeight clienttypes.Height,
 	timeoutTimestamp uint64,
 ) error {
-
 	// first, relay the SendTransfer to the real (embedded) ICS-20 transfer keeper
 	if err := k.Keeper.SendTransfer(
 		ctx,
@@ -86,7 +85,6 @@ func (k Keeper) OnRecvPacket(
 	packet channeltypes.Packet,
 	data ibctransfertypes.FungibleTokenPacketData,
 ) error {
-
 	if err := k.Keeper.OnRecvPacket(ctx, packet, data); err != nil {
 		return err
 	}
@@ -105,7 +103,6 @@ func (k Keeper) PostOnRecvPacket(
 	packet channeltypes.Packet,
 	data ibctransfertypes.FungibleTokenPacketData,
 ) {
-
 	var denomTrace ibctransfertypes.DenomTrace
 
 	if ibctransfertypes.ReceiverChainIsSource(packet.GetSourcePort(), packet.GetSourceChannel(), data.Denom) {

--- a/x/ibctransfer/module.go
+++ b/x/ibctransfer/module.go
@@ -33,7 +33,6 @@ func (am AppModule) OnRecvPacket(
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) ibcexported.Acknowledgement {
-
 	ack := am.AppModule.OnRecvPacket(ctx, packet, relayer)
 	if ack.Success() {
 		var data ibctransfertypes.FungibleTokenPacketData

--- a/x/leverage/client/cli/proposal_test.go
+++ b/x/leverage/client/cli/proposal_test.go
@@ -20,7 +20,7 @@ func TestParseUpdateRegistryProposal(t *testing.T) {
 	bz := []byte(`
 		foo
 	`)
-	os.WriteFile(filePath, bz, 0644)
+	os.WriteFile(filePath, bz, 0o644)
 
 	_, err := cli.ParseUpdateRegistryProposal(encCfg.Marshaler, filePath)
 	require.Error(t, err)
@@ -44,7 +44,7 @@ func TestParseUpdateRegistryProposal(t *testing.T) {
 		}
 	]
 }`)
-	os.WriteFile(filePath, bz, 0644)
+	os.WriteFile(filePath, bz, 0o644)
 
 	_, err = cli.ParseUpdateRegistryProposal(encCfg.Marshaler, filePath)
 	require.NoError(t, err)

--- a/x/leverage/client/tests/util.go
+++ b/x/leverage/client/tests/util.go
@@ -38,7 +38,7 @@ func (s *IntegrationTestSuite) UpdateRegistry(
 
 	bz, err := clientCtx.Codec.MarshalJSON(content)
 	s.Require().NoError(err)
-	s.Require().NoError(ioutil.WriteFile(path, bz, 0600))
+	s.Require().NoError(ioutil.WriteFile(path, bz, 0o600))
 
 	cmd := cli.NewCmdSubmitUpdateRegistryProposal()
 	flags.AddTxFlagsToCmd(cmd) // add flags manually since the gov workflow adds them automatically

--- a/x/leverage/keeper/invariants.go
+++ b/x/leverage/keeper/invariants.go
@@ -89,7 +89,6 @@ func ReserveAmountInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through the reserve amount %+v\n", err)
 		}
@@ -134,7 +133,6 @@ func CollateralAmountInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through the collateral amount %+v\n", err)
 		}
@@ -179,7 +177,6 @@ func BorrowAmountInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through adjusted borrow amounts %+v\n", err)
 		}
@@ -216,7 +213,6 @@ func BorrowAPYInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through the borrow APY %+v\n", err)
 		}
@@ -253,7 +249,6 @@ func LendAPYInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through the lend APY %+v\n", err)
 		}
@@ -290,7 +285,6 @@ func InterestScalarsInvariant(k Keeper) sdk.Invariant {
 			}
 			return nil
 		})
-
 		if err != nil {
 			msg += fmt.Sprintf("\tSome error occurred while iterating through the interest scalars %+v\n", err)
 		}

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -29,7 +29,6 @@ func NewKeeper(
 	bk types.BankKeeper,
 	ok types.OracleKeeper,
 ) Keeper {
-
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -395,7 +395,7 @@ func (k Keeper) GetCollateralSetting(ctx sdk.Context, borrowerAddr sdk.AccAddres
 // Because partial liquidation is possible and exchange rates vary, LiquidateBorrow returns the actual
 // amount of tokens repaid and uTokens rewarded (in that order).
 func (k Keeper) LiquidateBorrow(
-	ctx sdk.Context, liquidatorAddr, borrowerAddr sdk.AccAddress, desiredRepayment sdk.Coin, desiredReward sdk.Coin,
+	ctx sdk.Context, liquidatorAddr, borrowerAddr sdk.AccAddress, desiredRepayment, desiredReward sdk.Coin,
 ) (sdk.Int, sdk.Int, error) {
 	if !desiredRepayment.IsValid() {
 		return sdk.ZeroInt(), sdk.ZeroInt(), sdkerrors.Wrap(types.ErrInvalidAsset, desiredRepayment.String())

--- a/x/leverage/keeper/keeper_test.go
+++ b/x/leverage/keeper/keeper_test.go
@@ -533,7 +533,6 @@ func (s *IntegrationTestSuite) TestRepayAsset_Valid() {
 	// verify lender's uToken collateral remains at 1000 u/umee from initial conditions
 	collateralBalance = s.app.LeverageKeeper.GetCollateralAmount(s.ctx, lenderAddr, "u/"+umeeapp.BondDenom)
 	s.Require().Equal(collateralBalance, sdk.NewInt64Coin("u/"+umeeapp.BondDenom, 1000000000))
-
 }
 
 func (s *IntegrationTestSuite) TestRepayAsset_Overpay() {

--- a/x/leverage/keeper/msg_server.go
+++ b/x/leverage/keeper/msg_server.go
@@ -25,7 +25,6 @@ func (s msgServer) LendAsset(
 	goCtx context.Context,
 	msg *types.MsgLendAsset,
 ) (*types.MsgLendAssetResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	lenderAddr, err := sdk.AccAddressFromBech32(msg.Lender)
@@ -63,7 +62,6 @@ func (s msgServer) WithdrawAsset(
 	goCtx context.Context,
 	msg *types.MsgWithdrawAsset,
 ) (*types.MsgWithdrawAssetResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	lenderAddr, err := sdk.AccAddressFromBech32(msg.Lender)
@@ -101,7 +99,6 @@ func (s msgServer) SetCollateral(
 	goCtx context.Context,
 	msg *types.MsgSetCollateral,
 ) (*types.MsgSetCollateralResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -141,7 +138,6 @@ func (s msgServer) BorrowAsset(
 	goCtx context.Context,
 	msg *types.MsgBorrowAsset,
 ) (*types.MsgBorrowAssetResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -179,7 +175,6 @@ func (s msgServer) RepayAsset(
 	goCtx context.Context,
 	msg *types.MsgRepayAsset,
 ) (*types.MsgRepayAssetResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -224,7 +219,6 @@ func (s msgServer) Liquidate(
 	goCtx context.Context,
 	msg *types.MsgLiquidate,
 ) (*types.MsgLiquidateResponse, error) {
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	liquidatorAddr, err := sdk.AccAddressFromBech32(msg.Liquidator)

--- a/x/leverage/module.go
+++ b/x/leverage/module.go
@@ -66,7 +66,6 @@ func (AppModuleBasic) ValidateGenesis(
 	config client.TxEncodingConfig,
 	bz json.RawMessage,
 ) error {
-
 	var genState types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)

--- a/x/leverage/simulation/genesis.go
+++ b/x/leverage/simulation/genesis.go
@@ -20,17 +20,17 @@ const (
 
 // GenCompleteLiquidationThreshold produces a randomized CompleteLiquidationThreshold in the range of [0.050, 0.100]
 func GenCompleteLiquidationThreshold(r *rand.Rand) sdk.Dec {
-	return sdk.NewDecWithPrec(050, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(950)), 3))
+	return sdk.NewDecWithPrec(50, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(950)), 3))
 }
 
 // GenMinimumCloseFactor produces a randomized MinimumCloseFactor in the range of [0.001, 0.047]
 func GenMinimumCloseFactor(r *rand.Rand) sdk.Dec {
-	return sdk.NewDecWithPrec(001, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(046)), 3))
+	return sdk.NewDecWithPrec(1, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(0o46)), 3))
 }
 
 // GenOracleRewardFactor produces a randomized OracleRewardFactor in the range of [0.005, 0.100]
 func GenOracleRewardFactor(r *rand.Rand) sdk.Dec {
-	return sdk.NewDecWithPrec(005, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(995)), 3))
+	return sdk.NewDecWithPrec(5, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(995)), 3))
 }
 
 // GenSmallLiquidationSize produces a randomized SmallLiquidationSize in the range of [0, 1000]

--- a/x/leverage/simulation/genesis.go
+++ b/x/leverage/simulation/genesis.go
@@ -25,7 +25,7 @@ func GenCompleteLiquidationThreshold(r *rand.Rand) sdk.Dec {
 
 // GenMinimumCloseFactor produces a randomized MinimumCloseFactor in the range of [0.001, 0.047]
 func GenMinimumCloseFactor(r *rand.Rand) sdk.Dec {
-	return sdk.NewDecWithPrec(1, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(0o46)), 3))
+	return sdk.NewDecWithPrec(1, 3).Add(sdk.NewDecWithPrec(int64(r.Intn(46)), 3))
 }
 
 // GenOracleRewardFactor produces a randomized OracleRewardFactor in the range of [0.005, 0.100]

--- a/x/leverage/simulation/operations.go
+++ b/x/leverage/simulation/operations.go
@@ -35,7 +35,6 @@ func WeightedOperations(
 	appParams simtypes.AppParams, cdc codec.JSONCodec, ak types.AccountKeeper, bk types.BankKeeper,
 	lk keeper.Keeper,
 ) simulation.WeightedOperations {
-
 	var (
 		weightMsgLend          int
 		weightMsgWithdraw      int

--- a/x/leverage/types/expected_types.go
+++ b/x/leverage/types/expected_types.go
@@ -23,7 +23,7 @@ type BankKeeper interface {
 	SendCoinsFromModuleToModule(
 		ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins,
 	) error
-	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoins(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins

--- a/x/leverage/types/keys.go
+++ b/x/leverage/types/keys.go
@@ -170,20 +170,20 @@ func CreateUTokenSupplyKey(uTokenDenom string) []byte {
 
 // AddressFromKey extracts address from a key with the form
 // prefix | lengthPrefixed(addr) | ...
-func AddressFromKey(key []byte, prefix []byte) sdk.AccAddress {
+func AddressFromKey(key, prefix []byte) sdk.AccAddress {
 	addrLength := int(key[len(prefix)])
 	return key[len(prefix)+1 : len(prefix)+1+addrLength]
 }
 
 // DenomFromKeyWithAddress extracts denom from a key with the form
 // prefix | lengthPrefixed(addr) | denom | 0x00
-func DenomFromKeyWithAddress(key []byte, prefix []byte) string {
+func DenomFromKeyWithAddress(key, prefix []byte) string {
 	addrLength := int(key[len(prefix)])
 	return string(key[len(prefix)+addrLength+1 : len(key)-1])
 }
 
 // DenomFromKey extracts denom from a key with the form
 // prefix | denom | 0x00
-func DenomFromKey(key []byte, prefix []byte) string {
+func DenomFromKey(key, prefix []byte) string {
 	return string(key[len(prefix) : len(key)-1])
 }

--- a/x/leverage/types/tx.go
+++ b/x/leverage/types/tx.go
@@ -171,7 +171,7 @@ func (msg *MsgRepayAsset) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgLiquidate(liquidator, borrower sdk.AccAddress, repayment sdk.Coin, reward sdk.Coin) *MsgLiquidate {
+func NewMsgLiquidate(liquidator, borrower sdk.AccAddress, repayment, reward sdk.Coin) *MsgLiquidate {
 	return &MsgLiquidate{
 		Liquidator: borrower.String(),
 		Borrower:   borrower.String(),

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -42,7 +42,6 @@ func NewKeeper(
 	stakingKeeper types.StakingKeeper,
 	distrName string,
 ) Keeper {
-
 	// ensure oracle module account is set
 	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
@@ -266,7 +265,6 @@ func (k Keeper) GetAggregateExchangeRatePrevote(
 	ctx sdk.Context,
 	voter sdk.ValAddress,
 ) (types.AggregateExchangeRatePrevote, error) {
-
 	store := ctx.KVStore(k.storeKey)
 
 	bz := store.Get(types.GetAggregateExchangeRatePrevoteKey(voter))

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -69,7 +69,6 @@ func (AppModuleBasic) ValidateGenesis(
 	config client.TxEncodingConfig,
 	bz json.RawMessage,
 ) error {
-
 	var genState types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)

--- a/x/oracle/simulations/operations.go
+++ b/x/oracle/simulations/operations.go
@@ -193,7 +193,6 @@ func SimulateMsgAggregateExchangeRateVote(
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-
 		simAccount, _ := simtypes.RandomAcc(r, accs)
 		address := sdk.ValAddress(simAccount.Address)
 
@@ -277,7 +276,6 @@ func SimulateMsgDelegateFeedConsent(ak types.AccountKeeper, bk types.BankKeeper,
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-
 		simAccount, _ := simtypes.RandomAcc(r, accs)
 		delegateAccount, _ := simtypes.RandomAcc(r, accs)
 		valAddress := sdk.ValAddress(simAccount.Address)

--- a/x/oracle/types/expected_keeper.go
+++ b/x/oracle/types/expected_keeper.go
@@ -41,7 +41,7 @@ type AccountKeeper interface {
 type BankKeeper interface {
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
-	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule string, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
 

--- a/x/oracle/types/genesis.go
+++ b/x/oracle/types/genesis.go
@@ -15,7 +15,6 @@ func NewGenesisState(
 	aggregateExchangeRatePrevotes []AggregateExchangeRatePrevote,
 	aggregateExchangeRateVotes []AggregateExchangeRateVote,
 ) *GenesisState {
-
 	return &GenesisState{
 		Params:                        params,
 		ExchangeRates:                 rates,

--- a/x/oracle/types/hash.go
+++ b/x/oracle/types/hash.go
@@ -20,7 +20,7 @@ type AggregateVoteHash []byte
 
 // GetAggregateVoteHash computes hash value of ExchangeRateVote to avoid
 // redundant DecCoins stringify operation.
-func GetAggregateVoteHash(salt string, exchangeRatesStr string, voter sdk.ValAddress) AggregateVoteHash {
+func GetAggregateVoteHash(salt, exchangeRatesStr string, voter sdk.ValAddress) AggregateVoteHash {
 	hash := tmhash.NewTruncated()
 	sourceStr := fmt.Sprintf("%s:%s:%s", salt, exchangeRatesStr, voter.String())
 

--- a/x/oracle/types/hash_test.go
+++ b/x/oracle/types/hash_test.go
@@ -31,7 +31,7 @@ func TestAggregateVoteHash(t *testing.T) {
 	testMarshal(t, &aggregateVoteHash, &res, aggregateVoteHash.Marshal, (&res).Unmarshal)
 }
 
-func testMarshal(t *testing.T, original interface{}, res interface{}, marshal func() ([]byte, error), unmarshal func([]byte) error) {
+func testMarshal(t *testing.T, original, res interface{}, marshal func() ([]byte, error), unmarshal func([]byte) error) {
 	bz, err := marshal()
 	require.Nil(t, err)
 	err = unmarshal(bz)

--- a/x/oracle/types/msgs.go
+++ b/x/oracle/types/msgs.go
@@ -25,7 +25,6 @@ func NewMsgAggregateExchangeRatePrevote(
 	feeder sdk.AccAddress,
 	validator sdk.ValAddress,
 ) *MsgAggregateExchangeRatePrevote {
-
 	return &MsgAggregateExchangeRatePrevote{
 		Hash:      hash.String(),
 		Feeder:    feeder.String(),
@@ -81,7 +80,6 @@ func NewMsgAggregateExchangeRateVote(
 	feeder sdk.AccAddress,
 	validator sdk.ValAddress,
 ) *MsgAggregateExchangeRateVote {
-
 	return &MsgAggregateExchangeRateVote{
 		Salt:          salt,
 		ExchangeRates: exchangeRates,

--- a/x/oracle/types/vote.go
+++ b/x/oracle/types/vote.go
@@ -15,7 +15,6 @@ func NewAggregateExchangeRatePrevote(
 	voter sdk.ValAddress,
 	submitBlock uint64,
 ) AggregateExchangeRatePrevote {
-
 	return AggregateExchangeRatePrevote{
 		Hash:        hash.String(),
 		Voter:       voter.String(),
@@ -33,7 +32,6 @@ func NewAggregateExchangeRateVote(
 	exchangeRateTuples ExchangeRateTuples,
 	voter sdk.ValAddress,
 ) AggregateExchangeRateVote {
-
 	return AggregateExchangeRateVote{
 		ExchangeRateTuples: exchangeRateTuples,
 		Voter:              voter.String(),


### PR DESCRIPTION
## Description

Formatting pass using [gofumpt](https://github.com/mvdan/gofumpt), a stricter `gofmt`

```
gofumpt -l -w .

gofumpt -l -w -extra .
```


It might be worth using this in CI like a linter.

No functionality changes, so probably doesn't need a changelog.