### PR TITLE
!fix: restrict MsgWithdraw to only accept uToken inputs

### DIFF
--- a/proto/umee/leverage/v1/tx.proto
+++ b/proto/umee/leverage/v1/tx.proto
@@ -38,9 +38,8 @@ message MsgLendAsset {
   cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgWithdrawAsset represents a lender's request to withdraw a previously
-// loaned base asset type from the module. Amount can either be exact uTokens to
-// withdraw or equivalent base assets.
+// MsgWithdrawAsset represents a lender's request to withdraw lent assets.
+// Amount must be a uToken.
 message MsgWithdrawAsset {
   string                   lender = 1;
   cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];

--- a/x/leverage/client/tests/tests.go
+++ b/x/leverage/client/tests/tests.go
@@ -409,7 +409,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 		cli.GetCmdWithdrawAsset(),
 		[]string{
 			val.Address.String(),
-			"1000uumee",
+			"1000u/uumee",
 		},
 		nil,
 	}

--- a/x/leverage/types/tx.pb.go
+++ b/x/leverage/types/tx.pb.go
@@ -83,9 +83,8 @@ func (m *MsgLendAsset) GetAmount() types.Coin {
 	return types.Coin{}
 }
 
-// MsgWithdrawAsset represents a lender's request to withdraw a previously
-// loaned base asset type from the module. Amount can either be exact uTokens to
-// withdraw or equivalent base assets.
+// MsgWithdrawAsset represents a lender's request to withdraw lent assets.
+// Amount must be a uToken.
 type MsgWithdrawAsset struct {
 	Lender string     `protobuf:"bytes,1,opt,name=lender,proto3" json:"lender,omitempty"`
 	Amount types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount"`


### PR DESCRIPTION
## Description

Removes the ability of `MsgWithdraw` to convert base token inputs to uTokens automatically.

This fixes a very minor problem, where the double conversion of input `token -> uToken -> token` would result in a final token amount which had been rounded down twice as opposed to once when users input a token amount, e.g. `1000uumee -> 999u/uumee -> 998uumee`.

With this fix, user input is denominated in uTokens, so the rounding is minimized to the necessary amount.

Runtime verification had mentioned this in a "functional correctness" issue at one point.

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
