### PR TITLE
chore: Move proto v1beta1 to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,18 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [866](https://github.com/umee-network/umee/pull/866) Make the x/oracle keeper's GetExchangeRateBase method more efficient.
 
+### API Breaking
+
+- [870](https://github.com/umee-network/umee/pull/870) chore: Move proto v1beta1 to v1.
+
 ## [v2.0.1](https://github.com/umee-network/umee/releases/tag/v2.0.1) - 2022-04-25
 
 ### Features
+
 - [835](https://github.com/umee-network/umee/pull/835) Add miss counter query to oracle cli.
 
 ### Bug Fixes
+
 - [829](https://github.com/umee-network/umee/pull/829) Fix `umeed tx leverage liquidate` command args
 
 ### Improvements

--- a/proto/umee/leverage/v1/genesis.proto
+++ b/proto/umee/leverage/v1/genesis.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
-package umeenetwork.umee.leverage.v1beta1;
+package umeenetwork.umee.leverage.v1;
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
-import "umee/leverage/v1beta1/leverage.proto";
+import "umee/leverage/v1/leverage.proto";
 
 option go_package = "github.com/umee-network/umee/v2/x/leverage/types";
 

--- a/proto/umee/leverage/v1/gov.proto
+++ b/proto/umee/leverage/v1/gov.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package umeenetwork.umee.leverage.v1beta1;
+package umeenetwork.umee.leverage.v1;
 
 import "gogoproto/gogo.proto";
-import "umee/leverage/v1beta1/leverage.proto";
+import "umee/leverage/v1/leverage.proto";
 
 option go_package = "github.com/umee-network/umee/v2/x/leverage/types";
 

--- a/proto/umee/leverage/v1/leverage.proto
+++ b/proto/umee/leverage/v1/leverage.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package umeenetwork.umee.leverage.v1beta1;
+package umeenetwork.umee.leverage.v1;
 
 import "gogoproto/gogo.proto";
 

--- a/proto/umee/leverage/v1/query.proto
+++ b/proto/umee/leverage/v1/query.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package umeenetwork.umee.leverage.v1beta1;
+package umeenetwork.umee.leverage.v1;
 
 import "google/api/annotations.proto";
-import "umee/leverage/v1beta1/leverage.proto";
+import "umee/leverage/v1/leverage.proto";
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
@@ -12,113 +12,113 @@ option go_package = "github.com/umee-network/umee/v2/x/leverage/types";
 service Query {
   // RegisteredTokens queries for all the registered tokens.
   rpc RegisteredTokens(QueryRegisteredTokens) returns (QueryRegisteredTokensResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/registered_tokens";
+    option (google.api.http).get = "/umee/leverage/v1/registered_tokens";
   }
 
   // Params queries the parameters of the x/leverage module.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/params";
+    option (google.api.http).get = "/umee/leverage/v1/params";
   }
 
   // Borrowed queries for the borrowed amount of a user by token denomination.
   // If the denomination is not supplied, the total for each borrowed token is
   // returned.
   rpc Borrowed(QueryBorrowedRequest) returns (QueryBorrowedResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/borrowed";
+    option (google.api.http).get = "/umee/leverage/v1/borrowed";
   }
 
   // BorrowedValue queries for the usd value of the borrowed amount of a user
   // by token denomination.  If the denomination is not supplied, the sum across
   // all borrowed tokens is returned.
   rpc BorrowedValue(QueryBorrowedValueRequest) returns (QueryBorrowedValueResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/borrowed_value";
+    option (google.api.http).get = "/umee/leverage/v1/borrowed_value";
   }
 
   // Loaned queries for the amount of tokens loaned by a user by denomination.
   // If the denomination is not supplied, the total for each loaned token is
   // returned.
   rpc Loaned(QueryLoanedRequest) returns (QueryLoanedResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/loaned";
+    option (google.api.http).get = "/umee/leverage/v1/loaned";
   }
 
   // LoanedValue queries for the USD value loaned by a user by token
   // denomination. If the denomination is not supplied, the sum across all
   // loaned tokens is returned.
   rpc LoanedValue(QueryLoanedValueRequest) returns (QueryLoanedValueResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/loaned_value";
+    option (google.api.http).get = "/umee/leverage/v1/loaned_value";
   }
 
   // AvailableBorrow queries for the available amount to borrow of a specified denomination.
   rpc AvailableBorrow(QueryAvailableBorrowRequest) returns (QueryAvailableBorrowResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/available_borrow";
+    option (google.api.http).get = "/umee/leverage/v1/available_borrow";
   }
 
   // BorrowAPY queries for the borrow APY of a specified denomination.
   rpc BorrowAPY(QueryBorrowAPYRequest) returns (QueryBorrowAPYResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/borrow_apy";
+    option (google.api.http).get = "/umee/leverage/v1/borrow_apy";
   }
 
   // LendAPY queries for the lend APY of a specified denomination.
   rpc LendAPY(QueryLendAPYRequest) returns (QueryLendAPYResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/lend_apy";
+    option (google.api.http).get = "/umee/leverage/v1/lend_apy";
   }
 
   // MarketSize queries for the Market Size in USD of a specified denomination, which
   // is the USD value of total tokens loaned by all users plus borrow interest owed
   // by all users.
   rpc MarketSize(QueryMarketSizeRequest) returns (QueryMarketSizeResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/market_size";
+    option (google.api.http).get = "/umee/leverage/v1/market_size";
   }
 
   // TokenMarketSize queries for the Market Size in base tokens of a specified denomination,
   // which is the total tokens loaned by all users plus borrow interest owed by all users.
   rpc TokenMarketSize(QueryTokenMarketSizeRequest) returns (QueryTokenMarketSizeResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/token_market_size";
+    option (google.api.http).get = "/umee/leverage/v1/token_market_size";
   }
 
   // ReserveAmount queries for the amount reserved of a specified denomination.
   // If the token is not valid, the reserved amount is zero.
   rpc ReserveAmount(QueryReserveAmountRequest) returns (QueryReserveAmountResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/reserve_amount";
+    option (google.api.http).get = "/umee/leverage/v1/reserve_amount";
   }
 
   // CollateralSetting queries a borrower's collateral setting (enabled or disabled)
   // for a specified uToken denomination.
   rpc CollateralSetting(QueryCollateralSettingRequest) returns (QueryCollateralSettingResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/collateral_setting";
+    option (google.api.http).get = "/umee/leverage/v1/collateral_setting";
   }
 
   // Collateral queries the collateral amount of a user by token denomination.
   // If the denomination is not supplied, all of the user's collateral tokens
   // are returned.
   rpc Collateral(QueryCollateralRequest) returns (QueryCollateralResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/collateral";
+    option (google.api.http).get = "/umee/leverage/v1/collateral";
   }
 
   // CollateralValue queries for the total USD value of a user's collateral, or
   // the USD value held as a given base asset's associated uToken denomination.
   rpc CollateralValue(QueryCollateralValueRequest) returns (QueryCollateralValueResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/collateral_value";
+    option (google.api.http).get = "/umee/leverage/v1/collateral_value";
   }
 
   // ExchangeRate queries the uToken exchange rate of a given uToken denomination.
   rpc ExchangeRate(QueryExchangeRateRequest) returns (QueryExchangeRateResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/exchange_rate";
+    option (google.api.http).get = "/umee/leverage/v1/exchange_rate";
   }
 
   // BorrowLimit queries the borrow limit in USD of a given borrower.
   rpc BorrowLimit(QueryBorrowLimitRequest) returns (QueryBorrowLimitResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/borrow_limit";
+    option (google.api.http).get = "/umee/leverage/v1/borrow_limit";
   }
 
   // LiquidationLimit queries the limit in USD above which a given borrower is eligible for liquidation.
   rpc LiquidationLimit(QueryLiquidationLimitRequest) returns (QueryLiquidationLimitResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/liquidation_limit";
+    option (google.api.http).get = "/umee/leverage/v1/liquidation_limit";
   }
 
   // LiquidationTargets queries a list of all borrower addresses eligible for liquidation.
   rpc LiquidationTargets(QueryLiquidationTargetsRequest) returns (QueryLiquidationTargetsResponse) {
-    option (google.api.http).get = "/umee/leverage/v1beta1/liquidation_targets";
+    option (google.api.http).get = "/umee/leverage/v1/liquidation_targets";
   }
 }
 

--- a/proto/umee/leverage/v1/tx.proto
+++ b/proto/umee/leverage/v1/tx.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package umeenetwork.umee.leverage.v1beta1;
+package umeenetwork.umee.leverage.v1;
 
 import "cosmos/base/v1beta1/coin.proto";
 import "gogoproto/gogo.proto";

--- a/proto/umee/oracle/v1/genesis.proto
+++ b/proto/umee/oracle/v1/genesis.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package umeenetwork.umee.oracle.v1beta1;
+package umeenetwork.umee.oracle.v1;
 
 import "gogoproto/gogo.proto";
-import "umee/oracle/v1beta1/oracle.proto";
+import "umee/oracle/v1/oracle.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/umee-network/umee/v2/x/oracle/types";

--- a/proto/umee/oracle/v1/oracle.proto
+++ b/proto/umee/oracle/v1/oracle.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package umeenetwork.umee.oracle.v1beta1;
+package umeenetwork.umee.oracle.v1;
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";

--- a/proto/umee/oracle/v1/query.proto
+++ b/proto/umee/oracle/v1/query.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
-package umeenetwork.umee.oracle.v1beta1;
+package umeenetwork.umee.oracle.v1;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
-import "umee/oracle/v1beta1/oracle.proto";
+import "umee/oracle/v1/oracle.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/umee-network/umee/v2/x/oracle/types";
@@ -13,47 +13,47 @@ service Query {
   // ExchangeRates returns exchange rates of all denoms,
   // or, if specified, returns a single denom
   rpc ExchangeRates(QueryExchangeRatesRequest) returns (QueryExchangeRatesResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/denoms/exchange_rates/{denom}";
+    option (google.api.http).get = "/umee/oracle/v1/denoms/exchange_rates/{denom}";
   }
 
   // ActiveExchangeRates returns all active denoms
   rpc ActiveExchangeRates(QueryActiveExchangeRatesRequest) returns (QueryActiveExchangeRatesResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/denoms/active_exchange_rates";
+    option (google.api.http).get = "/umee/oracle/v1/denoms/active_exchange_rates";
   }
 
   // FeederDelegation returns feeder delegation of a validator
   rpc FeederDelegation(QueryFeederDelegationRequest) returns (QueryFeederDelegationResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/validators/{validator_addr}/feeder";
+    option (google.api.http).get = "/umee/oracle/v1/validators/{validator_addr}/feeder";
   }
 
   // MissCounter returns oracle miss counter of a validator
   rpc MissCounter(QueryMissCounterRequest) returns (QueryMissCounterResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/validators/{validator_addr}/miss";
+    option (google.api.http).get = "/umee/oracle/v1/validators/{validator_addr}/miss";
   }
 
   // AggregatePrevote returns an aggregate prevote of a validator
   rpc AggregatePrevote(QueryAggregatePrevoteRequest) returns (QueryAggregatePrevoteResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/validators/{validator_addr}/aggregate_prevote";
+    option (google.api.http).get = "/umee/oracle/v1/validators/{validator_addr}/aggregate_prevote";
   }
 
   // AggregatePrevotes returns aggregate prevotes of all validators
   rpc AggregatePrevotes(QueryAggregatePrevotesRequest) returns (QueryAggregatePrevotesResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/validators/aggregate_prevotes";
+    option (google.api.http).get = "/umee/oracle/v1/validators/aggregate_prevotes";
   }
 
   // AggregateVote returns an aggregate vote of a validator
   rpc AggregateVote(QueryAggregateVoteRequest) returns (QueryAggregateVoteResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/valdiators/{validator_addr}/aggregate_vote";
+    option (google.api.http).get = "/umee/oracle/v1/valdiators/{validator_addr}/aggregate_vote";
   }
 
   // AggregateVotes returns aggregate votes of all validators
   rpc AggregateVotes(QueryAggregateVotesRequest) returns (QueryAggregateVotesResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/validators/aggregate_votes";
+    option (google.api.http).get = "/umee/oracle/v1/validators/aggregate_votes";
   }
 
   // Params queries all parameters.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/umee/oracle/v1beta1/params";
+    option (google.api.http).get = "/umee/oracle/v1/params";
   }
 }
 

--- a/proto/umee/oracle/v1/tx.proto
+++ b/proto/umee/oracle/v1/tx.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package umeenetwork.umee.oracle.v1beta1;
+package umeenetwork.umee.oracle.v1;
 
 import "gogoproto/gogo.proto";
 


### PR DESCRIPTION
## Description

In Cosmos SDK we are using v1beta1 because we didn't release Cosmos SDK v1 and we were not sure about the final layout.

Unfortunately this pattern got copied in other projects without asking "why". We are not creating an SDK, but a final product, so we have our upcoming next production release. 

Follow up tasks:
- [ ] regenerate modules after the proto update
- [ ] think about the submodules.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
