### PR TITLE
feat: Require stablecoins to be re-denominated 

### DIFF
--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -184,12 +184,13 @@ func ParseConfig(configPath string) (Config, error) {
 	}
 
 	pairs := make(map[string]map[string]struct{})
+	coinQuotes := make(map[string]struct{})
 	for _, cp := range cfg.CurrencyPairs {
-		if !strings.Contains(strings.ToUpper(cp.Quote), denomUSD) {
-			return cfg, fmt.Errorf("unsupported pair quote: %s", cp.Quote)
-		}
 		if _, ok := pairs[cp.Base]; !ok {
 			pairs[cp.Base] = make(map[string]struct{})
+		}
+		if strings.ToUpper(cp.Quote) != denomUSD {
+			coinQuotes[cp.Quote] = struct{}{}
 		}
 
 		for _, provider := range cp.Providers {
@@ -197,6 +198,17 @@ func ParseConfig(configPath string) (Config, error) {
 				return cfg, fmt.Errorf("unsupported provider: %s", provider)
 			}
 			pairs[cp.Base][provider] = struct{}{}
+		}
+	}
+
+	for quote := range coinQuotes {
+		for index, pair := range cfg.CurrencyPairs {
+			if pair.Base == quote && pair.Quote == denomUSD {
+				break
+			}
+			if index == len(cfg.CurrencyPairs)-1 {
+				return cfg, fmt.Errorf("all non-usd quotes require a conversion rate feed")
+			}
 		}
 	}
 

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -148,6 +148,15 @@ providers = [
 	"huobi"
 ]
 
+[[currency_pairs]]
+base = "USDT"
+quote = "USD"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
 [account]
 address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
 validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
@@ -182,7 +191,7 @@ global_labels = [["chain-id", "umee-local-testnet"]]
 	require.Equal(t, "20s", cfg.Server.WriteTimeout)
 	require.Equal(t, "20s", cfg.Server.ReadTimeout)
 	require.True(t, cfg.Server.VerboseCORS)
-	require.Len(t, cfg.CurrencyPairs, 2)
+	require.Len(t, cfg.CurrencyPairs, 3)
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
 	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
@@ -222,6 +231,15 @@ providers = [
 	"huobi"
 ]
 
+[[currency_pairs]]
+base = "USDT"
+quote = "USD"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
 [account]
 address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
 validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
@@ -250,7 +268,7 @@ enabled = false
 	require.Equal(t, "20s", cfg.Server.WriteTimeout)
 	require.Equal(t, "20s", cfg.Server.ReadTimeout)
 	require.True(t, cfg.Server.VerboseCORS)
-	require.Len(t, cfg.CurrencyPairs, 2)
+	require.Len(t, cfg.CurrencyPairs, 3)
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
 	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
@@ -260,6 +278,37 @@ enabled = false
 }
 
 func TestParseConfig_InvalidProvider(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "price-feeder.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	content := []byte(`
+listen_addr = ""
+
+[[currency_pairs]]
+base = "ATOM"
+quote = "USD"
+providers = [
+	"kraken",
+	"binance"
+]
+
+[[currency_pairs]]
+base = "UMEE"
+quote = "USD"
+providers = [
+	"kraken",
+	"foobar"
+]
+`)
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+
+	_, err = config.ParseConfig(tmpFile.Name())
+	require.Error(t, err)
+}
+
+func TestParseConfig_NonUSDQuote(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "price-feeder.toml")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
@@ -280,7 +329,7 @@ base = "UMEE"
 quote = "USDT"
 providers = [
 	"kraken",
-	"foobar"
+	"binance"
 ]
 `)
 	_, err = tmpFile.Write(content)


### PR DESCRIPTION
## Description

This adds the requirement that any quotes for coins which are based in USD be re-denominated in USD.

This will also allow us to support coins which do not have solid stablecoin quotes (e.g., they only have /ATOM liquidity pools on osmosis) by allowing validators to configure the price feeder to have an ATOM/USD feed 😄 

closes: #892

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
