### PR TITLE
feat!: make the price feeder's uris configurable

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+- [#1038](https://github.com/umee-network/umee/pull/1038) Adds the option for validators to override API endpoints in our config.
 - [#1002](https://github.com/umee-network/umee/pull/1002) Add linting to the price feeder CI.
 - [#998](https://github.com/umee-network/umee/pull/998) Make deviation thresholds configurable for stablecoin support.
 - [#925](https://github.com/umee-network/umee/pull/925) Require stablecoins to be converted to USD to protect against depegging.

--- a/price-feeder/cmd/price-feeder.go
+++ b/price-feeder/cmd/price-feeder.go
@@ -149,12 +149,18 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		deviations[deviation.Base] = threshold
 	}
 
+	endpoints := make(map[string]config.ProviderEndpoint, len(cfg.ProviderEndpoints))
+	for _, endpoint := range cfg.ProviderEndpoints {
+		endpoints[endpoint.Name] = endpoint
+	}
+
 	oracle := oracle.New(
 		logger,
 		oracleClient,
 		cfg.CurrencyPairs,
 		providerTimeout,
 		deviations,
+		endpoints,
 	)
 
 	metrics, err := telemetry.New(cfg.Telemetry)

--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -180,6 +180,9 @@ func endpointValidation(sl validator.StructLevel) {
 	if len(endpoint.Name) < 1 || len(endpoint.Rest) < 1 || len(endpoint.Websocket) < 1 {
 		sl.ReportError(endpoint, "endpoint", "Endpoint", "unsupportedEndpointType", "")
 	}
+	if _, ok := SupportedProviders[endpoint.Name]; !ok {
+		sl.ReportError(endpoint.Name, "name", "Name", "unsupportedEndpointProvider", "")
+	}
 }
 
 // Validate returns an error if the Config object is invalid.

--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -57,15 +57,16 @@ var (
 type (
 	// Config defines all necessary price-feeder configuration parameters.
 	Config struct {
-		Server          Server         `toml:"server"`
-		CurrencyPairs   []CurrencyPair `toml:"currency_pairs" validate:"required,gt=0,dive,required"`
-		Deviations      []Deviation    `toml:"deviation_thresholds"`
-		Account         Account        `toml:"account" validate:"required,gt=0,dive,required"`
-		Keyring         Keyring        `toml:"keyring" validate:"required,gt=0,dive,required"`
-		RPC             RPC            `toml:"rpc" validate:"required,gt=0,dive,required"`
-		Telemetry       Telemetry      `toml:"telemetry"`
-		GasAdjustment   float64        `toml:"gas_adjustment" validate:"required"`
-		ProviderTimeout string         `toml:"provider_timeout"`
+		Server            Server             `toml:"server"`
+		CurrencyPairs     []CurrencyPair     `toml:"currency_pairs" validate:"required,gt=0,dive,required"`
+		Deviations        []Deviation        `toml:"deviation_thresholds"`
+		Account           Account            `toml:"account" validate:"required,gt=0,dive,required"`
+		Keyring           Keyring            `toml:"keyring" validate:"required,gt=0,dive,required"`
+		RPC               RPC                `toml:"rpc" validate:"required,gt=0,dive,required"`
+		Telemetry         Telemetry          `toml:"telemetry"`
+		GasAdjustment     float64            `toml:"gas_adjustment" validate:"required"`
+		ProviderTimeout   string             `toml:"provider_timeout"`
+		ProviderEndpoints []ProviderEndpoint `toml:"provider_endpoints" validate:"dive"`
 	}
 
 	// Server defines the API server configuration.
@@ -143,9 +144,22 @@ type (
 		// Valid values are "prometheus" or "generic"
 		Type string `toml:"type"`
 	}
+
+	// ProviderEndpoint defines an override setting in our config for the
+	// hardcoded rest and websocket api endpoints.
+	ProviderEndpoint struct {
+		// Name of the provider, ex. "binance"
+		Name string `toml:"name"`
+
+		// Rest endpoint for the provider, ex. "https://api1.binance.com"
+		Rest string `toml:"rest"`
+
+		// Websocket endpoint for the provider, ex. "stream.binance.com:9443"
+		Websocket string `toml:"websocket"`
+	}
 )
 
-// telemetryValidation is custom validation for the Telemetry struct
+// telemetryValidation is custom validation for the Telemetry struct.
 func telemetryValidation(sl validator.StructLevel) {
 	tel := sl.Current().Interface().(Telemetry)
 
@@ -159,9 +173,19 @@ func telemetryValidation(sl validator.StructLevel) {
 	}
 }
 
+// endpointValidation is custom validation for the ProviderEndpoint struct.
+func endpointValidation(sl validator.StructLevel) {
+	endpoint := sl.Current().Interface().(ProviderEndpoint)
+
+	if len(endpoint.Name) < 1 || len(endpoint.Rest) < 1 || len(endpoint.Websocket) < 1 {
+		sl.ReportError(endpoint, "endpoint", "Endpoint", "unsupportedEndpointType", "")
+	}
+}
+
 // Validate returns an error if the Config object is invalid.
 func (c Config) Validate() error {
 	validate.RegisterStructValidation(telemetryValidation, Telemetry{})
+	validate.RegisterStructValidation(endpointValidation, ProviderEndpoint{})
 	return validate.Struct(c)
 }
 

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -107,6 +107,47 @@ func TestValidate(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"invalid endpoints",
+			config.Config{
+				Server: config.Server{
+					ListenAddr:     "0.0.0.0:7171",
+					VerboseCORS:    false,
+					AllowedOrigins: []string{},
+				},
+				CurrencyPairs: []config.CurrencyPair{
+					{Base: "ATOM", Quote: "USDT", Providers: []string{"kraken"}},
+				},
+				Account: config.Account{
+					Address:   "fromaddr",
+					Validator: "valaddr",
+					ChainID:   "chain-id",
+				},
+				Keyring: config.Keyring{
+					Backend: "test",
+					Dir:     "/Users/username/.umee",
+				},
+				RPC: config.RPC{
+					TMRPCEndpoint: "http://localhost:26657",
+					GRPCEndpoint:  "localhost:9090",
+					RPCTimeout:    "100ms",
+				},
+				Telemetry: config.Telemetry{
+					ServiceName:         "price-feeder",
+					Enabled:             true,
+					EnableHostname:      true,
+					EnableHostnameLabel: true,
+					EnableServiceLabel:  true,
+					GlobalLabels:        make([][]string, 1),
+					Type:                "generic",
+				},
+				GasAdjustment: 1.5,
+				ProviderEndpoints: []config.ProviderEndpoint{
+					{},
+				},
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -143,7 +143,54 @@ func TestValidate(t *testing.T) {
 				},
 				GasAdjustment: 1.5,
 				ProviderEndpoints: []config.ProviderEndpoint{
-					{},
+					{
+						Name: "binance",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"invalid endpoint provider",
+			config.Config{
+				Server: config.Server{
+					ListenAddr:     "0.0.0.0:7171",
+					VerboseCORS:    false,
+					AllowedOrigins: []string{},
+				},
+				CurrencyPairs: []config.CurrencyPair{
+					{Base: "ATOM", Quote: "USDT", Providers: []string{"kraken"}},
+				},
+				Account: config.Account{
+					Address:   "fromaddr",
+					Validator: "valaddr",
+					ChainID:   "chain-id",
+				},
+				Keyring: config.Keyring{
+					Backend: "test",
+					Dir:     "/Users/username/.umee",
+				},
+				RPC: config.RPC{
+					TMRPCEndpoint: "http://localhost:26657",
+					GRPCEndpoint:  "localhost:9090",
+					RPCTimeout:    "100ms",
+				},
+				Telemetry: config.Telemetry{
+					ServiceName:         "price-feeder",
+					Enabled:             true,
+					EnableHostname:      true,
+					EnableHostnameLabel: true,
+					EnableServiceLabel:  true,
+					GlobalLabels:        make([][]string, 1),
+					Type:                "generic",
+				},
+				GasAdjustment: 1.5,
+				ProviderEndpoints: []config.ProviderEndpoint{
+					{
+						Name:      "foo",
+						Rest:      "bar",
+						Websocket: "baz",
+					},
 				},
 			},
 			true,

--- a/price-feeder/oracle/oracle_test.go
+++ b/price-feeder/oracle/oracle_test.go
@@ -109,6 +109,7 @@ func (ots *OracleTestSuite) SetupSuite() {
 		},
 		time.Millisecond*100,
 		make(map[string]sdk.Dec),
+		make(map[string]config.ProviderEndpoint),
 	)
 }
 

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -88,9 +88,9 @@ func NewBinanceProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*BinanceProvider, error) {
-	if (endpoints.Name) != "binance" {
+	if (endpoints.Name) != config.ProviderBinance {
 		endpoints = config.ProviderEndpoint{
-			Name:      "binance",
+			Name:      config.ProviderBinance,
 			Rest:      binanceRestHost,
 			Websocket: binanceWSHost,
 		}

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	binanceHost          = "stream.binance.com:9443"
+	binanceWSHost        = "stream.binance.com:9443"
 	binancePath          = "/ws/umeestream"
-	binancePairsEndpoint = "https://api1.binance.com/api/v3/ticker/price"
+	binanceRestHost      = "https://api1.binance.com"
+	binancePairsEndpoint = "/api/v3/ticker/price"
 )
 
 var _ Provider = (*BinanceProvider)(nil)
@@ -36,6 +37,7 @@ type (
 		wsClient        *websocket.Conn
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
 		tickers         map[string]BinanceTicker      // Symbol => BinanceTicker
 		candles         map[string][]BinanceCandle    // Symbol => BinanceCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -83,11 +85,20 @@ type (
 func NewBinanceProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*BinanceProvider, error) {
+	if (endpoints.Name) != "binance" {
+		endpoints = config.ProviderEndpoint{
+			Name:      "binance",
+			Rest:      binanceRestHost,
+			Websocket: binanceWSHost,
+		}
+	}
+
 	wsURL := url.URL{
 		Scheme: "wss",
-		Host:   binanceHost,
+		Host:   endpoints.Websocket,
 		Path:   binancePath,
 	}
 
@@ -100,6 +111,7 @@ func NewBinanceProvider(
 		wsURL:           wsURL,
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "binance").Logger(),
+		endpoints:       endpoints,
 		tickers:         map[string]BinanceTicker{},
 		candles:         map[string][]BinanceCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -408,7 +420,7 @@ func (p *BinanceProvider) subscribePairs(pairs ...string) error {
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 // ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
 func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(binancePairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + binancePairsEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	binanceWSHost        = "stream.binance.com:9443"
-	binancePath          = "/ws/umeestream"
-	binanceRestHost      = "https://api1.binance.com"
-	binancePairsEndpoint = "/api/v3/ticker/price"
+	binanceWSHost   = "stream.binance.com:9443"
+	binanceWSPath   = "/ws/umeestream"
+	binanceRestHost = "https://api1.binance.com"
+	binanceRestPath = "/api/v3/ticker/price"
 )
 
 var _ Provider = (*BinanceProvider)(nil)
@@ -99,7 +99,7 @@ func NewBinanceProvider(
 	wsURL := url.URL{
 		Scheme: "wss",
 		Host:   endpoints.Websocket,
-		Path:   binancePath,
+		Path:   binanceWSPath,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -420,7 +420,7 @@ func (p *BinanceProvider) subscribePairs(pairs ...string) error {
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 // ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
 func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + binancePairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + binanceRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -7,11 +7,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestBinanceProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewBinanceProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -74,7 +80,12 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestBinanceProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewBinanceProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewBinanceProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -99,9 +99,9 @@ func NewCoinbaseProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*CoinbaseProvider, error) {
-	if endpoints.Name != "coinbase" {
+	if endpoints.Name != config.ProviderCoinbase {
 		endpoints = config.ProviderEndpoint{
-			Name:      "coinbase",
+			Name:      config.ProviderCoinbase,
 			Rest:      coinbaseRestHost,
 			Websocket: coinbaseWSHost,
 		}

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -21,12 +21,12 @@ import (
 )
 
 const (
-	coinbaseWSHost           = "ws-feed.exchange.coinbase.com"
-	coinbasePingCheck        = time.Second * 28 // should be < 30
-	coinbaseRestHost         = "https://api.exchange.coinbase.com"
-	coinbaseProductsEndpoint = "/products"
-	timeLayout               = "2006-01-02T15:04:05.000000Z"
-	unixMinute               = 60000
+	coinbaseWSHost    = "ws-feed.exchange.coinbase.com"
+	coinbasePingCheck = time.Second * 28 // should be < 30
+	coinbaseRestHost  = "https://api.exchange.coinbase.com"
+	coinbaseRestPath  = "/products"
+	timeLayout        = "2006-01-02T15:04:05.000000Z"
+	unixMinute        = 60000
 )
 
 var _ Provider = (*CoinbaseProvider)(nil)
@@ -247,7 +247,7 @@ func (p *CoinbaseProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) err
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *CoinbaseProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + coinbaseProductsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + coinbaseRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	coinbaseHost          = "ws-feed.exchange.coinbase.com"
-	coinbasePingCheck     = time.Second * 28 // should be < 30
-	coinbasePairsEndpoint = "https://api.exchange.coinbase.com/products"
-	timeLayout            = "2006-01-02T15:04:05.000000Z"
-	unixMinute            = 60000
+	coinbaseWSHost           = "ws-feed.exchange.coinbase.com"
+	coinbasePingCheck        = time.Second * 28 // should be < 30
+	coinbaseRestHost         = "https://api.exchange.coinbase.com"
+	coinbaseProductsEndpoint = "/products"
+	timeLayout               = "2006-01-02T15:04:05.000000Z"
+	unixMinute               = 60000
 )
 
 var _ Provider = (*CoinbaseProvider)(nil)
@@ -41,6 +42,7 @@ type (
 		logger          zerolog.Logger
 		reconnectTimer  *time.Ticker
 		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
 		trades          map[string][]CoinbaseTrade    // Symbol => []CoinbaseTrade
 		tickers         map[string]CoinbaseTicker     // Symbol => CoinbaseTicker
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -94,11 +96,19 @@ type (
 func NewCoinbaseProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*CoinbaseProvider, error) {
+	if endpoints.Name != "coinbase" {
+		endpoints = config.ProviderEndpoint{
+			Name:      "coinbase",
+			Rest:      coinbaseRestHost,
+			Websocket: coinbaseWSHost,
+		}
+	}
 	wsURL := url.URL{
 		Scheme: "wss",
-		Host:   coinbaseHost,
+		Host:   endpoints.Websocket,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -111,6 +121,7 @@ func NewCoinbaseProvider(
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "coinbase").Logger(),
 		reconnectTimer:  time.NewTicker(coinbasePingCheck),
+		endpoints:       endpoints,
 		trades:          map[string][]CoinbaseTrade{},
 		tickers:         map[string]CoinbaseTicker{},
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -236,7 +247,7 @@ func (p *CoinbaseProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) err
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *CoinbaseProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(coinbasePairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + coinbaseProductsEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/coinbase_test.go
+++ b/price-feeder/oracle/provider/coinbase_test.go
@@ -7,11 +7,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewCoinbaseProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	p, err := NewCoinbaseProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -71,7 +77,12 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestCoinbaseProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewCoinbaseProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewCoinbaseProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	gateWSHost        = "ws.gate.io"
-	gatePath          = "/v3"
-	gatePingCheck     = time.Second * 28 // should be < 30
-	gateRestHost      = "https://api.gateio.ws"
-	gatePairsEndpoint = "/api/v4/spot/currency_pairs"
+	gateWSHost    = "ws.gate.io"
+	gateWSPath    = "/v3"
+	gatePingCheck = time.Second * 28 // should be < 30
+	gateRestHost  = "https://api.gateio.ws"
+	gateRestPath  = "/api/v4/spot/currency_pairs"
 )
 
 var _ Provider = (*GateProvider)(nil)
@@ -122,7 +122,7 @@ func NewGateProvider(
 	wsURL := url.URL{
 		Scheme: "wss",
 		Host:   endpoints.Websocket,
-		Path:   gatePath,
+		Path:   gateWSPath,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -580,7 +580,7 @@ func (p *GateProvider) pongHandler(appData string) error {
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *GateProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + gatePairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + gateRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -105,7 +105,12 @@ type (
 )
 
 // NewGateProvider creates a new GateProvider.
-func NewGateProvider(ctx context.Context, logger zerolog.Logger, endpoints config.ProviderEndpoint, pairs ...types.CurrencyPair) (*GateProvider, error) {
+func NewGateProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
+	pairs ...types.CurrencyPair,
+) (*GateProvider, error) {
 	if endpoints.Name != "gate" {
 		endpoints = config.ProviderEndpoint{
 			Name:      "gate",

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -111,9 +111,9 @@ func NewGateProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*GateProvider, error) {
-	if endpoints.Name != "gate" {
+	if endpoints.Name != config.ProviderGate {
 		endpoints = config.ProviderEndpoint{
-			Name:      "gate",
+			Name:      config.ProviderGate,
 			Rest:      gateRestHost,
 			Websocket: gateWSHost,
 		}

--- a/price-feeder/oracle/provider/gate_test.go
+++ b/price-feeder/oracle/provider/gate_test.go
@@ -7,11 +7,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestGateProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewGateProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewGateProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -74,7 +80,12 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestGateProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewGateProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewGateProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	huobiWSHost          = "api-aws.huobi.pro"
-	huobiPath            = "/ws"
-	huobiReconnectTime   = time.Minute * 2
-	huobiRestHost        = "https://api.huobi.pro"
-	huobiTickersEndpoint = "/market/tickers"
+	huobiWSHost        = "api-aws.huobi.pro"
+	huobiWSPath        = "/ws"
+	huobiReconnectTime = time.Minute * 2
+	huobiRestHost      = "https://api.huobi.pro"
+	huobiRestPath      = "/market/tickers"
 )
 
 var _ Provider = (*HuobiProvider)(nil)
@@ -111,7 +111,7 @@ func NewHuobiProvider(
 	wsURL := url.URL{
 		Scheme: "wss",
 		Host:   endpoints.Websocket,
-		Path:   huobiPath,
+		Path:   huobiWSPath,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -459,7 +459,7 @@ func (p *HuobiProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *HuobiProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + huobiTickersEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + huobiRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -100,9 +100,9 @@ func NewHuobiProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*HuobiProvider, error) {
-	if endpoints.Name != "huobi" {
+	if endpoints.Name != config.ProviderHuobi {
 		endpoints = config.ProviderEndpoint{
-			Name:      "huobi",
+			Name:      config.ProviderHuobi,
 			Rest:      huobiRestHost,
 			Websocket: huobiWSHost,
 		}

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -22,10 +22,11 @@ import (
 )
 
 const (
-	huobiHost          = "api-aws.huobi.pro"
-	huobiPath          = "/ws"
-	huobiReconnectTime = time.Minute * 2
-	huobiPairsEndpoint = "https://api.huobi.pro/market/tickers"
+	huobiWSHost          = "api-aws.huobi.pro"
+	huobiPath            = "/ws"
+	huobiReconnectTime   = time.Minute * 2
+	huobiRestHost        = "https://api.huobi.pro"
+	huobiTickersEndpoint = "/market/tickers"
 )
 
 var _ Provider = (*HuobiProvider)(nil)
@@ -41,6 +42,7 @@ type (
 		wsClient        *websocket.Conn
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
 		tickers         map[string]HuobiTicker        // market.$symbol.ticker => HuobiTicker
 		candles         map[string][]HuobiCandle      // market.$symbol.kline.$period => HuobiCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -92,10 +94,18 @@ type (
 )
 
 // NewHuobiProvider returns a new Huobi provider with the WS connection and msg handler.
-func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.CurrencyPair) (*HuobiProvider, error) {
+func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, endpoints config.ProviderEndpoint, pairs ...types.CurrencyPair) (*HuobiProvider, error) {
+	if endpoints.Name != "huobi" {
+		endpoints = config.ProviderEndpoint{
+			Name:      "huobi",
+			Rest:      huobiRestHost,
+			Websocket: huobiWSHost,
+		}
+	}
+
 	wsURL := url.URL{
 		Scheme: "wss",
-		Host:   huobiHost,
+		Host:   endpoints.Websocket,
 		Path:   huobiPath,
 	}
 
@@ -108,6 +118,7 @@ func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, pairs ...types
 		wsURL:           wsURL,
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "huobi").Logger(),
+		endpoints:       endpoints,
 		tickers:         map[string]HuobiTicker{},
 		candles:         map[string][]HuobiCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -443,7 +454,7 @@ func (p *HuobiProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *HuobiProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(huobiPairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + huobiTickersEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -94,7 +94,12 @@ type (
 )
 
 // NewHuobiProvider returns a new Huobi provider with the WS connection and msg handler.
-func NewHuobiProvider(ctx context.Context, logger zerolog.Logger, endpoints config.ProviderEndpoint, pairs ...types.CurrencyPair) (*HuobiProvider, error) {
+func NewHuobiProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
+	pairs ...types.CurrencyPair,
+) (*HuobiProvider, error) {
 	if endpoints.Name != "huobi" {
 		endpoints = config.ProviderEndpoint{
 			Name:      "huobi",

--- a/price-feeder/oracle/provider/huobi_test.go
+++ b/price-feeder/oracle/provider/huobi_test.go
@@ -8,11 +8,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestHuobiProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewHuobiProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewHuobiProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -81,7 +87,12 @@ func TestHuobiProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestHuobiProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewHuobiProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewHuobiProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -21,7 +21,7 @@ import (
 const (
 	krakenWSHost                  = "ws.kraken.com"
 	KrakenRestHost                = "https://api.kraken.com"
-	KrakenPairsEndpoint           = "/0/public/AssetPairs"
+	KrakenRestPath                = "/0/public/AssetPairs"
 	krakenEventSystemStatus       = "systemStatus"
 	krakenEventSubscriptionStatus = "subscriptionStatus"
 )
@@ -627,7 +627,7 @@ func (p *KrakenProvider) removeSubscribedTickers(tickerSymbols ...string) {
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *KrakenProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + KrakenPairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + KrakenRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -107,9 +107,9 @@ func NewKrakenProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*KrakenProvider, error) {
-	if endpoints.Name != "kraken" {
+	if endpoints.Name != config.ProviderKraken {
 		endpoints = config.ProviderEndpoint{
-			Name:      "kraken",
+			Name:      config.ProviderKraken,
 			Rest:      KrakenRestHost,
 			Websocket: krakenWSHost,
 		}

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	krakenHost                    = "ws.kraken.com"
-	KrakenPairsEndpoint           = "https://api.kraken.com/0/public/AssetPairs"
+	krakenWSHost                  = "ws.kraken.com"
+	KrakenRestHost                = "https://api.kraken.com"
+	KrakenPairsEndpoint           = "/0/public/AssetPairs"
 	krakenEventSystemStatus       = "systemStatus"
 	krakenEventSubscriptionStatus = "subscriptionStatus"
 )
@@ -37,6 +38,7 @@ type (
 		wsClient        *websocket.Conn
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
 		tickers         map[string]TickerPrice        // Symbol => TickerPrice
 		candles         map[string][]KrakenCandle     // Symbol => KrakenCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -102,11 +104,20 @@ type (
 func NewKrakenProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*KrakenProvider, error) {
+	if endpoints.Name != "kraken" {
+		endpoints = config.ProviderEndpoint{
+			Name:      "kraken",
+			Rest:      KrakenRestHost,
+			Websocket: krakenWSHost,
+		}
+	}
+
 	wsURL := url.URL{
 		Scheme: "wss",
-		Host:   krakenHost,
+		Host:   endpoints.Websocket,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -118,6 +129,7 @@ func NewKrakenProvider(
 		wsURL:           wsURL,
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "kraken").Logger(),
+		endpoints:       endpoints,
 		tickers:         map[string]TickerPrice{},
 		candles:         map[string][]KrakenCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -615,7 +627,7 @@ func (p *KrakenProvider) removeSubscribedTickers(tickerSymbols ...string) {
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *KrakenProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(KrakenPairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + KrakenPairsEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/kraken_test.go
+++ b/price-feeder/oracle/provider/kraken_test.go
@@ -7,11 +7,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestKrakenProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewKrakenProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	p, err := NewKrakenProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -71,7 +77,12 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestKrakenProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewKrakenProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewKrakenProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -20,11 +20,11 @@ import (
 )
 
 const (
-	okxWSHost          = "ws.okx.com:8443"
-	okxPath            = "/ws/v5/public"
-	okxPingCheck       = time.Second * 28 // should be < 30
-	okxRestHost        = "https://www.okx.com"
-	okxTickersEndpoint = "/api/v5/market/tickers?instType=SPOT"
+	okxWSHost    = "ws.okx.com:8443"
+	okxWSPath    = "/ws/v5/public"
+	okxPingCheck = time.Second * 28 // should be < 30
+	okxRestHost  = "https://www.okx.com"
+	okxRestPath  = "/api/v5/market/tickers?instType=SPOT"
 )
 
 var _ Provider = (*OkxProvider)(nil)
@@ -120,7 +120,7 @@ func NewOkxProvider(
 	wsURL := url.URL{
 		Scheme: "wss",
 		Host:   endpoints.Websocket,
-		Path:   okxPath,
+		Path:   okxWSPath,
 	}
 
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
@@ -459,7 +459,7 @@ func (p *OkxProvider) pongHandler(appData string) error {
 
 // GetAvailablePairs return all available pairs symbol to susbscribe.
 func (p *OkxProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + okxTickersEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + okxRestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -109,9 +109,9 @@ func NewOkxProvider(
 	endpoints config.ProviderEndpoint,
 	pairs ...types.CurrencyPair,
 ) (*OkxProvider, error) {
-	if endpoints.Name != "okx" {
+	if endpoints.Name != config.ProviderOkx {
 		endpoints = config.ProviderEndpoint{
-			Name:      "okx",
+			Name:      config.ProviderOkx,
 			Rest:      okxRestHost,
 			Websocket: okxWSHost,
 		}

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	okxHost          = "ws.okx.com:8443"
-	okxPath          = "/ws/v5/public"
-	okxPingCheck     = time.Second * 28 // should be < 30
-	okxPairsEndpoint = "https://www.okx.com/api/v5/market/tickers?instType=SPOT"
+	okxWSHost          = "ws.okx.com:8443"
+	okxPath            = "/ws/v5/public"
+	okxPingCheck       = time.Second * 28 // should be < 30
+	okxRestHost        = "https://www.okx.com"
+	okxTickersEndpoint = "/api/v5/market/tickers?instType=SPOT"
 )
 
 var _ Provider = (*OkxProvider)(nil)
@@ -39,6 +40,7 @@ type (
 		logger          zerolog.Logger
 		reconnectTimer  *time.Ticker
 		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
 		tickers         map[string]OkxTickerPair      // InstId => OkxTickerPair
 		candles         map[string][]OkxCandlePair    // InstId => 0kxCandlePair
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -101,10 +103,23 @@ type (
 )
 
 // NewOkxProvider creates a new OkxProvider.
-func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.CurrencyPair) (*OkxProvider, error) {
+func NewOkxProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
+	pairs ...types.CurrencyPair,
+) (*OkxProvider, error) {
+	if endpoints.Name != "okx" {
+		endpoints = config.ProviderEndpoint{
+			Name:      "okx",
+			Rest:      okxRestHost,
+			Websocket: okxWSHost,
+		}
+	}
+
 	wsURL := url.URL{
 		Scheme: "wss",
-		Host:   okxHost,
+		Host:   endpoints.Websocket,
 		Path:   okxPath,
 	}
 
@@ -118,6 +133,7 @@ func NewOkxProvider(ctx context.Context, logger zerolog.Logger, pairs ...types.C
 		wsClient:        wsConn,
 		logger:          logger.With().Str("provider", "okx").Logger(),
 		reconnectTimer:  time.NewTicker(okxPingCheck),
+		endpoints:       endpoints,
 		tickers:         map[string]OkxTickerPair{},
 		candles:         map[string][]OkxCandlePair{},
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -443,7 +459,7 @@ func (p *OkxProvider) pongHandler(appData string) error {
 
 // GetAvailablePairs return all available pairs symbol to susbscribe.
 func (p *OkxProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(okxPairsEndpoint)
+	resp, err := http.Get(p.endpoints.Rest + okxTickersEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/price-feeder/oracle/provider/okx_test.go
+++ b/price-feeder/oracle/provider/okx_test.go
@@ -7,11 +7,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestOkxProvider_GetTickerPrices(t *testing.T) {
-	p, err := NewOkxProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "BTC", Quote: "USDT"})
+	p, err := NewOkxProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
@@ -80,7 +86,12 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestOkxProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewOkxProvider(context.TODO(), zerolog.Nop(), types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+	p, err := NewOkxProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
 	require.NoError(t, err)
 
 	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -62,7 +62,7 @@ type (
 )
 
 func NewOsmosisProvider(endpoint config.ProviderEndpoint) *OsmosisProvider {
-	if endpoint.Name == "osmosis" {
+	if endpoint.Name == config.ProviderOsmosis {
 		return &OsmosisProvider{
 			baseURL: endpoint.Rest,
 			client:  newDefaultHTTPClient(),

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -7,14 +7,14 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 const (
-	osmosisBaseURL        = "https://api-osmosis.imperator.co"
+	osmosisRestURL        = "https://api-osmosis.imperator.co"
 	osmosisTokenEndpoint  = "/tokens/v1"
 	osmosisCandleEndpoint = "/tokens/v2/historical"
 	osmosisPairsEndpoint  = "/pairs/v1/summary"
@@ -61,17 +61,16 @@ type (
 	}
 )
 
-func NewOsmosisProvider() *OsmosisProvider {
-	return &OsmosisProvider{
-		baseURL: osmosisBaseURL,
-		client:  newDefaultHTTPClient(),
+func NewOsmosisProvider(endpoint config.ProviderEndpoint) *OsmosisProvider {
+	if endpoint.Name == "osmosis" {
+		return &OsmosisProvider{
+			baseURL: endpoint.Rest,
+			client:  newDefaultHTTPClient(),
+		}
 	}
-}
-
-func NewOsmosisProviderWithTimeout(timeout time.Duration) *OsmosisProvider {
 	return &OsmosisProvider{
-		baseURL: osmosisBaseURL,
-		client:  newHTTPClientWithTimeout(timeout),
+		baseURL: osmosisRestURL,
+		client:  newDefaultHTTPClient(),
 	}
 }
 

--- a/price-feeder/oracle/provider/osmosis_test.go
+++ b/price-feeder/oracle/provider/osmosis_test.go
@@ -7,11 +7,12 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	"github.com/umee-network/umee/price-feeder/config"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
-	p := NewOsmosisProvider()
+	p := NewOsmosisProvider(config.ProviderEndpoint{})
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -156,7 +157,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestOsmosisProvider_GetAvailablePairs(t *testing.T) {
-	p := NewOsmosisProvider()
+	p := NewOsmosisProvider(config.ProviderEndpoint{})
 	p.GetAvailablePairs()
 
 	t.Run("valid_available_pair", func(t *testing.T) {

--- a/price-feeder/price-feeder.example.toml
+++ b/price-feeder/price-feeder.example.toml
@@ -56,3 +56,8 @@ enabled = true
 global_labels = [["chain-id", "umee-local-testnet"]]
 service_name = "price-feeder"
 type = "prometheus"
+
+[[provider_endpoints]]
+name = "binance"
+rest = "https://api1.binance.com"
+websocket = "stream.binance.com:9443"


### PR DESCRIPTION
## Description

Adds a feature which would allow validators to customize which websocket / rest URIs that they'd like to use. Very useful in case one of these is removed or renamed 😄 

closes: #1031

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
