### PR TITLE
!feat: price-feeder: add the ability to configure asset deviation thresholds

### DIFF
--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -54,6 +54,7 @@ type (
 	Config struct {
 		Server          Server         `toml:"server"`
 		CurrencyPairs   []CurrencyPair `toml:"currency_pairs" validate:"required,gt=0,dive,required"`
+		Deviations      []Deviation    `toml:"deviation_thresholds"`
 		Account         Account        `toml:"account" validate:"required,gt=0,dive,required"`
 		Keyring         Keyring        `toml:"keyring" validate:"required,gt=0,dive,required"`
 		RPC             RPC            `toml:"rpc" validate:"required,gt=0,dive,required"`
@@ -77,6 +78,13 @@ type (
 		Base      string   `toml:"base" validate:"required"`
 		Quote     string   `toml:"quote" validate:"required"`
 		Providers []string `toml:"providers" validate:"required,gt=0,dive,required"`
+	}
+
+	// Deviation defines a maximum amount of standard deviations that a given asset can
+	// be from the median without being filtered out before voting.
+	Deviation struct {
+		Base      string `toml:"base" validate:"required"`
+		Threshold string `toml:"threshold" validate:"required"`
 	}
 
 	// Account defines account related configuration that is related to the Umee

--- a/price-feeder/oracle/filter_test.go
+++ b/price-feeder/oracle/filter_test.go
@@ -52,6 +52,7 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 	pricesFiltered, err := FilterCandleDeviations(
 		zerolog.Nop(),
 		providerCandles,
+		make(map[string]sdk.Dec),
 	)
 
 	_, ok := pricesFiltered[config.ProviderCoinbase]
@@ -93,6 +94,7 @@ func TestSuccessFilterTickerDeviations(t *testing.T) {
 	pricesFiltered, err := FilterTickerDeviations(
 		zerolog.Nop(),
 		providerTickers,
+		make(map[string]sdk.Dec),
 	)
 
 	_, ok := pricesFiltered[config.ProviderCoinbase]

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -63,6 +63,7 @@ type Oracle struct {
 	previousVotePeriod float64
 	priceProviders     map[string]provider.Provider
 	oracleClient       client.OracleClient
+	deviations         map[string]sdk.Dec
 
 	mtx             sync.RWMutex
 	lastPriceSyncTS time.Time
@@ -74,6 +75,7 @@ func New(
 	oc client.OracleClient,
 	currencyPairs []config.CurrencyPair,
 	providerTimeout time.Duration,
+	deviations map[string]sdk.Dec,
 ) *Oracle {
 	providerPairs := make(map[string][]types.CurrencyPair)
 
@@ -94,6 +96,7 @@ func New(
 		priceProviders:  make(map[string]provider.Provider),
 		previousPrevote: nil,
 		providerTimeout: providerTimeout,
+		deviations:      deviations,
 	}
 }
 
@@ -234,7 +237,13 @@ func (o *Oracle) SetPrices(ctx context.Context, acceptList oracletypes.DenomList
 		o.logger.Debug().Err(err).Msg("failed to get ticker prices from provider")
 	}
 
-	computedPrices, err := GetComputedPrices(o.logger, providerCandles, providerPrices, o.providerPairs)
+	computedPrices, err := GetComputedPrices(
+		o.logger,
+		providerCandles,
+		providerPrices,
+		o.providerPairs,
+		o.deviations,
+	)
 	if err != nil {
 		return err
 	}
@@ -261,9 +270,14 @@ func GetComputedPrices(
 	providerCandles provider.AggregatedProviderCandles,
 	providerPrices provider.AggregatedProviderPrices,
 	providerPairs map[string][]types.CurrencyPair,
+	deviations map[string]sdk.Dec,
 ) (prices map[string]sdk.Dec, err error) {
 	// filter out any erroneous candles
-	filteredCandles, err := FilterCandleDeviations(logger, providerCandles)
+	filteredCandles, err := FilterCandleDeviations(
+		logger,
+		providerCandles,
+		deviations,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +297,11 @@ func GetComputedPrices(
 	// If TVWAP candles are not available or were filtered out due to staleness,
 	// use most recent prices & VWAP instead.
 	if len(tvwapPrices) == 0 {
-		filteredProviderPrices, err := FilterTickerDeviations(logger, providerPrices)
+		filteredProviderPrices, err := FilterTickerDeviations(
+			logger,
+			providerPrices,
+			deviations,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/price-feeder/oracle/oracle_test.go
+++ b/price-feeder/oracle/oracle_test.go
@@ -108,6 +108,7 @@ func (ots *OracleTestSuite) SetupSuite() {
 			},
 		},
 		time.Millisecond*100,
+		make(map[string]sdk.Dec),
 	)
 }
 
@@ -479,6 +480,7 @@ func TestSuccessGetComputedPricesCandles(t *testing.T) {
 		providerCandles,
 		make(provider.AggregatedProviderPrices, 1),
 		providerPair,
+		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(t, err, "It should successfully get computed candle prices")
@@ -511,6 +513,7 @@ func TestSuccessGetComputedPricesTickers(t *testing.T) {
 		make(provider.AggregatedProviderCandles, 1),
 		providerPrices,
 		providerPair,
+		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(t, err, "It should successfully get computed ticker prices")


### PR DESCRIPTION
## Description

Adds a field in our config which allows validators to configure how many standard deviations away from the mean they want to allow prices to be for a given asset.

closes: #977

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
