### PR TITLE
chore: add go tool tip to makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [782](https://github.com/umee-network/umee/pull/782) Add unit test to `x/oracle/types/denom.go` and `x/oracle/types/keys.go`.
 - [786](https://github.com/umee-network/umee/pull/786) Add unit test to `x/oracle/...`.
 - [798](https://github.com/umee-network/umee/pull/798) Increase `x/oracle` unit test coverage.
+- [803](https://github.com/umee-network/umee/pull/803) Add `cover-html` command to makefile.
 
 ## [v2.0.0](https://github.com/umee-network/umee/releases/tag/v2.0.0) - 2022-04-06
 

--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ PACKAGES_UNIT=$(shell go list ./... | grep -v -e '/tests/e2e' -e '/tests/simulat
 PACKAGES_E2E=$(shell go list ./... | grep '/e2e')
 TEST_PACKAGES=./...
 TEST_TARGETS := test-unit test-unit-cover test-race test-e2e
+TEST_COVERAGE_PROFILE=coverage.txt
 
 test-unit: ARGS=-timeout=10m -tags='norace'
 test-unit: TEST_PACKAGES=$(PACKAGES_UNIT)
-# After generate coverage file use `go tool cover -html=coverage.txt` to look for low coverage paths
-test-unit-cover: ARGS=-timeout=10m -tags='norace' -coverprofile=coverage.txt -covermode=atomic
+test-unit-cover: ARGS=-timeout=10m -tags='norace' -coverprofile=$(TEST_COVERAGE_PROFILE) -covermode=atomic
 test-unit-cover: TEST_PACKAGES=$(PACKAGES_UNIT)
 test-race: ARGS=-timeout=10m -race
 test-race: TEST_PACKAGES=$(PACKAGES_UNIT)
@@ -144,6 +144,11 @@ endif
 lint:
 	@echo "--> Running linter"
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
+
+cover-html: test-unit-cover
+	@echo "--> Opening in the browser"
+	@go tool cover -html=$(TEST_COVERAGE_PROFILE)
+
 
 .PHONY: lint
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ TEST_TARGETS := test-unit test-unit-cover test-race test-e2e
 
 test-unit: ARGS=-timeout=10m -tags='norace'
 test-unit: TEST_PACKAGES=$(PACKAGES_UNIT)
+# After generate coverage file use `go tool cover -html=coverage.txt` to look for low coverage paths
 test-unit-cover: ARGS=-timeout=10m -tags='norace' -coverprofile=coverage.txt -covermode=atomic
 test-unit-cover: TEST_PACKAGES=$(PACKAGES_UNIT)
 test-race: ARGS=-timeout=10m -race


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- Add go tip to the makefile to generate easily readable coverage
- run `make test-unit-cover`
- open it in the browser with `go tool cover -html=coverage.txt`
![image](https://user-images.githubusercontent.com/17556614/163037873-b27646f4-0038-4ec6-ac30-d2e76f7478a1.png)

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
