### PR TITLE
fix: liquidate command from-address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+- [829](https://github.com/umee-network/umee/pull/829) Fix `umeed tx leverage liquidate` command args
+
 ### Improvements
 
 - [781](https://github.com/umee-network/umee/pull/781) Oracle module unit test cleanup.

--- a/x/leverage/simulation/operations.go
+++ b/x/leverage/simulation/operations.go
@@ -291,7 +291,7 @@ func SimulateMsgLiquidate(ak simulation.AccountKeeper, bk types.BankKeeper, lk k
 			Msg:           msg,
 			MsgType:       types.EventTypeLiquidate,
 			Context:       ctx,
-			SimAccount:    borrower,
+			SimAccount:    liquidator,
 			AccountKeeper: ak,
 			Bankkeeper:    bk,
 			ModuleName:    types.ModuleName,

--- a/x/leverage/types/tx.go
+++ b/x/leverage/types/tx.go
@@ -173,7 +173,7 @@ func (msg *MsgRepayAsset) GetSignBytes() []byte {
 
 func NewMsgLiquidate(liquidator, borrower sdk.AccAddress, repayment, reward sdk.Coin) *MsgLiquidate {
 	return &MsgLiquidate{
-		Liquidator: borrower.String(),
+		Liquidator: liquidator.String(),
 		Borrower:   borrower.String(),
 		Repayment:  repayment,
 		Reward:     reward,


### PR DESCRIPTION
## Description

liquidate command was using borrower address as liquidator

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed