### PR TITLE
ci: Changing branch for  breaking changes checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [935](https://github.com/umee-network/umee/pull/935) Fix protobuf linting
-- [960](https://github.com/umee-network/umee/pull/960) Change Breaking Changes to check against the main branch
 
 ## [v2.0.2](https://github.com/umee-network/umee/releases/tag/v2.0.2) - 2022-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [935](https://github.com/umee-network/umee/pull/935) Fix protobuf linting
+- [960](https://github.com/umee-network/umee/pull/960) Change Breaking Changes to check against the main branch
 
 ## [v2.0.2](https://github.com/umee-network/umee/releases/tag/v2.0.2) - 2022-05-13
 

--- a/Makefile
+++ b/Makefile
@@ -214,5 +214,5 @@ proto-lint:
 
 proto-check-breaking: 
 	@echo "Checking for breaking changes"
-	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=brianosaurus/fix-proto-linting
+	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=main
 


### PR DESCRIPTION
## Description

The way breaking changes for the protobuf works:

1. We had to check in a directory structure for the new build system and have breaking changes check against itself first.
2. The second step was to merge the changes to main. 
3. The third step (this PR) is to change the branch breaking changes checks against back to main.

----

### Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
