### PR TITLE
chore!: rename leverage message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [1023](https://github.com/umee-network/umee/pull/1023) Restrict MsgWithdraw to only uToken input (no base token auto-convert)
 - [1106](https://github.com/umee-network/umee/pull/1106) Rename Lend to Supply, including MsgLendAsset, Token EnableLend, docs, and internal functions. Also QueryLoaned similar queries to QuerySupplied.
 - [1113](https://github.com/umee-network/umee/pull/1113) Rename Amount field to Asset when sdk.Coin type in Msg proto.
+- [xxxx](https://github.com/umee-network/umee/pull/xxxx) Rename MsgWithdrawAsset, MsgBorrowAsset, MsgRepayAsset, MsgAddCollateral, and MsgRemoveCollateral to MsgWithdraw, MsgBorrow, MsgRepay, MsgCollateralize, MsgDecollateralize.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [1023](https://github.com/umee-network/umee/pull/1023) Restrict MsgWithdraw to only uToken input (no base token auto-convert)
 - [1106](https://github.com/umee-network/umee/pull/1106) Rename Lend to Supply, including MsgLendAsset, Token EnableLend, docs, and internal functions. Also QueryLoaned similar queries to QuerySupplied.
 - [1113](https://github.com/umee-network/umee/pull/1113) Rename Amount field to Asset when sdk.Coin type in Msg proto.
-- [xxxx](https://github.com/umee-network/umee/pull/xxxx) Rename MsgWithdrawAsset, MsgBorrowAsset, MsgRepayAsset, MsgAddCollateral, and MsgRemoveCollateral to MsgWithdraw, MsgBorrow, MsgRepay, MsgCollateralize, MsgDecollateralize.
+- [1122](https://github.com/umee-network/umee/pull/1122) Rename MsgWithdrawAsset, MsgBorrowAsset, MsgRepayAsset, MsgAddCollateral, and MsgRemoveCollateral to MsgWithdraw, MsgBorrow, MsgRepay, MsgCollateralize, MsgDecollateralize.
 
 ### Features
 

--- a/docs/architecture/ADR-002-deposit-assets.md
+++ b/docs/architecture/ADR-002-deposit-assets.md
@@ -33,9 +33,9 @@ message MsgLendAsset {
 
 When a user supplies tokens, the tokens are moved to the `x/leverage` module account. Simultaneously, uTokens are minted and sent to the user's wallet. The module uses its current token:uToken exchange rate.
 
-// MsgWithdrawAsset represents a user's request to withdraw supplied assets.
+// MsgWithdraw represents a user's request to withdraw supplied assets.
 // Coin denomination must be a uToken.
-message MsgWithdrawAsset {
+message MsgWithdraw {
   string                   supplier = 1;
   cosmos.base.v1beta1.Coin coin     = 2 [(gogoproto.nullable) = false];
 }

--- a/docs/architecture/ADR-003-borrow-assets.md
+++ b/docs/architecture/ADR-003-borrow-assets.md
@@ -132,15 +132,15 @@ type MsgSetCollateral struct {
   Enable   bool
 }
 
-// MsgBorrowAsset - a user wishes to borrow assets of an allowed type
-type MsgBorrowAsset struct {
+// MsgBorrow - a user wishes to borrow assets of an allowed type
+type MsgBorrow struct {
   Borrower sdk.AccAddress
   // not a uToken
   Asset   sdk.Coin
 }
 
-// MsgRepayAsset - a user wishes to repay assets of a borrowed type
-type MsgRepayAsset struct {
+// MsgRepay - a user wishes to repay assets of a borrowed type
+type MsgRepay struct {
   Borrower sdk.AccAddress
   Asset    sdk.Coin
 }

--- a/docs/architecture/ADR-004-interest-and-reserves.md
+++ b/docs/architecture/ADR-004-interest-and-reserves.md
@@ -107,7 +107,7 @@ Reserve amount is stored for each denom using the following format:
 KeyPrefixReserveAmount | denom | 0 -> sdk.Int
 ```
 
-Reserves are part of the module account's balance, but may not leave the module account as the result of `MsgBorrowAsset` or `MsgWithdrawAsset`. Only governance actions (outside the scope of this ADR) may release or transfer reserves.
+Reserves are part of the module account's balance, but may not leave the module account as the result of `MsgBorrow` or `MsgWithdraw`. Only governance actions (outside the scope of this ADR) may release or transfer reserves.
 
 Reserve balance is updated in the `AccrueAllInterest` function:
 
@@ -171,7 +171,7 @@ The scenario above is not fatal to our model - Bob (supplier) continues to gain 
 
 The edge case above can only occur when the available lending pool (i.e. module account balance minus reserve requirements) for a specific token denomination, is less than `ReserveFactor` times the interest accrued on all open loans for that token in a single block. In practical terms, that means ~100% supply utilization.
 
-This is not a threatening scenario, as it resolves as soon as either a sufficient `RepayAsset` or a `MsgSupply` is made in the relevant asset type, both of which are **highly** incentivized by the extreme dynamic interest rates found near 100% utilization.
+This is not a threatening scenario, as it resolves as soon as either a sufficient `Repay` or a `MsgSupply` is made in the relevant asset type, both of which are **highly** incentivized by the extreme dynamic interest rates found near 100% utilization.
 
 ## Consequences
 

--- a/docs/architecture/ADR-004-interest-and-reserves.md
+++ b/docs/architecture/ADR-004-interest-and-reserves.md
@@ -171,7 +171,7 @@ The scenario above is not fatal to our model - Bob (supplier) continues to gain 
 
 The edge case above can only occur when the available lending pool (i.e. module account balance minus reserve requirements) for a specific token denomination, is less than `ReserveFactor` times the interest accrued on all open loans for that token in a single block. In practical terms, that means ~100% supply utilization.
 
-This is not a threatening scenario, as it resolves as soon as either a sufficient `Repay` or a `MsgSupply` is made in the relevant asset type, both of which are **highly** incentivized by the extreme dynamic interest rates found near 100% utilization.
+This is not a threatening scenario, as it resolves as soon as either a sufficient `MsgRepay` or a `MsgSupply` is made in the relevant asset type, both of which are **highly** incentivized by the extreme dynamic interest rates found near 100% utilization.
 
 ## Consequences
 

--- a/proto/umee/leverage/v1/tx.proto
+++ b/proto/umee/leverage/v1/tx.proto
@@ -8,30 +8,29 @@ option go_package = "github.com/umee-network/umee/v2/x/leverage/types";
 
 // Msg defines the x/leverage module's Msg service.
 service Msg {
-  // Supply moves tokens from user balance to the module balance for lending or collateral.
+  // Supply moves tokens from user balance to the module for lending or collateral.
+  // The user receives uTokens in return.
   rpc Supply(MsgSupply) returns (MsgSupplyResponse);
 
-  // WithdrawAsset defines a method for withdrawing previously supplied coins from
-  // the capital facility.
-  rpc WithdrawAsset(MsgWithdrawAsset) returns (MsgWithdrawAssetResponse);
+  // Withdraw moves previously supplied tokens from the module back to the user balance in
+  // exchange for burning uTokens.
+  rpc Withdraw(MsgWithdraw) returns (MsgWithdrawResponse);
 
-  // AddCollateral defines a method for users to enable selected uTokens
-  // as collateral.
-  rpc AddCollateral(MsgAddCollateral) returns (MsgAddCollateralResponse);
+  // Collateralize enables selected uTokens as collateral, which moves them to the module.
+  rpc Collateralize(MsgCollateralize) returns (MsgCollateralizeResponse);
 
-  // RemoveCollateral defines a method for users to disable selected uTokens
-  // as collateral.
-  rpc RemoveCollateral(MsgRemoveCollateral) returns (MsgRemoveCollateralResponse);
+  // Decollateralize disables selected uTokens as collateral. They are returned to the user's
+  // balance from the module.
+  rpc Decollateralize(MsgDecollateralize) returns (MsgDecollateralizeResponse);
 
-  // BorrowAsset defines a method for borrowing coins from the capital facility.
-  rpc BorrowAsset(MsgBorrowAsset) returns (MsgBorrowAssetResponse);
+  // Borrow allows a user to borrow tokens from the module if they have sufficient collateral.
+  rpc Borrow(MsgBorrow) returns (MsgBorrowResponse);
 
-  // RepayAsset defines a method for repaying borrowed coins to the capital
-  // facility.
-  rpc RepayAsset(MsgRepayAsset) returns (MsgRepayAssetResponse);
+  // Repay allows a user to repay previously borrowed tokens and interest.
+  rpc Repay(MsgRepay) returns (MsgRepayResponse);
 
-  // Liquidate defines a method for repaying a different user's borrowed coins
-  // to the capital facility in exchange for some of their collateral.
+  // Liquidate allows a user to repay a different user's borrowed coins in exchange for some
+  // of their collateral.
   rpc Liquidate(MsgLiquidate) returns (MsgLiquidateResponse);
 }
 
@@ -42,42 +41,42 @@ message MsgSupply {
   cosmos.base.v1beta1.Coin asset    = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgWithdrawAsset represents a user's request to withdraw supplied assets.
+// MsgWithdraw represents a user's request to withdraw supplied assets.
 // Asset must be a uToken.
-message MsgWithdrawAsset {
+message MsgWithdraw {
   // Supplier is the account address withdrawing assets and the signer of the message.
   string                   supplier = 1;
   cosmos.base.v1beta1.Coin asset    = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgAddCollateral represents a user's request to enable selected
+// MsgCollateralize represents a user's request to enable selected
 // uTokens as collateral.
-message MsgAddCollateral {
+message MsgCollateralize {
   // Borrower is the account address adding collateral and the signer of the message.
   string                   borrower = 1;
   cosmos.base.v1beta1.Coin coin     = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgRemoveCollateral represents a user's request to disable selected
+// MsgDecollateralize represents a user's request to disable selected
 // uTokens as collateral.
-message MsgRemoveCollateral {
+message MsgDecollateralize {
   // Borrower is the account address removing collateral and the signer of the message.
   string                   borrower = 1;
   cosmos.base.v1beta1.Coin coin     = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgBorrowAsset represents a user's request to borrow a base asset type
+// MsgBorrow represents a user's request to borrow a base asset type
 // from the module.
-message MsgBorrowAsset {
+message MsgBorrow {
   // Borrower is the account address taking a loan and the signer
   // of the message.
   string                   borrower = 1;
   cosmos.base.v1beta1.Coin asset    = 2 [(gogoproto.nullable) = false];
 }
 
-// MsgRepayAsset represents a user's request to repay a borrowed base asset
+// MsgRepay represents a user's request to repay a borrowed base asset
 // type to the module.
-message MsgRepayAsset {
+message MsgRepay {
   // Borrower is the account address repaying a loan and the signer
   // of the message.
   string                   borrower = 1;
@@ -98,20 +97,20 @@ message MsgLiquidate {
 // MsgSupplyResponse defines the Msg/Supply response type.
 message MsgSupplyResponse {}
 
-// MsgWithdrawAssetResponse defines the Msg/WithdrawAsset response type.
-message MsgWithdrawAssetResponse {}
+// MsgWithdrawResponse defines the Msg/Withdraw response type.
+message MsgWithdrawResponse {}
 
-// MsgAddCollateralResponse defines the Msg/AddCollateral response type.
-message MsgAddCollateralResponse {}
+// MsgCollateralizeResponse defines the Msg/Collateralize response type.
+message MsgCollateralizeResponse {}
 
-// MsgRemoveCollateralResponse defines the Msg/RemoveCollateral response type.
-message MsgRemoveCollateralResponse {}
+// MsgDecollateralizeResponse defines the Msg/Decollateralize response type.
+message MsgDecollateralizeResponse {}
 
-// MsgBorrowAssetResponse defines the Msg/BorrowAsset response type.
-message MsgBorrowAssetResponse {}
+// MsgBorrowResponse defines the Msg/Borrow response type.
+message MsgBorrowResponse {}
 
-// MsgRepayAssetResponse defines the Msg/RepayAsset response type.
-message MsgRepayAssetResponse {
+// MsgRepayResponse defines the Msg/Repay response type.
+message MsgRepayResponse {
   cosmos.base.v1beta1.Coin repaid = 1 [(gogoproto.nullable) = false];
 }
 

--- a/x/leverage/client/cli/tx.go
+++ b/x/leverage/client/cli/tx.go
@@ -26,11 +26,11 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		GetCmdSupply(),
-		GetCmdWithdrawAsset(),
-		GetCmdAddCollateral(),
-		GetCmdRemoveCollateral(),
-		GetCmdBorrowAsset(),
-		GetCmdRepayAsset(),
+		GetCmdWithdraw(),
+		GetCmdCollateralize(),
+		GetCmdDecollateralize(),
+		GetCmdBorrow(),
+		GetCmdRepay(),
 		GetCmdLiquidate(),
 	)
 
@@ -70,9 +70,9 @@ func GetCmdSupply() *cobra.Command {
 	return cmd
 }
 
-// GetCmdWithdrawAsset creates a Cobra command to generate or broadcast a
-// transaction with a MsgWithdrawAsset message.
-func GetCmdWithdrawAsset() *cobra.Command {
+// GetCmdWithdraw creates a Cobra command to generate or broadcast a
+// transaction with a MsgWithdraw message.
+func GetCmdWithdraw() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "withdraw-asset [supplier] [amount]",
 		Args:  cobra.ExactArgs(2),
@@ -92,7 +92,7 @@ func GetCmdWithdrawAsset() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgWithdrawAsset(clientCtx.GetFromAddress(), asset)
+			msg := types.NewMsgWithdraw(clientCtx.GetFromAddress(), asset)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -103,9 +103,9 @@ func GetCmdWithdrawAsset() *cobra.Command {
 	return cmd
 }
 
-// GetCmdAddCollateral creates a Cobra command to generate or broadcast a
-// transaction with a MsgAddCollateral message.
-func GetCmdAddCollateral() *cobra.Command {
+// GetCmdCollateralize creates a Cobra command to generate or broadcast a
+// transaction with a MsgCollateralize message.
+func GetCmdCollateralize() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-collateral [borrower] [coin]",
 		Args:  cobra.ExactArgs(2),
@@ -124,7 +124,7 @@ func GetCmdAddCollateral() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			msg := types.NewMsgAddCollateral(clientCtx.GetFromAddress(), coin)
+			msg := types.NewMsgCollateralize(clientCtx.GetFromAddress(), coin)
 			if err = msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -138,9 +138,9 @@ func GetCmdAddCollateral() *cobra.Command {
 	return cmd
 }
 
-// GetCmdRemoveCollateral returns a CLI command handler to generate or broadcast a
-// transaction with a MsgRemoveCollateral message.
-func GetCmdRemoveCollateral() *cobra.Command {
+// GetCmdDecollateralize returns a CLI command handler to generate or broadcast a
+// transaction with a MsgDecollateralize message.
+func GetCmdDecollateralize() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove-collateral [borrower] [coin]",
 		Args:  cobra.ExactArgs(2),
@@ -159,7 +159,7 @@ func GetCmdRemoveCollateral() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			msg := types.NewMsgRemoveCollateral(clientCtx.GetFromAddress(), coin)
+			msg := types.NewMsgDecollateralize(clientCtx.GetFromAddress(), coin)
 			if err = msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -173,9 +173,9 @@ func GetCmdRemoveCollateral() *cobra.Command {
 	return cmd
 }
 
-// GetCmdBorrowAsset creates a Cobra command to generate or broadcast a
-// transaction with a MsgBorrowAsset message.
-func GetCmdBorrowAsset() *cobra.Command {
+// GetCmdBorrow creates a Cobra command to generate or broadcast a
+// transaction with a MsgBorrow message.
+func GetCmdBorrow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "borrow-asset [borrower] [amount]",
 		Args:  cobra.ExactArgs(2),
@@ -195,7 +195,7 @@ func GetCmdBorrowAsset() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgBorrowAsset(clientCtx.GetFromAddress(), asset)
+			msg := types.NewMsgBorrow(clientCtx.GetFromAddress(), asset)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -206,9 +206,9 @@ func GetCmdBorrowAsset() *cobra.Command {
 	return cmd
 }
 
-// GetCmdRepayAsset creates a Cobra command to generate or broadcast a
-// transaction with a MsgRepayAsset message.
-func GetCmdRepayAsset() *cobra.Command {
+// GetCmdRepay creates a Cobra command to generate or broadcast a
+// transaction with a MsgRepay message.
+func GetCmdRepay() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repay-asset [borrower] [amount]",
 		Args:  cobra.ExactArgs(2),
@@ -228,7 +228,7 @@ func GetCmdRepayAsset() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgRepayAsset(clientCtx.GetFromAddress(), asset)
+			msg := types.NewMsgRepay(clientCtx.GetFromAddress(), asset)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/leverage/client/cli/tx.go
+++ b/x/leverage/client/cli/tx.go
@@ -41,7 +41,7 @@ func GetTxCmd() *cobra.Command {
 // transaction with a MsgSupply message.
 func GetCmdSupply() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "supply-asset [supplier] [amount]",
+		Use:   "supply [supplier] [amount]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Supply a specified amount of a supported asset",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +74,7 @@ func GetCmdSupply() *cobra.Command {
 // transaction with a MsgWithdraw message.
 func GetCmdWithdraw() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "withdraw-asset [supplier] [amount]",
+		Use:   "withdraw [supplier] [amount]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Withdraw a specified amount of a supplied asset",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -107,7 +107,7 @@ func GetCmdWithdraw() *cobra.Command {
 // transaction with a MsgCollateralize message.
 func GetCmdCollateralize() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add-collateral [borrower] [coin]",
+		Use:   "collateralize [borrower] [coin]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Add uTokens as collateral",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -142,7 +142,7 @@ func GetCmdCollateralize() *cobra.Command {
 // transaction with a MsgDecollateralize message.
 func GetCmdDecollateralize() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove-collateral [borrower] [coin]",
+		Use:   "decollateralize [borrower] [coin]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Remove uTokens from collateral",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -177,7 +177,7 @@ func GetCmdDecollateralize() *cobra.Command {
 // transaction with a MsgBorrow message.
 func GetCmdBorrow() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "borrow-asset [borrower] [amount]",
+		Use:   "borrow [borrower] [amount]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Borrow a specified amount of a supported asset",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -210,7 +210,7 @@ func GetCmdBorrow() *cobra.Command {
 // transaction with a MsgRepay message.
 func GetCmdRepay() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "repay-asset [borrower] [amount]",
+		Use:   "repay [borrower] [amount]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Repay a specified amount of a borrowed asset",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/leverage/client/tests/tests.go
+++ b/x/leverage/client/tests/tests.go
@@ -341,7 +341,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	addCollateral := testTransaction{
 		"add collateral",
-		cli.GetCmdAddCollateral(),
+		cli.GetCmdCollateralize(),
 		[]string{
 			val.Address.String(),
 			"1000u/uumee",
@@ -351,7 +351,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	borrow := testTransaction{
 		"borrow",
-		cli.GetCmdBorrowAsset(),
+		cli.GetCmdBorrow(),
 		[]string{
 			val.Address.String(),
 			"50uumee",
@@ -373,7 +373,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	fixCollateral := testTransaction{
 		"add back collateral received from liquidation",
-		cli.GetCmdAddCollateral(),
+		cli.GetCmdCollateralize(),
 		[]string{
 			val.Address.String(),
 			"4u/uumee",
@@ -383,7 +383,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	repay := testTransaction{
 		"repay",
-		cli.GetCmdRepayAsset(),
+		cli.GetCmdRepay(),
 		[]string{
 			val.Address.String(),
 			"51uumee",
@@ -393,7 +393,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	removeCollateral := testTransaction{
 		"remove collateral",
-		cli.GetCmdRemoveCollateral(),
+		cli.GetCmdDecollateralize(),
 		[]string{
 			val.Address.String(),
 			"1000u/uumee",
@@ -403,7 +403,7 @@ func (s *IntegrationTestSuite) TestLeverageScenario() {
 
 	withdraw := testTransaction{
 		"withdraw",
-		cli.GetCmdWithdrawAsset(),
+		cli.GetCmdWithdraw(),
 		[]string{
 			val.Address.String(),
 			"1000u/uumee",

--- a/x/leverage/keeper/borrows_test.go
+++ b/x/leverage/keeper/borrows_test.go
@@ -134,7 +134,7 @@ func (s *IntegrationTestSuite) TestDeriveBorrowUtilization() {
 	s.Require().Equal(sdk.ZeroDec(), utilization)
 
 	// user borrows 200 uumee, reducing module account to 800 uumee
-	s.Require().NoError(s.tk.BorrowAsset(s.ctx, addr, sdk.NewInt64Coin(umeeDenom, 200)))
+	s.Require().NoError(s.tk.Borrow(s.ctx, addr, sdk.NewInt64Coin(umeeDenom, 200)))
 
 	// 20% utilization (200 / 200+800-0)
 	utilization = s.tk.SupplyUtilization(s.ctx, umeeDenom)
@@ -155,7 +155,7 @@ func (s *IntegrationTestSuite) TestDeriveBorrowUtilization() {
 	s.Require().NoError(s.app.LeverageKeeper.SetTokenSettings(s.ctx, umeeToken))
 
 	// user borrows 600 uumee, reducing module account to 0 uumee
-	s.Require().NoError(s.tk.BorrowAsset(s.ctx, addr, sdk.NewInt64Coin(umeeDenom, 600)))
+	s.Require().NoError(s.tk.Borrow(s.ctx, addr, sdk.NewInt64Coin(umeeDenom, 600)))
 
 	// 100% utilization (800 / 800+200-200))
 	utilization = s.tk.SupplyUtilization(s.ctx, umeeDenom)

--- a/x/leverage/keeper/collateral_test.go
+++ b/x/leverage/keeper/collateral_test.go
@@ -23,7 +23,7 @@ func (s *IntegrationTestSuite) TestGetCollateralAmount() {
 	s.Require().Equal(sdk.NewInt64Coin(uDenom, 0), collateral)
 
 	// enable u/umee as collateral
-	s.Require().NoError(s.tk.AddCollateral(s.ctx, addr, sdk.NewInt64Coin(uDenom, 1000)))
+	s.Require().NoError(s.tk.Collateralize(s.ctx, addr, sdk.NewInt64Coin(uDenom, 1000)))
 
 	// confirm collateral amount is 1000 u/uumee
 	collateral = s.tk.GetCollateralAmount(s.ctx, addr, uDenom)
@@ -38,7 +38,7 @@ func (s *IntegrationTestSuite) TestGetCollateralAmount() {
 	s.Require().Equal(sdk.NewInt64Coin("abcd", 0), collateral)
 
 	// disable u/umee as collateral
-	s.Require().NoError(s.tk.RemoveCollateral(s.ctx, addr, sdk.NewInt64Coin(uDenom, 1000)))
+	s.Require().NoError(s.tk.Decollateralize(s.ctx, addr, sdk.NewInt64Coin(uDenom, 1000)))
 
 	// confirm collateral amount is 0 u/uumee
 	collateral = s.tk.GetCollateralAmount(s.ctx, addr, uDenom)

--- a/x/leverage/keeper/keeper.go
+++ b/x/leverage/keeper/keeper.go
@@ -110,10 +110,10 @@ func (k Keeper) Supply(ctx sdk.Context, supplierAddr sdk.AccAddress, loan sdk.Co
 	return nil
 }
 
-// WithdrawAsset attempts to deposit uTokens into the leverage module in exchange
+// Withdraw attempts to deposit uTokens into the leverage module in exchange
 // for the original tokens supplied. Accepts a uToken amount to exchange for base tokens.
 // If the uToken denom is invalid or account or module balance insufficient, returns error.
-func (k Keeper) WithdrawAsset(ctx sdk.Context, supplierAddr sdk.AccAddress, coin sdk.Coin) error {
+func (k Keeper) Withdraw(ctx sdk.Context, supplierAddr sdk.AccAddress, coin sdk.Coin) error {
 	if !k.IsAcceptedUToken(ctx, coin.Denom) {
 		return sdkerrors.Wrap(types.ErrInvalidAsset, coin.String())
 	}
@@ -193,11 +193,11 @@ func (k Keeper) WithdrawAsset(ctx sdk.Context, supplierAddr sdk.AccAddress, coin
 	return nil
 }
 
-// BorrowAsset attempts to borrow tokens from the leverage module account using
+// Borrow attempts to borrow tokens from the leverage module account using
 // collateral uTokens. If asset type is invalid, collateral is insufficient,
 // or module balance is insufficient, we return an error.
-func (k Keeper) BorrowAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, borrow sdk.Coin) error {
-	if err := k.validateBorrowAsset(ctx, borrow); err != nil {
+func (k Keeper) Borrow(ctx sdk.Context, borrowerAddr sdk.AccAddress, borrow sdk.Coin) error {
+	if err := k.validateBorrow(ctx, borrow); err != nil {
 		return err
 	}
 
@@ -243,12 +243,12 @@ func (k Keeper) BorrowAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, borrow
 	return nil
 }
 
-// RepayAsset attempts to repay a borrow position. If asset type is invalid, account balance
+// Repay attempts to repay a borrow position. If asset type is invalid, account balance
 // is insufficient, or borrower has no borrows in payment denom to repay, we return an error.
 // Additionally, if the amount provided is greater than the full repayment amount, only the
 // necessary amount is transferred. Because amount repaid may be less than the repayment attempted,
-// RepayAsset returns the actual amount repaid.
-func (k Keeper) RepayAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, payment sdk.Coin) (sdk.Int, error) {
+// Repay returns the actual amount repaid.
+func (k Keeper) Repay(ctx sdk.Context, borrowerAddr sdk.AccAddress, payment sdk.Coin) (sdk.Int, error) {
 	if !payment.IsValid() {
 		return sdk.ZeroInt(), types.ErrInvalidAsset.Wrap(payment.String())
 	}
@@ -283,8 +283,8 @@ func (k Keeper) RepayAsset(ctx sdk.Context, borrowerAddr sdk.AccAddress, payment
 	return payment.Amount, nil
 }
 
-// AddCollateral enables selected uTokens for use as collateral by a single borrower.
-func (k Keeper) AddCollateral(ctx sdk.Context, borrowerAddr sdk.AccAddress, coin sdk.Coin) error {
+// Collateralize enables selected uTokens for use as collateral by a single borrower.
+func (k Keeper) Collateralize(ctx sdk.Context, borrowerAddr sdk.AccAddress, coin sdk.Coin) error {
 	if err := k.validateCollateralAsset(ctx, coin); err != nil {
 		return err
 	}
@@ -302,8 +302,8 @@ func (k Keeper) AddCollateral(ctx sdk.Context, borrowerAddr sdk.AccAddress, coin
 	return nil
 }
 
-// RemoveCollateral disables selected uTokens for use as collateral by a single borrower.
-func (k Keeper) RemoveCollateral(ctx sdk.Context, borrowerAddr sdk.AccAddress, coin sdk.Coin) error {
+// Decollateralize disables selected uTokens for use as collateral by a single borrower.
+func (k Keeper) Decollateralize(ctx sdk.Context, borrowerAddr sdk.AccAddress, coin sdk.Coin) error {
 	if err := coin.Validate(); err != nil {
 		return err
 	}

--- a/x/leverage/keeper/msg_server.go
+++ b/x/leverage/keeper/msg_server.go
@@ -43,7 +43,7 @@ func (s msgServer) Supply(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeLoanAsset,
+			types.EventTypeSupply,
 			sdk.NewAttribute(types.EventAttrSupplier, supplierAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Asset.String()),
 		),

--- a/x/leverage/keeper/msg_server.go
+++ b/x/leverage/keeper/msg_server.go
@@ -57,10 +57,10 @@ func (s msgServer) Supply(
 	return &types.MsgSupplyResponse{}, nil
 }
 
-func (s msgServer) WithdrawAsset(
+func (s msgServer) Withdraw(
 	goCtx context.Context,
-	msg *types.MsgWithdrawAsset,
-) (*types.MsgWithdrawAssetResponse, error) {
+	msg *types.MsgWithdraw,
+) (*types.MsgWithdrawResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	supplierAddr, err := sdk.AccAddressFromBech32(msg.Supplier)
@@ -68,7 +68,7 @@ func (s msgServer) WithdrawAsset(
 		return nil, err
 	}
 
-	if err := s.keeper.WithdrawAsset(ctx, supplierAddr, msg.Asset); err != nil {
+	if err := s.keeper.Withdraw(ctx, supplierAddr, msg.Asset); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (s msgServer) WithdrawAsset(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeWithdrawAsset,
+			types.EventTypeWithdraw,
 			sdk.NewAttribute(types.EventAttrSupplier, supplierAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Asset.String()),
 		),
@@ -91,13 +91,13 @@ func (s msgServer) WithdrawAsset(
 		),
 	})
 
-	return &types.MsgWithdrawAssetResponse{}, nil
+	return &types.MsgWithdrawResponse{}, nil
 }
 
-func (s msgServer) AddCollateral(
+func (s msgServer) Collateralize(
 	goCtx context.Context,
-	msg *types.MsgAddCollateral,
-) (*types.MsgAddCollateralResponse, error) {
+	msg *types.MsgCollateralize,
+) (*types.MsgCollateralizeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -105,7 +105,7 @@ func (s msgServer) AddCollateral(
 		return nil, err
 	}
 
-	if err := s.keeper.AddCollateral(ctx, borrowerAddr, msg.Coin); err != nil {
+	if err := s.keeper.Collateralize(ctx, borrowerAddr, msg.Coin); err != nil {
 		return nil, err
 	}
 
@@ -117,7 +117,7 @@ func (s msgServer) AddCollateral(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeAddCollateral,
+			types.EventTypeCollateralize,
 			sdk.NewAttribute(types.EventAttrBorrower, borrowerAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Coin.String()),
 		),
@@ -128,13 +128,13 @@ func (s msgServer) AddCollateral(
 		),
 	})
 
-	return &types.MsgAddCollateralResponse{}, nil
+	return &types.MsgCollateralizeResponse{}, nil
 }
 
-func (s msgServer) RemoveCollateral(
+func (s msgServer) Decollateralize(
 	goCtx context.Context,
-	msg *types.MsgRemoveCollateral,
-) (*types.MsgRemoveCollateralResponse, error) {
+	msg *types.MsgDecollateralize,
+) (*types.MsgDecollateralizeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -142,7 +142,7 @@ func (s msgServer) RemoveCollateral(
 		return nil, err
 	}
 
-	if err := s.keeper.RemoveCollateral(ctx, borrowerAddr, msg.Coin); err != nil {
+	if err := s.keeper.Decollateralize(ctx, borrowerAddr, msg.Coin); err != nil {
 		return nil, err
 	}
 
@@ -154,7 +154,7 @@ func (s msgServer) RemoveCollateral(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeRemoveCollateral,
+			types.EventTypeDecollateralize,
 			sdk.NewAttribute(types.EventAttrBorrower, borrowerAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Coin.String()),
 		),
@@ -165,13 +165,13 @@ func (s msgServer) RemoveCollateral(
 		),
 	})
 
-	return &types.MsgRemoveCollateralResponse{}, nil
+	return &types.MsgDecollateralizeResponse{}, nil
 }
 
-func (s msgServer) BorrowAsset(
+func (s msgServer) Borrow(
 	goCtx context.Context,
-	msg *types.MsgBorrowAsset,
-) (*types.MsgBorrowAssetResponse, error) {
+	msg *types.MsgBorrow,
+) (*types.MsgBorrowResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -179,7 +179,7 @@ func (s msgServer) BorrowAsset(
 		return nil, err
 	}
 
-	if err := s.keeper.BorrowAsset(ctx, borrowerAddr, msg.Asset); err != nil {
+	if err := s.keeper.Borrow(ctx, borrowerAddr, msg.Asset); err != nil {
 		return nil, err
 	}
 
@@ -191,7 +191,7 @@ func (s msgServer) BorrowAsset(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			types.EventTypeBorrowAsset,
+			types.EventTypeBorrow,
 			sdk.NewAttribute(types.EventAttrBorrower, borrowerAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Asset.String()),
 		),
@@ -202,13 +202,13 @@ func (s msgServer) BorrowAsset(
 		),
 	})
 
-	return &types.MsgBorrowAssetResponse{}, nil
+	return &types.MsgBorrowResponse{}, nil
 }
 
-func (s msgServer) RepayAsset(
+func (s msgServer) Repay(
 	goCtx context.Context,
-	msg *types.MsgRepayAsset,
-) (*types.MsgRepayAssetResponse, error) {
+	msg *types.MsgRepay,
+) (*types.MsgRepayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	borrowerAddr, err := sdk.AccAddressFromBech32(msg.Borrower)
@@ -216,7 +216,7 @@ func (s msgServer) RepayAsset(
 		return nil, err
 	}
 
-	repaid, err := s.keeper.RepayAsset(ctx, borrowerAddr, msg.Asset)
+	repaid, err := s.keeper.Repay(ctx, borrowerAddr, msg.Asset)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (s msgServer) RepayAsset(
 		),
 	})
 
-	return &types.MsgRepayAssetResponse{
+	return &types.MsgRepayResponse{
 		Repaid: repaidCoin,
 	}, nil
 }

--- a/x/leverage/keeper/validate.go
+++ b/x/leverage/keeper/validate.go
@@ -18,8 +18,8 @@ func (k Keeper) validateSupply(ctx sdk.Context, loan sdk.Coin) error {
 	return token.AssertSupplyEnabled()
 }
 
-// validateBorrowAsset validates an sdk.Coin and ensures its Denom is a Token with EnableMsgBorrow
-func (k Keeper) validateBorrowAsset(ctx sdk.Context, borrow sdk.Coin) error {
+// validateBorrow validates an sdk.Coin and ensures its Denom is a Token with EnableMsgBorrow
+func (k Keeper) validateBorrow(ctx sdk.Context, borrow sdk.Coin) error {
 	if !borrow.IsValid() {
 		return types.ErrInvalidAsset.Wrap(borrow.String())
 	}

--- a/x/leverage/simulation/operations.go
+++ b/x/leverage/simulation/operations.go
@@ -123,7 +123,7 @@ func SimulateMsgSupply(ak simulation.AccountKeeper, bk types.BankKeeper) simtype
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		from, coin, skip := randomSpendableFields(r, ctx, accs, bk)
 		if skip {
-			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeLoanAsset, "skip all transfers"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeSupply, "skip all transfers"), nil, nil
 		}
 
 		msg := types.NewMsgSupply(from.Address, coin)
@@ -134,7 +134,7 @@ func SimulateMsgSupply(ak simulation.AccountKeeper, bk types.BankKeeper) simtype
 			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:             nil,
 			Msg:             msg,
-			MsgType:         types.EventTypeLoanAsset,
+			MsgType:         types.EventTypeSupply,
 			Context:         ctx,
 			SimAccount:      from,
 			AccountKeeper:   ak,

--- a/x/leverage/simulation/operations.go
+++ b/x/leverage/simulation/operations.go
@@ -23,12 +23,12 @@ const (
 	DefaultWeightMsgDecollateralize   int = 0
 	DefaultWeightMsgRepay             int = 70
 	DefaultWeightMsgLiquidate         int = 75
-	OperationWeightMsgSupply              = "op_weight_msg_supply_asset"
-	OperationWeightMsgWithdraw            = "op_weight_msg_withdraw_asset"
-	OperationWeightMsgBorrow              = "op_weight_msg_borrow_asset"
-	OperationWeightMsgCollateralize       = "op_weight_msg_add_collateral"
-	OperationWeightMsgDecollateralize     = "op_weight_msg_remove_collateral"
-	OperationWeightMsgRepay               = "op_weight_msg_repay_asset"
+	OperationWeightMsgSupply              = "op_weight_msg_supply"
+	OperationWeightMsgWithdraw            = "op_weight_msg_withdraw"
+	OperationWeightMsgBorrow              = "op_weight_msg_borrow"
+	OperationWeightMsgCollateralize       = "op_weight_msg_collateralize"
+	OperationWeightMsgDecollateralize     = "op_weight_msg_decollateralize"
+	OperationWeightMsgRepay               = "op_weight_msg_repay"
 	OperationWeightMsgLiquidate           = "op_weight_msg_liquidate"
 )
 

--- a/x/leverage/simulation/operations.go
+++ b/x/leverage/simulation/operations.go
@@ -16,20 +16,20 @@ import (
 
 // Default simulation operation weights for leverage messages
 const (
-	DefaultWeightMsgSupply             int = 100
-	DefaultWeightMsgWithdrawAsset      int = 85
-	DefaultWeightMsgBorrowAsset        int = 80
-	DefaultWeightMsgAddCollateral      int = 60
-	DefaultWeightMsgRemoveCollateral   int = 0
-	DefaultWeightMsgRepayAsset         int = 70
-	DefaultWeightMsgLiquidate          int = 75
-	OperationWeightMsgSupply               = "op_weight_msg_supply_asset"
-	OperationWeightMsgWithdrawAsset        = "op_weight_msg_withdraw_asset"
-	OperationWeightMsgBorrowAsset          = "op_weight_msg_borrow_asset"
-	OperationWeightMsgAddCollateral        = "op_weight_msg_add_collateral"
-	OperationWeightMsgRemoveCollateral     = "op_weight_msg_remove_collateral"
-	OperationWeightMsgRepayAsset           = "op_weight_msg_repay_asset"
-	OperationWeightMsgLiquidate            = "op_weight_msg_liquidate"
+	DefaultWeightMsgSupply            int = 100
+	DefaultWeightMsgWithdraw          int = 85
+	DefaultWeightMsgBorrow            int = 80
+	DefaultWeightMsgCollateralize     int = 60
+	DefaultWeightMsgDecollateralize   int = 0
+	DefaultWeightMsgRepay             int = 70
+	DefaultWeightMsgLiquidate         int = 75
+	OperationWeightMsgSupply              = "op_weight_msg_supply_asset"
+	OperationWeightMsgWithdraw            = "op_weight_msg_withdraw_asset"
+	OperationWeightMsgBorrow              = "op_weight_msg_borrow_asset"
+	OperationWeightMsgCollateralize       = "op_weight_msg_add_collateral"
+	OperationWeightMsgDecollateralize     = "op_weight_msg_remove_collateral"
+	OperationWeightMsgRepay               = "op_weight_msg_repay_asset"
+	OperationWeightMsgLiquidate           = "op_weight_msg_liquidate"
 )
 
 // WeightedOperations returns all the operations from the leverage module with their respective weights
@@ -38,42 +38,42 @@ func WeightedOperations(
 	lk keeper.Keeper,
 ) simulation.WeightedOperations {
 	var (
-		weightMsgSupply           int
-		weightMsgWithdraw         int
-		weightMsgBorrow           int
-		weightMsgAddCollateral    int
-		weightMsgRemoveCollateral int
-		weightMsgRepayAsset       int
-		weightMsgLiquidate        int
+		weightMsgSupply          int
+		weightMsgWithdraw        int
+		weightMsgBorrow          int
+		weightMsgCollateralize   int
+		weightMsgDecollateralize int
+		weightMsgRepay           int
+		weightMsgLiquidate       int
 	)
 	appParams.GetOrGenerate(cdc, OperationWeightMsgSupply, &weightMsgSupply, nil,
 		func(_ *rand.Rand) {
 			weightMsgSupply = DefaultWeightMsgSupply
 		},
 	)
-	appParams.GetOrGenerate(cdc, OperationWeightMsgWithdrawAsset, &weightMsgWithdraw, nil,
+	appParams.GetOrGenerate(cdc, OperationWeightMsgWithdraw, &weightMsgWithdraw, nil,
 		func(_ *rand.Rand) {
-			weightMsgWithdraw = DefaultWeightMsgWithdrawAsset
+			weightMsgWithdraw = DefaultWeightMsgWithdraw
 		},
 	)
-	appParams.GetOrGenerate(cdc, OperationWeightMsgBorrowAsset, &weightMsgBorrow, nil,
+	appParams.GetOrGenerate(cdc, OperationWeightMsgBorrow, &weightMsgBorrow, nil,
 		func(_ *rand.Rand) {
-			weightMsgBorrow = DefaultWeightMsgBorrowAsset
+			weightMsgBorrow = DefaultWeightMsgBorrow
 		},
 	)
-	appParams.GetOrGenerate(cdc, OperationWeightMsgAddCollateral, &weightMsgAddCollateral, nil,
+	appParams.GetOrGenerate(cdc, OperationWeightMsgCollateralize, &weightMsgCollateralize, nil,
 		func(_ *rand.Rand) {
-			weightMsgAddCollateral = DefaultWeightMsgAddCollateral
+			weightMsgCollateralize = DefaultWeightMsgCollateralize
 		},
 	)
-	appParams.GetOrGenerate(cdc, OperationWeightMsgRemoveCollateral, &weightMsgRemoveCollateral, nil,
+	appParams.GetOrGenerate(cdc, OperationWeightMsgDecollateralize, &weightMsgDecollateralize, nil,
 		func(_ *rand.Rand) {
-			weightMsgRemoveCollateral = DefaultWeightMsgRemoveCollateral
+			weightMsgDecollateralize = DefaultWeightMsgDecollateralize
 		},
 	)
-	appParams.GetOrGenerate(cdc, OperationWeightMsgRepayAsset, &weightMsgRepayAsset, nil,
+	appParams.GetOrGenerate(cdc, OperationWeightMsgRepay, &weightMsgRepay, nil,
 		func(_ *rand.Rand) {
-			weightMsgRepayAsset = DefaultWeightMsgRepayAsset
+			weightMsgRepay = DefaultWeightMsgRepay
 		},
 	)
 	appParams.GetOrGenerate(cdc, OperationWeightMsgLiquidate, &weightMsgLiquidate, nil,
@@ -89,23 +89,23 @@ func WeightedOperations(
 		),
 		simulation.NewWeightedOperation(
 			weightMsgWithdraw,
-			SimulateMsgWithdrawAsset(ak, bk, lk),
+			SimulateMsgWithdraw(ak, bk, lk),
 		),
 		simulation.NewWeightedOperation(
 			weightMsgBorrow,
-			SimulateMsgBorrowAsset(ak, bk, lk),
+			SimulateMsgBorrow(ak, bk, lk),
 		),
 		simulation.NewWeightedOperation(
-			weightMsgAddCollateral,
-			SimulateMsgAddCollateral(ak, bk, lk),
+			weightMsgCollateralize,
+			SimulateMsgCollateralize(ak, bk, lk),
 		),
 		simulation.NewWeightedOperation(
-			weightMsgRemoveCollateral,
-			SimulateMsgRemoveCollateral(ak, bk, lk),
+			weightMsgDecollateralize,
+			SimulateMsgDecollateralize(ak, bk, lk),
 		),
 		simulation.NewWeightedOperation(
-			weightMsgRepayAsset,
-			SimulateMsgRepayAsset(ak, bk, lk),
+			weightMsgRepay,
+			SimulateMsgRepay(ak, bk, lk),
 		),
 		simulation.NewWeightedOperation(
 			weightMsgLiquidate,
@@ -147,19 +147,19 @@ func SimulateMsgSupply(ak simulation.AccountKeeper, bk types.BankKeeper) simtype
 	}
 }
 
-// SimulateMsgWithdrawAsset tests and runs a single msg withdraw where
+// SimulateMsgWithdraw tests and runs a single msg withdraw where
 // an account attempts to withdraw some supplied assets.
-func SimulateMsgWithdrawAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
+func SimulateMsgWithdraw(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		from, withdrawUToken, skip := randomWithdrawFields(r, ctx, accs, bk, lk)
 		if skip {
-			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeWithdrawAsset, "skip all transfers"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeWithdraw, "skip all transfers"), nil, nil
 		}
 
-		msg := types.NewMsgWithdrawAsset(from.Address, withdrawUToken)
+		msg := types.NewMsgWithdraw(from.Address, withdrawUToken)
 
 		txCtx := simulation.OperationInput{
 			R:             r,
@@ -167,7 +167,7 @@ func SimulateMsgWithdrawAsset(ak simulation.AccountKeeper, bk types.BankKeeper, 
 			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:           nil,
 			Msg:           msg,
-			MsgType:       types.EventTypeWithdrawAsset,
+			MsgType:       types.EventTypeWithdraw,
 			Context:       ctx,
 			SimAccount:    from,
 			AccountKeeper: ak,
@@ -179,19 +179,19 @@ func SimulateMsgWithdrawAsset(ak simulation.AccountKeeper, bk types.BankKeeper, 
 	}
 }
 
-// SimulateMsgBorrowAsset tests and runs a single msg borrow where
+// SimulateMsgBorrow tests and runs a single msg borrow where
 // an account attempts to borrow some assets.
-func SimulateMsgBorrowAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
+func SimulateMsgBorrow(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		from, token, skip := randomTokenFields(r, ctx, accs, lk)
 		if skip {
-			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeBorrowAsset, "skip all transfers"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeBorrow, "skip all transfers"), nil, nil
 		}
 
-		msg := types.NewMsgBorrowAsset(from.Address, token)
+		msg := types.NewMsgBorrow(from.Address, token)
 
 		txCtx := simulation.OperationInput{
 			R:             r,
@@ -199,7 +199,7 @@ func SimulateMsgBorrowAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk
 			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:           nil,
 			Msg:           msg,
-			MsgType:       types.EventTypeBorrowAsset,
+			MsgType:       types.EventTypeBorrow,
 			Context:       ctx,
 			SimAccount:    from,
 			AccountKeeper: ak,
@@ -211,9 +211,9 @@ func SimulateMsgBorrowAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk
 	}
 }
 
-// SimulateMsgAddCollateral tests and runs a single msg which adds
+// SimulateMsgCollateralize tests and runs a single msg which adds
 // some collateral to a user.
-func SimulateMsgAddCollateral(
+func SimulateMsgCollateralize(
 	ak simulation.AccountKeeper,
 	bk types.BankKeeper,
 	lk keeper.Keeper,
@@ -224,12 +224,12 @@ func SimulateMsgAddCollateral(
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		from, token, skip := randomTokenFields(r, ctx, accs, lk)
 		if skip {
-			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeAddCollateral, "skip all transfers"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeCollateralize, "skip all transfers"), nil, nil
 		}
 
 		uDenom := lk.FromTokenToUTokenDenom(ctx, token.Denom)
 		coin := sdk.NewCoin(uDenom, token.Amount)
-		msg := types.NewMsgAddCollateral(from.Address, coin)
+		msg := types.NewMsgCollateralize(from.Address, coin)
 
 		txCtx := simulation.OperationInput{
 			R:             r,
@@ -237,7 +237,7 @@ func SimulateMsgAddCollateral(
 			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:           nil,
 			Msg:           msg,
-			MsgType:       types.EventTypeAddCollateral,
+			MsgType:       types.EventTypeCollateralize,
 			Context:       ctx,
 			SimAccount:    from,
 			AccountKeeper: ak,
@@ -249,9 +249,9 @@ func SimulateMsgAddCollateral(
 	}
 }
 
-// SimulateMsgRemoveCollateral tests and runs a single msg which removes
+// SimulateMsgDecollateralize tests and runs a single msg which removes
 // some collateral from a user.
-func SimulateMsgRemoveCollateral(
+func SimulateMsgDecollateralize(
 	ak simulation.AccountKeeper,
 	bk types.BankKeeper,
 	lk keeper.Keeper,
@@ -262,12 +262,12 @@ func SimulateMsgRemoveCollateral(
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		from, token, skip := randomTokenFields(r, ctx, accs, lk)
 		if skip {
-			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeRemoveCollateral, "skip all transfers"), nil, nil
+			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeDecollateralize, "skip all transfers"), nil, nil
 		}
 
 		uDenom := lk.FromTokenToUTokenDenom(ctx, token.Denom)
 		coin := sdk.NewCoin(uDenom, token.Amount)
-		msg := types.NewMsgRemoveCollateral(from.Address, coin)
+		msg := types.NewMsgDecollateralize(from.Address, coin)
 
 		txCtx := simulation.OperationInput{
 			R:             r,
@@ -275,7 +275,7 @@ func SimulateMsgRemoveCollateral(
 			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:           nil,
 			Msg:           msg,
-			MsgType:       types.EventTypeRemoveCollateral,
+			MsgType:       types.EventTypeDecollateralize,
 			Context:       ctx,
 			SimAccount:    from,
 			AccountKeeper: ak,
@@ -287,9 +287,9 @@ func SimulateMsgRemoveCollateral(
 	}
 }
 
-// SimulateMsgRepayAsset tests and runs a single msg repay where
+// SimulateMsgRepay tests and runs a single msg repay where
 // an account repays some borrowed assets.
-func SimulateMsgRepayAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
+func SimulateMsgRepay(ak simulation.AccountKeeper, bk types.BankKeeper, lk keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simtypes.Account, chainID string,
@@ -299,7 +299,7 @@ func SimulateMsgRepayAsset(ak simulation.AccountKeeper, bk types.BankKeeper, lk 
 			return simtypes.NoOpMsg(types.ModuleName, types.EventTypeRepayBorrowedAsset, "skip all transfers"), nil, nil
 		}
 
-		msg := types.NewMsgRepayAsset(from.Address, borrowToken)
+		msg := types.NewMsgRepay(from.Address, borrowToken)
 
 		txCtx := simulation.OperationInput{
 			R:             r,

--- a/x/leverage/simulation/operations_test.go
+++ b/x/leverage/simulation/operations_test.go
@@ -136,7 +136,7 @@ func (s *SimTestSuite) TestWeightedOperations() {
 		opMsgRoute string
 		opMsgName  string
 	}{
-		{simulation.DefaultWeightMsgSupply, types.ModuleName, types.EventTypeLoanAsset},
+		{simulation.DefaultWeightMsgSupply, types.ModuleName, types.EventTypeSupply},
 		{simulation.DefaultWeightMsgWithdraw, types.ModuleName, types.EventTypeWithdraw},
 		{simulation.DefaultWeightMsgBorrow, types.ModuleName, types.EventTypeBorrow},
 		{simulation.DefaultWeightMsgCollateralize, types.ModuleName, types.EventTypeCollateralize},
@@ -171,7 +171,7 @@ func (s *SimTestSuite) TestSimulateMsgSupply() {
 
 	s.Require().True(operationMsg.OK)
 	s.Require().Equal("umee1ghekyjucln7y67ntx7cf27m9dpuxxemn8w6h33", msg.Supplier)
-	s.Require().Equal(types.EventTypeLoanAsset, msg.Type())
+	s.Require().Equal(types.EventTypeSupply, msg.Type())
 	s.Require().Equal("185121068uumee", msg.Asset.String())
 	s.Require().Len(futureOperations, 0)
 }

--- a/x/leverage/spec/01_concepts.md
+++ b/x/leverage/spec/01_concepts.md
@@ -36,15 +36,15 @@ Users have the following actions available to them:
 
   If the user is undercollateralized (borrowed value > borrow limit), enabled collateral is eligible for liquidation and cannot be disabled until the user's borrows are healthy again.
 
-- [Withdraw](04_messages.md#MsgWithdrawAsset) supplied assets by turning in uTokens of the associated denomination.
+- [Withdraw](04_messages.md#MsgWithdraw) supplied assets by turning in uTokens of the associated denomination.
 
   Withdraw respects the [uToken Exchange Rate](01_concepts.md#uToken-Exchange-Rate). A user can always withdraw non-collateral uTokens, but can only withdraw collateral-enabled uTokens if it would not reduce their [Borrow Limit](01_concepts.md#Borrow-Limit) below their total borrowed value.
 
-- [Borrow](04_messages.md#MsgBorrowAsset) assets of an accepted type, up to their [Borrow Limit](01_concepts.md#Borrow-Limit).
+- [Borrow](04_messages.md#MsgBorrow) assets of an accepted type, up to their [Borrow Limit](01_concepts.md#Borrow-Limit).
 
   Interest will accrue on borrows for as long as they are not paid off, with the amount owed increasing at a rate of the asset's [Borrow APY](01_concepts.md#Borrow-APY).
 
-- [Repay](04_messages.md#MsgRepayAsset) assets of a borrowed type, directly reducing the amount owed.
+- [Repay](04_messages.md#MsgRepay) assets of a borrowed type, directly reducing the amount owed.
 
   Repayments that exceed a borrower's amount owed in the selected denomination succeed at paying the reduced amount rather than failing outright.
 

--- a/x/leverage/spec/04_messages.md
+++ b/x/leverage/spec/04_messages.md
@@ -15,12 +15,12 @@ The message will fail under the following conditions:
 - `amount` is not a valid amount of an accepted asset
 - `supplier` balance is insufficient
 
-## MsgWithdrawAsset
+## MsgWithdraw
 
 A user withdraws supplied assets.
 
 ```protobuf
-message MsgWithdrawAsset {
+message MsgWithdraw {
   string                   supplier = 1;
   cosmos.base.v1beta1.Coin amount = 2;
 }
@@ -34,12 +34,12 @@ The following additional failures are only possible for collateral-enabled _uTok
 - Withdrawing the required uToken collateral would reduce `supplier`'s `BorrowLimit` below their total borrowed value
 - Borrow value or borrow limit cannot be computed due to a missing `x/oracle` price
 
-## MsgAddCollateral
+## MsgCollateralize
 
 A user adds some uTokens from their balance to the module as collateral.
 
 ```protobuf
-message MsgAddCollateral {
+message MsgCollateralize {
   string                   supplier = 1;
   cosmos.base.v1beta1.Coin amount = 2;
 }
@@ -48,12 +48,12 @@ message MsgAddCollateral {
 The message will fail under the following conditions:
 - Insufficient uTokens in wallet
 
-## MsgRemoveCollateral
+## MsgDecollateralize
 
 A user moves some uTokens from their collateral back to their balance.
 
 ```protobuf
-message MsgRemoveCollateral {
+message MsgDecollateralize {
   string                   supplier = 1;
   cosmos.base.v1beta1.Coin amount = 2;
 }
@@ -64,12 +64,12 @@ The message will fail under the following conditions:
 - Disabling the required _uTokens_ as collateral would reduce `borrower`'s `BorrowLimit` below their total borrowed value
 - Borrow value or borrow limit cannot be computed due to a missing `x/oracle` price
 
-## MsgBorrowAsset
+## MsgBorrow
 
 A user borrows base assets from the module.
 
 ```protobuf
-message MsgBorrowAsset {
+message MsgBorrow {
   string                   borrower = 1;
   cosmos.base.v1beta1.Coin amount = 2;
 }
@@ -80,12 +80,12 @@ The message will fail under the following conditions:
 - Borrowing the requested amount would cause `borrower` to exceed their `BorrowLimit`
 - Borrow value or borrow limit cannot be computed due to a missing `x/oracle` price
 
-## MsgRepayAsset
+## MsgRepay
 
 A user fully or partially repays one of their borrows. If the requested amount would overpay, it is reduced to the full repayment amount before attempting.
 
 ```protobuf
-message MsgRepayAsset {
+message MsgRepay {
   string                   borrower = 1;
   cosmos.base.v1beta1.Coin amount = 2;
 }

--- a/x/leverage/spec/06_events.md
+++ b/x/leverage/spec/06_events.md
@@ -14,14 +14,14 @@ The leverage module emits the following events:
 | message  | action        | /umeenetwork.umee.leverage.v1beta1.MsgSupply    |
 | message  | sender        | {supplierAddress}                               |
 
-### MsgWithdrawAsset
+### MsgWithdraw
 
 | Type     | Attribute Key | Attribute Value                                     |
 | -------- | ------------- | --------------------------------------------------- |
 | withdraw | sender        | {supplierAddress}                                   |
 | withdraw | amount        | {amount}                                            |
 | message  | module        | leverage                                            |
-| message  | action        | /umeenetwork.umee.leverage.v1beta1.MsgWithdrawAsset |
+| message  | action        | /umeenetwork.umee.leverage.v1beta1.MsgWithdraw |
 | message  | sender        | {supplierAddress}                                   |
 
 ### MsgSetCollateral
@@ -35,24 +35,24 @@ The leverage module emits the following events:
 | message        | action        | /umeenetwork.umee.leverage.v1beta1.MsgSetCollateral |
 | message        | sender        | {borrowerAddress}                                   |
 
-### MsgBorrowAsset
+### MsgBorrow
 
 | Type    | Attribute Key | Attribute Value                                   |
 | ------- | ------------- | ------------------------------------------------- |
 | borrow  | sender        | {borrowerAddress}                                 |
 | borrow  | amount        | {amount}                                          |
 | message | module        | leverage                                          |
-| message | action        | /umeenetwork.umee.leverage.v1beta1.MsgBorrowAsset |
+| message | action        | /umeenetwork.umee.leverage.v1beta1.MsgBorrow |
 | message | sender        | {borrowerAddress}                                 |
 
-### MsgRepayAsset
+### MsgRepay
 
 | Type    | Attribute Key | Attribute Value                                  |
 | ------- | ------------- | ------------------------------------------------ |
 | repay   | sender        | {borrowerAddress}                                |
 | repay   | amount        | {amount}*                                        |
 | message | module        | leverage                                         |
-| message | action        | /umeenetwork.umee.leverage.v1beta1.MsgRepayAsset |
+| message | action        | /umeenetwork.umee.leverage.v1beta1.MsgRepay |
 | message | sender        | {borrowerAddress}                                |
 
 * Amount successfully repaid may be lower than the amount requested in the message if the original amount would exceed full repayment.

--- a/x/leverage/spec/README.md
+++ b/x/leverage/spec/README.md
@@ -30,11 +30,11 @@ The leverage module depends directly on `x/oracle` for asset prices, and interac
 3. **[Queries](03_queries.md)**
 4. **[Messages](04_messages.md)**
     - [MsgSupply](04_messages.md#MsgSupply)
-    - [MsgWithdrawAsset](04_messages.md#MsgWithdrawAsset)
-    - [MsgAddCollateral](04_messages.md#MsgAddCollateral)
-    - [MsgRemoveCollateral](04_messages.md#MsgRemoveCollateral)
-    - [MsgBorrowAsset](04_messages.md#MsgBorrowAsset)
-    - [MsgRepayAsset](04_messages.md#MsgRepayAsset)
+    - [MsgWithdraw](04_messages.md#MsgWithdraw)
+    - [MsgCollateralize](04_messages.md#MsgCollateralize)
+    - [MsgDecollateralize](04_messages.md#MsgDecollateralize)
+    - [MsgBorrow](04_messages.md#MsgBorrow)
+    - [MsgRepay](04_messages.md#MsgRepay)
     - [MsgLiquidate](04_messages.md#MsgLiquidate)
 5. **[EndBlock](05_endblock.md)**
     - [Bad Debt Sweeping](05_endblock.md#Sweep-Bad-Debt)

--- a/x/leverage/types/codec.go
+++ b/x/leverage/types/codec.go
@@ -29,12 +29,12 @@ func init() {
 // Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgSupply{}, "umee/leverage/MsgSupply", nil)
-	cdc.RegisterConcrete(&MsgWithdrawAsset{}, "umee/leverage/MsgWithdrawAsset", nil)
+	cdc.RegisterConcrete(&MsgWithdraw{}, "umee/leverage/MsgWithdraw", nil)
 	cdc.RegisterConcrete(&UpdateRegistryProposal{}, "umee/leverage/UpdateRegistryProposal", nil)
-	cdc.RegisterConcrete(&MsgAddCollateral{}, "umee/leverage/MsgAddCollateral", nil)
-	cdc.RegisterConcrete(&MsgRemoveCollateral{}, "umee/leverage/MsgRemoveCollateral", nil)
-	cdc.RegisterConcrete(&MsgBorrowAsset{}, "umee/leverage/MsgBorrowAsset", nil)
-	cdc.RegisterConcrete(&MsgRepayAsset{}, "umee/leverage/MsgRepayAsset", nil)
+	cdc.RegisterConcrete(&MsgCollateralize{}, "umee/leverage/MsgCollateralize", nil)
+	cdc.RegisterConcrete(&MsgDecollateralize{}, "umee/leverage/MsgDecollateralize", nil)
+	cdc.RegisterConcrete(&MsgBorrow{}, "umee/leverage/MsgBorrow", nil)
+	cdc.RegisterConcrete(&MsgRepay{}, "umee/leverage/MsgRepay", nil)
 	cdc.RegisterConcrete(&MsgLiquidate{}, "umee/leverage/MsgLiquidate", nil)
 }
 
@@ -42,11 +42,11 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgSupply{},
-		&MsgWithdrawAsset{},
-		&MsgAddCollateral{},
-		&MsgRemoveCollateral{},
-		&MsgBorrowAsset{},
-		&MsgRepayAsset{},
+		&MsgWithdraw{},
+		&MsgCollateralize{},
+		&MsgDecollateralize{},
+		&MsgBorrow{},
+		&MsgRepay{},
 		&MsgLiquidate{},
 	)
 

--- a/x/leverage/types/events.go
+++ b/x/leverage/types/events.go
@@ -3,10 +3,10 @@ package types
 // Event types and attributes for the leverage module
 const (
 	EventTypeLoanAsset          = "loan_asset"
-	EventTypeWithdrawAsset      = "withdraw_asset"
-	EventTypeAddCollateral      = "add_collateral"
-	EventTypeRemoveCollateral   = "remove_collateral"
-	EventTypeBorrowAsset        = "borrow_asset"
+	EventTypeWithdraw           = "withdraw_asset"
+	EventTypeCollateralize      = "add_collateral"
+	EventTypeDecollateralize    = "remove_collateral"
+	EventTypeBorrow             = "borrow_asset"
 	EventTypeRepayBorrowedAsset = "repay_borrowed_asset"
 	EventTypeLiquidate          = "liquidate_borrow_position"
 	EventTypeRepayBadDebt       = "repay_bad_debt"

--- a/x/leverage/types/events.go
+++ b/x/leverage/types/events.go
@@ -2,13 +2,13 @@ package types
 
 // Event types and attributes for the leverage module
 const (
-	EventTypeLoanAsset          = "loan_asset"
-	EventTypeWithdraw           = "withdraw_asset"
-	EventTypeCollateralize      = "add_collateral"
-	EventTypeDecollateralize    = "remove_collateral"
-	EventTypeBorrow             = "borrow_asset"
-	EventTypeRepayBorrowedAsset = "repay_borrowed_asset"
-	EventTypeLiquidate          = "liquidate_borrow_position"
+	EventTypeSupply             = "supply"
+	EventTypeWithdraw           = "withdraw"
+	EventTypeCollateralize      = "collateralize"
+	EventTypeDecollateralize    = "decollateralize"
+	EventTypeBorrow             = "borrow"
+	EventTypeRepayBorrowedAsset = "repay"
+	EventTypeLiquidate          = "liquidate"
 	EventTypeRepayBadDebt       = "repay_bad_debt"
 	EventTypeReservesExhausted  = "reserves_exhausted"
 	EventTypeInterestAccrual    = "interest_accrual"

--- a/x/leverage/types/tx.go
+++ b/x/leverage/types/tx.go
@@ -39,17 +39,17 @@ func (msg *MsgSupply) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgWithdrawAsset(supplier sdk.AccAddress, asset sdk.Coin) *MsgWithdrawAsset {
-	return &MsgWithdrawAsset{
+func NewMsgWithdraw(supplier sdk.AccAddress, asset sdk.Coin) *MsgWithdraw {
+	return &MsgWithdraw{
 		Supplier: supplier.String(),
 		Asset:    asset,
 	}
 }
 
-func (msg MsgWithdrawAsset) Route() string { return ModuleName }
-func (msg MsgWithdrawAsset) Type() string  { return EventTypeWithdrawAsset }
+func (msg MsgWithdraw) Route() string { return ModuleName }
+func (msg MsgWithdraw) Type() string  { return EventTypeWithdraw }
 
-func (msg *MsgWithdrawAsset) ValidateBasic() error {
+func (msg *MsgWithdraw) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetSupplier())
 	if err != nil {
 		return err
@@ -62,28 +62,28 @@ func (msg *MsgWithdrawAsset) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgWithdrawAsset) GetSigners() []sdk.AccAddress {
+func (msg *MsgWithdraw) GetSigners() []sdk.AccAddress {
 	supplier, _ := sdk.AccAddressFromBech32(msg.GetSupplier())
 	return []sdk.AccAddress{supplier}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on
-func (msg *MsgWithdrawAsset) GetSignBytes() []byte {
+func (msg *MsgWithdraw) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgAddCollateral(borrower sdk.AccAddress, coin sdk.Coin) *MsgAddCollateral {
-	return &MsgAddCollateral{
+func NewMsgCollateralize(borrower sdk.AccAddress, coin sdk.Coin) *MsgCollateralize {
+	return &MsgCollateralize{
 		Borrower: borrower.String(),
 		Coin:     coin,
 	}
 }
 
-func (msg MsgAddCollateral) Route() string { return ModuleName }
-func (msg MsgAddCollateral) Type() string  { return EventTypeAddCollateral }
+func (msg MsgCollateralize) Route() string { return ModuleName }
+func (msg MsgCollateralize) Type() string  { return EventTypeCollateralize }
 
-func (msg *MsgAddCollateral) ValidateBasic() error {
+func (msg *MsgCollateralize) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetBorrower())
 	if err != nil {
 		return err
@@ -91,28 +91,28 @@ func (msg *MsgAddCollateral) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgAddCollateral) GetSigners() []sdk.AccAddress {
+func (msg *MsgCollateralize) GetSigners() []sdk.AccAddress {
 	borrower, _ := sdk.AccAddressFromBech32(msg.GetBorrower())
 	return []sdk.AccAddress{borrower}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on
-func (msg *MsgAddCollateral) GetSignBytes() []byte {
+func (msg *MsgCollateralize) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgRemoveCollateral(borrower sdk.AccAddress, coin sdk.Coin) *MsgRemoveCollateral {
-	return &MsgRemoveCollateral{
+func NewMsgDecollateralize(borrower sdk.AccAddress, coin sdk.Coin) *MsgDecollateralize {
+	return &MsgDecollateralize{
 		Borrower: borrower.String(),
 		Coin:     coin,
 	}
 }
 
-func (msg MsgRemoveCollateral) Route() string { return ModuleName }
-func (msg MsgRemoveCollateral) Type() string  { return EventTypeRemoveCollateral }
+func (msg MsgDecollateralize) Route() string { return ModuleName }
+func (msg MsgDecollateralize) Type() string  { return EventTypeDecollateralize }
 
-func (msg *MsgRemoveCollateral) ValidateBasic() error {
+func (msg *MsgDecollateralize) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetBorrower())
 	if err != nil {
 		return err
@@ -120,28 +120,28 @@ func (msg *MsgRemoveCollateral) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgRemoveCollateral) GetSigners() []sdk.AccAddress {
+func (msg *MsgDecollateralize) GetSigners() []sdk.AccAddress {
 	borrower, _ := sdk.AccAddressFromBech32(msg.GetBorrower())
 	return []sdk.AccAddress{borrower}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on
-func (msg *MsgRemoveCollateral) GetSignBytes() []byte {
+func (msg *MsgDecollateralize) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgBorrowAsset(borrower sdk.AccAddress, asset sdk.Coin) *MsgBorrowAsset {
-	return &MsgBorrowAsset{
+func NewMsgBorrow(borrower sdk.AccAddress, asset sdk.Coin) *MsgBorrow {
+	return &MsgBorrow{
 		Borrower: borrower.String(),
 		Asset:    asset,
 	}
 }
 
-func (msg MsgBorrowAsset) Route() string { return ModuleName }
-func (msg MsgBorrowAsset) Type() string  { return EventTypeBorrowAsset }
+func (msg MsgBorrow) Route() string { return ModuleName }
+func (msg MsgBorrow) Type() string  { return EventTypeBorrow }
 
-func (msg *MsgBorrowAsset) ValidateBasic() error {
+func (msg *MsgBorrow) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetBorrower())
 	if err != nil {
 		return err
@@ -154,28 +154,28 @@ func (msg *MsgBorrowAsset) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgBorrowAsset) GetSigners() []sdk.AccAddress {
+func (msg *MsgBorrow) GetSigners() []sdk.AccAddress {
 	borrower, _ := sdk.AccAddressFromBech32(msg.GetBorrower())
 	return []sdk.AccAddress{borrower}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on
-func (msg *MsgBorrowAsset) GetSignBytes() []byte {
+func (msg *MsgBorrow) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
-func NewMsgRepayAsset(borrower sdk.AccAddress, asset sdk.Coin) *MsgRepayAsset {
-	return &MsgRepayAsset{
+func NewMsgRepay(borrower sdk.AccAddress, asset sdk.Coin) *MsgRepay {
+	return &MsgRepay{
 		Borrower: borrower.String(),
 		Asset:    asset,
 	}
 }
 
-func (msg MsgRepayAsset) Route() string { return ModuleName }
-func (msg MsgRepayAsset) Type() string  { return EventTypeRepayBorrowedAsset }
+func (msg MsgRepay) Route() string { return ModuleName }
+func (msg MsgRepay) Type() string  { return EventTypeRepayBorrowedAsset }
 
-func (msg *MsgRepayAsset) ValidateBasic() error {
+func (msg *MsgRepay) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetBorrower())
 	if err != nil {
 		return err
@@ -188,13 +188,13 @@ func (msg *MsgRepayAsset) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgRepayAsset) GetSigners() []sdk.AccAddress {
+func (msg *MsgRepay) GetSigners() []sdk.AccAddress {
 	borrower, _ := sdk.AccAddressFromBech32(msg.GetBorrower())
 	return []sdk.AccAddress{borrower}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on
-func (msg *MsgRepayAsset) GetSignBytes() []byte {
+func (msg *MsgRepay) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }

--- a/x/leverage/types/tx.go
+++ b/x/leverage/types/tx.go
@@ -13,7 +13,7 @@ func NewMsgSupply(supplier sdk.AccAddress, asset sdk.Coin) *MsgSupply {
 }
 
 func (msg MsgSupply) Route() string { return ModuleName }
-func (msg MsgSupply) Type() string  { return EventTypeLoanAsset }
+func (msg MsgSupply) Type() string  { return EventTypeSupply }
 
 func (msg *MsgSupply) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.GetSupplier())

--- a/x/leverage/types/tx.pb.go
+++ b/x/leverage/types/tx.pb.go
@@ -83,26 +83,26 @@ func (m *MsgSupply) GetAsset() types.Coin {
 	return types.Coin{}
 }
 
-// MsgWithdrawAsset represents a user's request to withdraw supplied assets.
+// MsgWithdraw represents a user's request to withdraw supplied assets.
 // Asset must be a uToken.
-type MsgWithdrawAsset struct {
+type MsgWithdraw struct {
 	// Supplier is the account address withdrawing assets and the signer of the message.
 	Supplier string     `protobuf:"bytes,1,opt,name=supplier,proto3" json:"supplier,omitempty"`
 	Asset    types.Coin `protobuf:"bytes,2,opt,name=asset,proto3" json:"asset"`
 }
 
-func (m *MsgWithdrawAsset) Reset()         { *m = MsgWithdrawAsset{} }
-func (m *MsgWithdrawAsset) String() string { return proto.CompactTextString(m) }
-func (*MsgWithdrawAsset) ProtoMessage()    {}
-func (*MsgWithdrawAsset) Descriptor() ([]byte, []int) {
+func (m *MsgWithdraw) Reset()         { *m = MsgWithdraw{} }
+func (m *MsgWithdraw) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdraw) ProtoMessage()    {}
+func (*MsgWithdraw) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{1}
 }
-func (m *MsgWithdrawAsset) XXX_Unmarshal(b []byte) error {
+func (m *MsgWithdraw) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgWithdrawAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithdraw) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgWithdrawAsset.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgWithdraw.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -112,52 +112,52 @@ func (m *MsgWithdrawAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
-func (m *MsgWithdrawAsset) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithdrawAsset.Merge(m, src)
+func (m *MsgWithdraw) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdraw.Merge(m, src)
 }
-func (m *MsgWithdrawAsset) XXX_Size() int {
+func (m *MsgWithdraw) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgWithdrawAsset) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgWithdrawAsset.DiscardUnknown(m)
+func (m *MsgWithdraw) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdraw.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgWithdrawAsset proto.InternalMessageInfo
+var xxx_messageInfo_MsgWithdraw proto.InternalMessageInfo
 
-func (m *MsgWithdrawAsset) GetSupplier() string {
+func (m *MsgWithdraw) GetSupplier() string {
 	if m != nil {
 		return m.Supplier
 	}
 	return ""
 }
 
-func (m *MsgWithdrawAsset) GetAsset() types.Coin {
+func (m *MsgWithdraw) GetAsset() types.Coin {
 	if m != nil {
 		return m.Asset
 	}
 	return types.Coin{}
 }
 
-// MsgAddCollateral represents a user's request to enable selected
+// MsgCollateralize represents a user's request to enable selected
 // uTokens as collateral.
-type MsgAddCollateral struct {
+type MsgCollateralize struct {
 	// Borrower is the account address adding collateral and the signer of the message.
 	Borrower string     `protobuf:"bytes,1,opt,name=borrower,proto3" json:"borrower,omitempty"`
 	Coin     types.Coin `protobuf:"bytes,2,opt,name=coin,proto3" json:"coin"`
 }
 
-func (m *MsgAddCollateral) Reset()         { *m = MsgAddCollateral{} }
-func (m *MsgAddCollateral) String() string { return proto.CompactTextString(m) }
-func (*MsgAddCollateral) ProtoMessage()    {}
-func (*MsgAddCollateral) Descriptor() ([]byte, []int) {
+func (m *MsgCollateralize) Reset()         { *m = MsgCollateralize{} }
+func (m *MsgCollateralize) String() string { return proto.CompactTextString(m) }
+func (*MsgCollateralize) ProtoMessage()    {}
+func (*MsgCollateralize) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{2}
 }
-func (m *MsgAddCollateral) XXX_Unmarshal(b []byte) error {
+func (m *MsgCollateralize) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgAddCollateral) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCollateralize) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgAddCollateral.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCollateralize.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -167,52 +167,52 @@ func (m *MsgAddCollateral) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
-func (m *MsgAddCollateral) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgAddCollateral.Merge(m, src)
+func (m *MsgCollateralize) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCollateralize.Merge(m, src)
 }
-func (m *MsgAddCollateral) XXX_Size() int {
+func (m *MsgCollateralize) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgAddCollateral) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgAddCollateral.DiscardUnknown(m)
+func (m *MsgCollateralize) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCollateralize.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgAddCollateral proto.InternalMessageInfo
+var xxx_messageInfo_MsgCollateralize proto.InternalMessageInfo
 
-func (m *MsgAddCollateral) GetBorrower() string {
+func (m *MsgCollateralize) GetBorrower() string {
 	if m != nil {
 		return m.Borrower
 	}
 	return ""
 }
 
-func (m *MsgAddCollateral) GetCoin() types.Coin {
+func (m *MsgCollateralize) GetCoin() types.Coin {
 	if m != nil {
 		return m.Coin
 	}
 	return types.Coin{}
 }
 
-// MsgRemoveCollateral represents a user's request to disable selected
+// MsgDecollateralize represents a user's request to disable selected
 // uTokens as collateral.
-type MsgRemoveCollateral struct {
+type MsgDecollateralize struct {
 	// Borrower is the account address removing collateral and the signer of the message.
 	Borrower string     `protobuf:"bytes,1,opt,name=borrower,proto3" json:"borrower,omitempty"`
 	Coin     types.Coin `protobuf:"bytes,2,opt,name=coin,proto3" json:"coin"`
 }
 
-func (m *MsgRemoveCollateral) Reset()         { *m = MsgRemoveCollateral{} }
-func (m *MsgRemoveCollateral) String() string { return proto.CompactTextString(m) }
-func (*MsgRemoveCollateral) ProtoMessage()    {}
-func (*MsgRemoveCollateral) Descriptor() ([]byte, []int) {
+func (m *MsgDecollateralize) Reset()         { *m = MsgDecollateralize{} }
+func (m *MsgDecollateralize) String() string { return proto.CompactTextString(m) }
+func (*MsgDecollateralize) ProtoMessage()    {}
+func (*MsgDecollateralize) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{3}
 }
-func (m *MsgRemoveCollateral) XXX_Unmarshal(b []byte) error {
+func (m *MsgDecollateralize) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgRemoveCollateral) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgDecollateralize) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgRemoveCollateral.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgDecollateralize.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -222,53 +222,53 @@ func (m *MsgRemoveCollateral) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
-func (m *MsgRemoveCollateral) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgRemoveCollateral.Merge(m, src)
+func (m *MsgDecollateralize) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDecollateralize.Merge(m, src)
 }
-func (m *MsgRemoveCollateral) XXX_Size() int {
+func (m *MsgDecollateralize) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgRemoveCollateral) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgRemoveCollateral.DiscardUnknown(m)
+func (m *MsgDecollateralize) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDecollateralize.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgRemoveCollateral proto.InternalMessageInfo
+var xxx_messageInfo_MsgDecollateralize proto.InternalMessageInfo
 
-func (m *MsgRemoveCollateral) GetBorrower() string {
+func (m *MsgDecollateralize) GetBorrower() string {
 	if m != nil {
 		return m.Borrower
 	}
 	return ""
 }
 
-func (m *MsgRemoveCollateral) GetCoin() types.Coin {
+func (m *MsgDecollateralize) GetCoin() types.Coin {
 	if m != nil {
 		return m.Coin
 	}
 	return types.Coin{}
 }
 
-// MsgBorrowAsset represents a user's request to borrow a base asset type
+// MsgBorrow represents a user's request to borrow a base asset type
 // from the module.
-type MsgBorrowAsset struct {
+type MsgBorrow struct {
 	// Borrower is the account address taking a loan and the signer
 	// of the message.
 	Borrower string     `protobuf:"bytes,1,opt,name=borrower,proto3" json:"borrower,omitempty"`
 	Asset    types.Coin `protobuf:"bytes,2,opt,name=asset,proto3" json:"asset"`
 }
 
-func (m *MsgBorrowAsset) Reset()         { *m = MsgBorrowAsset{} }
-func (m *MsgBorrowAsset) String() string { return proto.CompactTextString(m) }
-func (*MsgBorrowAsset) ProtoMessage()    {}
-func (*MsgBorrowAsset) Descriptor() ([]byte, []int) {
+func (m *MsgBorrow) Reset()         { *m = MsgBorrow{} }
+func (m *MsgBorrow) String() string { return proto.CompactTextString(m) }
+func (*MsgBorrow) ProtoMessage()    {}
+func (*MsgBorrow) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{4}
 }
-func (m *MsgBorrowAsset) XXX_Unmarshal(b []byte) error {
+func (m *MsgBorrow) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgBorrowAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgBorrow) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgBorrowAsset.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgBorrow.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -278,53 +278,53 @@ func (m *MsgBorrowAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
-func (m *MsgBorrowAsset) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgBorrowAsset.Merge(m, src)
+func (m *MsgBorrow) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgBorrow.Merge(m, src)
 }
-func (m *MsgBorrowAsset) XXX_Size() int {
+func (m *MsgBorrow) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgBorrowAsset) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgBorrowAsset.DiscardUnknown(m)
+func (m *MsgBorrow) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgBorrow.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgBorrowAsset proto.InternalMessageInfo
+var xxx_messageInfo_MsgBorrow proto.InternalMessageInfo
 
-func (m *MsgBorrowAsset) GetBorrower() string {
+func (m *MsgBorrow) GetBorrower() string {
 	if m != nil {
 		return m.Borrower
 	}
 	return ""
 }
 
-func (m *MsgBorrowAsset) GetAsset() types.Coin {
+func (m *MsgBorrow) GetAsset() types.Coin {
 	if m != nil {
 		return m.Asset
 	}
 	return types.Coin{}
 }
 
-// MsgRepayAsset represents a user's request to repay a borrowed base asset
+// MsgRepay represents a user's request to repay a borrowed base asset
 // type to the module.
-type MsgRepayAsset struct {
+type MsgRepay struct {
 	// Borrower is the account address repaying a loan and the signer
 	// of the message.
 	Borrower string     `protobuf:"bytes,1,opt,name=borrower,proto3" json:"borrower,omitempty"`
 	Asset    types.Coin `protobuf:"bytes,2,opt,name=asset,proto3" json:"asset"`
 }
 
-func (m *MsgRepayAsset) Reset()         { *m = MsgRepayAsset{} }
-func (m *MsgRepayAsset) String() string { return proto.CompactTextString(m) }
-func (*MsgRepayAsset) ProtoMessage()    {}
-func (*MsgRepayAsset) Descriptor() ([]byte, []int) {
+func (m *MsgRepay) Reset()         { *m = MsgRepay{} }
+func (m *MsgRepay) String() string { return proto.CompactTextString(m) }
+func (*MsgRepay) ProtoMessage()    {}
+func (*MsgRepay) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{5}
 }
-func (m *MsgRepayAsset) XXX_Unmarshal(b []byte) error {
+func (m *MsgRepay) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgRepayAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgRepay) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgRepayAsset.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgRepay.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -334,26 +334,26 @@ func (m *MsgRepayAsset) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-func (m *MsgRepayAsset) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgRepayAsset.Merge(m, src)
+func (m *MsgRepay) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgRepay.Merge(m, src)
 }
-func (m *MsgRepayAsset) XXX_Size() int {
+func (m *MsgRepay) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgRepayAsset) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgRepayAsset.DiscardUnknown(m)
+func (m *MsgRepay) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgRepay.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgRepayAsset proto.InternalMessageInfo
+var xxx_messageInfo_MsgRepay proto.InternalMessageInfo
 
-func (m *MsgRepayAsset) GetBorrower() string {
+func (m *MsgRepay) GetBorrower() string {
 	if m != nil {
 		return m.Borrower
 	}
 	return ""
 }
 
-func (m *MsgRepayAsset) GetAsset() types.Coin {
+func (m *MsgRepay) GetAsset() types.Coin {
 	if m != nil {
 		return m.Asset
 	}
@@ -469,22 +469,22 @@ func (m *MsgSupplyResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgSupplyResponse proto.InternalMessageInfo
 
-// MsgWithdrawAssetResponse defines the Msg/WithdrawAsset response type.
-type MsgWithdrawAssetResponse struct {
+// MsgWithdrawResponse defines the Msg/Withdraw response type.
+type MsgWithdrawResponse struct {
 }
 
-func (m *MsgWithdrawAssetResponse) Reset()         { *m = MsgWithdrawAssetResponse{} }
-func (m *MsgWithdrawAssetResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgWithdrawAssetResponse) ProtoMessage()    {}
-func (*MsgWithdrawAssetResponse) Descriptor() ([]byte, []int) {
+func (m *MsgWithdrawResponse) Reset()         { *m = MsgWithdrawResponse{} }
+func (m *MsgWithdrawResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawResponse) ProtoMessage()    {}
+func (*MsgWithdrawResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{8}
 }
-func (m *MsgWithdrawAssetResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgWithdrawResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgWithdrawAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithdrawResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgWithdrawAssetResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgWithdrawResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -494,34 +494,34 @@ func (m *MsgWithdrawAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-func (m *MsgWithdrawAssetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithdrawAssetResponse.Merge(m, src)
+func (m *MsgWithdrawResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawResponse.Merge(m, src)
 }
-func (m *MsgWithdrawAssetResponse) XXX_Size() int {
+func (m *MsgWithdrawResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgWithdrawAssetResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgWithdrawAssetResponse.DiscardUnknown(m)
+func (m *MsgWithdrawResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgWithdrawAssetResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgWithdrawResponse proto.InternalMessageInfo
 
-// MsgAddCollateralResponse defines the Msg/AddCollateral response type.
-type MsgAddCollateralResponse struct {
+// MsgCollateralizeResponse defines the Msg/Collateralize response type.
+type MsgCollateralizeResponse struct {
 }
 
-func (m *MsgAddCollateralResponse) Reset()         { *m = MsgAddCollateralResponse{} }
-func (m *MsgAddCollateralResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgAddCollateralResponse) ProtoMessage()    {}
-func (*MsgAddCollateralResponse) Descriptor() ([]byte, []int) {
+func (m *MsgCollateralizeResponse) Reset()         { *m = MsgCollateralizeResponse{} }
+func (m *MsgCollateralizeResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgCollateralizeResponse) ProtoMessage()    {}
+func (*MsgCollateralizeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{9}
 }
-func (m *MsgAddCollateralResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgCollateralizeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgAddCollateralResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgCollateralizeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgAddCollateralResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgCollateralizeResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -531,34 +531,34 @@ func (m *MsgAddCollateralResponse) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-func (m *MsgAddCollateralResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgAddCollateralResponse.Merge(m, src)
+func (m *MsgCollateralizeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCollateralizeResponse.Merge(m, src)
 }
-func (m *MsgAddCollateralResponse) XXX_Size() int {
+func (m *MsgCollateralizeResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgAddCollateralResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgAddCollateralResponse.DiscardUnknown(m)
+func (m *MsgCollateralizeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCollateralizeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgAddCollateralResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgCollateralizeResponse proto.InternalMessageInfo
 
-// MsgRemoveCollateralResponse defines the Msg/RemoveCollateral response type.
-type MsgRemoveCollateralResponse struct {
+// MsgDecollateralizeResponse defines the Msg/Decollateralize response type.
+type MsgDecollateralizeResponse struct {
 }
 
-func (m *MsgRemoveCollateralResponse) Reset()         { *m = MsgRemoveCollateralResponse{} }
-func (m *MsgRemoveCollateralResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgRemoveCollateralResponse) ProtoMessage()    {}
-func (*MsgRemoveCollateralResponse) Descriptor() ([]byte, []int) {
+func (m *MsgDecollateralizeResponse) Reset()         { *m = MsgDecollateralizeResponse{} }
+func (m *MsgDecollateralizeResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgDecollateralizeResponse) ProtoMessage()    {}
+func (*MsgDecollateralizeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{10}
 }
-func (m *MsgRemoveCollateralResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgDecollateralizeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgRemoveCollateralResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgDecollateralizeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgRemoveCollateralResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgDecollateralizeResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -568,34 +568,34 @@ func (m *MsgRemoveCollateralResponse) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
-func (m *MsgRemoveCollateralResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgRemoveCollateralResponse.Merge(m, src)
+func (m *MsgDecollateralizeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDecollateralizeResponse.Merge(m, src)
 }
-func (m *MsgRemoveCollateralResponse) XXX_Size() int {
+func (m *MsgDecollateralizeResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgRemoveCollateralResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgRemoveCollateralResponse.DiscardUnknown(m)
+func (m *MsgDecollateralizeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDecollateralizeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgRemoveCollateralResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgDecollateralizeResponse proto.InternalMessageInfo
 
-// MsgBorrowAssetResponse defines the Msg/BorrowAsset response type.
-type MsgBorrowAssetResponse struct {
+// MsgBorrowResponse defines the Msg/Borrow response type.
+type MsgBorrowResponse struct {
 }
 
-func (m *MsgBorrowAssetResponse) Reset()         { *m = MsgBorrowAssetResponse{} }
-func (m *MsgBorrowAssetResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgBorrowAssetResponse) ProtoMessage()    {}
-func (*MsgBorrowAssetResponse) Descriptor() ([]byte, []int) {
+func (m *MsgBorrowResponse) Reset()         { *m = MsgBorrowResponse{} }
+func (m *MsgBorrowResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgBorrowResponse) ProtoMessage()    {}
+func (*MsgBorrowResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{11}
 }
-func (m *MsgBorrowAssetResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgBorrowResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgBorrowAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgBorrowResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgBorrowAssetResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgBorrowResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -605,35 +605,35 @@ func (m *MsgBorrowAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-func (m *MsgBorrowAssetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgBorrowAssetResponse.Merge(m, src)
+func (m *MsgBorrowResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgBorrowResponse.Merge(m, src)
 }
-func (m *MsgBorrowAssetResponse) XXX_Size() int {
+func (m *MsgBorrowResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgBorrowAssetResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgBorrowAssetResponse.DiscardUnknown(m)
+func (m *MsgBorrowResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgBorrowResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgBorrowAssetResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgBorrowResponse proto.InternalMessageInfo
 
-// MsgRepayAssetResponse defines the Msg/RepayAsset response type.
-type MsgRepayAssetResponse struct {
+// MsgRepayResponse defines the Msg/Repay response type.
+type MsgRepayResponse struct {
 	Repaid types.Coin `protobuf:"bytes,1,opt,name=repaid,proto3" json:"repaid"`
 }
 
-func (m *MsgRepayAssetResponse) Reset()         { *m = MsgRepayAssetResponse{} }
-func (m *MsgRepayAssetResponse) String() string { return proto.CompactTextString(m) }
-func (*MsgRepayAssetResponse) ProtoMessage()    {}
-func (*MsgRepayAssetResponse) Descriptor() ([]byte, []int) {
+func (m *MsgRepayResponse) Reset()         { *m = MsgRepayResponse{} }
+func (m *MsgRepayResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgRepayResponse) ProtoMessage()    {}
+func (*MsgRepayResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72683128ee6e8843, []int{12}
 }
-func (m *MsgRepayAssetResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgRepayResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *MsgRepayAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgRepayResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_MsgRepayAssetResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgRepayResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -643,19 +643,19 @@ func (m *MsgRepayAssetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
-func (m *MsgRepayAssetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgRepayAssetResponse.Merge(m, src)
+func (m *MsgRepayResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgRepayResponse.Merge(m, src)
 }
-func (m *MsgRepayAssetResponse) XXX_Size() int {
+func (m *MsgRepayResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *MsgRepayAssetResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_MsgRepayAssetResponse.DiscardUnknown(m)
+func (m *MsgRepayResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgRepayResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_MsgRepayAssetResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgRepayResponse proto.InternalMessageInfo
 
-func (m *MsgRepayAssetResponse) GetRepaid() types.Coin {
+func (m *MsgRepayResponse) GetRepaid() types.Coin {
 	if m != nil {
 		return m.Repaid
 	}
@@ -717,63 +717,63 @@ func (m *MsgLiquidateResponse) GetReward() types.Coin {
 
 func init() {
 	proto.RegisterType((*MsgSupply)(nil), "umee.leverage.v1.MsgSupply")
-	proto.RegisterType((*MsgWithdrawAsset)(nil), "umee.leverage.v1.MsgWithdrawAsset")
-	proto.RegisterType((*MsgAddCollateral)(nil), "umee.leverage.v1.MsgAddCollateral")
-	proto.RegisterType((*MsgRemoveCollateral)(nil), "umee.leverage.v1.MsgRemoveCollateral")
-	proto.RegisterType((*MsgBorrowAsset)(nil), "umee.leverage.v1.MsgBorrowAsset")
-	proto.RegisterType((*MsgRepayAsset)(nil), "umee.leverage.v1.MsgRepayAsset")
+	proto.RegisterType((*MsgWithdraw)(nil), "umee.leverage.v1.MsgWithdraw")
+	proto.RegisterType((*MsgCollateralize)(nil), "umee.leverage.v1.MsgCollateralize")
+	proto.RegisterType((*MsgDecollateralize)(nil), "umee.leverage.v1.MsgDecollateralize")
+	proto.RegisterType((*MsgBorrow)(nil), "umee.leverage.v1.MsgBorrow")
+	proto.RegisterType((*MsgRepay)(nil), "umee.leverage.v1.MsgRepay")
 	proto.RegisterType((*MsgLiquidate)(nil), "umee.leverage.v1.MsgLiquidate")
 	proto.RegisterType((*MsgSupplyResponse)(nil), "umee.leverage.v1.MsgSupplyResponse")
-	proto.RegisterType((*MsgWithdrawAssetResponse)(nil), "umee.leverage.v1.MsgWithdrawAssetResponse")
-	proto.RegisterType((*MsgAddCollateralResponse)(nil), "umee.leverage.v1.MsgAddCollateralResponse")
-	proto.RegisterType((*MsgRemoveCollateralResponse)(nil), "umee.leverage.v1.MsgRemoveCollateralResponse")
-	proto.RegisterType((*MsgBorrowAssetResponse)(nil), "umee.leverage.v1.MsgBorrowAssetResponse")
-	proto.RegisterType((*MsgRepayAssetResponse)(nil), "umee.leverage.v1.MsgRepayAssetResponse")
+	proto.RegisterType((*MsgWithdrawResponse)(nil), "umee.leverage.v1.MsgWithdrawResponse")
+	proto.RegisterType((*MsgCollateralizeResponse)(nil), "umee.leverage.v1.MsgCollateralizeResponse")
+	proto.RegisterType((*MsgDecollateralizeResponse)(nil), "umee.leverage.v1.MsgDecollateralizeResponse")
+	proto.RegisterType((*MsgBorrowResponse)(nil), "umee.leverage.v1.MsgBorrowResponse")
+	proto.RegisterType((*MsgRepayResponse)(nil), "umee.leverage.v1.MsgRepayResponse")
 	proto.RegisterType((*MsgLiquidateResponse)(nil), "umee.leverage.v1.MsgLiquidateResponse")
 }
 
 func init() { proto.RegisterFile("umee/leverage/v1/tx.proto", fileDescriptor_72683128ee6e8843) }
 
 var fileDescriptor_72683128ee6e8843 = []byte{
-	// 596 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x55, 0x4f, 0x6f, 0xd3, 0x4e,
-	0x10, 0x8d, 0xfb, 0x27, 0xfa, 0x65, 0xfa, 0x2b, 0x0a, 0x6e, 0x41, 0xae, 0x2b, 0xdc, 0xc8, 0x08,
-	0x88, 0x90, 0x6a, 0x93, 0x54, 0x88, 0x13, 0x87, 0xa6, 0xb7, 0x0a, 0x4b, 0x28, 0x95, 0x40, 0x70,
-	0x00, 0xad, 0xe3, 0xc5, 0xb1, 0x70, 0xb2, 0x66, 0x77, 0x93, 0x34, 0x1f, 0x00, 0x89, 0x23, 0x9f,
-	0x89, 0x53, 0x8f, 0x3d, 0x72, 0x42, 0x28, 0xf9, 0x22, 0x68, 0x9d, 0x78, 0x63, 0x07, 0xa7, 0x09,
-	0xa0, 0xdc, 0x76, 0xf7, 0xbd, 0x99, 0x37, 0x3b, 0x3b, 0x7e, 0x86, 0x83, 0x5e, 0x07, 0x63, 0x3b,
-	0xc4, 0x7d, 0x4c, 0x91, 0x8f, 0xed, 0x7e, 0xcd, 0xe6, 0x97, 0x56, 0x44, 0x09, 0x27, 0x6a, 0x59,
-	0x40, 0x56, 0x02, 0x59, 0xfd, 0x9a, 0x6e, 0xb4, 0x08, 0xeb, 0x10, 0x66, 0xbb, 0x88, 0x09, 0xaa,
-	0x8b, 0x39, 0xaa, 0xd9, 0x2d, 0x12, 0x74, 0x27, 0x11, 0xfa, 0xbe, 0x4f, 0x7c, 0x12, 0x2f, 0x6d,
-	0xb1, 0x9a, 0x9c, 0x9a, 0xef, 0xa0, 0xe4, 0x30, 0xff, 0xa2, 0x17, 0x45, 0xe1, 0x50, 0xd5, 0xe1,
-	0x3f, 0x26, 0x56, 0x01, 0xa6, 0x9a, 0x52, 0x51, 0xaa, 0xa5, 0xa6, 0xdc, 0xab, 0x4f, 0x61, 0x1b,
-	0x31, 0x86, 0xb9, 0xb6, 0x51, 0x51, 0xaa, 0x3b, 0xf5, 0x03, 0x6b, 0x22, 0x67, 0x09, 0x39, 0x6b,
-	0x2a, 0x67, 0x9d, 0x91, 0xa0, 0xdb, 0xd8, 0xba, 0xfa, 0x71, 0x54, 0x68, 0x4e, 0xd8, 0x26, 0x86,
-	0xb2, 0xc3, 0xfc, 0xd7, 0x01, 0x6f, 0x7b, 0x14, 0x0d, 0x4e, 0xc5, 0xd9, 0x3a, 0x64, 0x5a, 0xb1,
-	0xcc, 0xa9, 0xe7, 0x9d, 0x91, 0x30, 0x44, 0x1c, 0x53, 0x14, 0x0a, 0x19, 0x97, 0x50, 0x4a, 0x06,
-	0x33, 0x99, 0x64, 0xaf, 0x9e, 0xc0, 0x96, 0x68, 0xcd, 0xaa, 0x2a, 0x31, 0xd9, 0xfc, 0x00, 0x7b,
-	0x0e, 0xf3, 0x9b, 0xb8, 0x43, 0xfa, 0x78, 0x9d, 0x3a, 0x2d, 0xb8, 0xe5, 0x30, 0xbf, 0x11, 0xe7,
-	0x90, 0x1d, 0x5b, 0x28, 0xf1, 0x97, 0x1d, 0x73, 0x61, 0x37, 0xbe, 0x4c, 0x84, 0x86, 0x6b, 0xd3,
-	0xf8, 0xa6, 0xc0, 0xff, 0x0e, 0xf3, 0x5f, 0x04, 0x9f, 0x7a, 0x81, 0x87, 0x38, 0x56, 0x0d, 0x80,
-	0x70, 0xba, 0x21, 0x89, 0x4a, 0xea, 0x24, 0x53, 0xc3, 0xc6, 0x5c, 0x0d, 0xcf, 0xa1, 0x44, 0x45,
-	0xb5, 0x1d, 0xdc, 0xe5, 0xda, 0xe6, 0x6a, 0x75, 0xcc, 0x22, 0xd4, 0x67, 0x50, 0xa4, 0x78, 0x80,
-	0xa8, 0xa7, 0x6d, 0xad, 0x16, 0x3b, 0xa5, 0x9b, 0x7b, 0x70, 0x5b, 0x7e, 0x21, 0x4d, 0xcc, 0x22,
-	0xd2, 0x65, 0xd8, 0xd4, 0x41, 0x9b, 0x1f, 0xeb, 0x39, 0x2c, 0x33, 0x8b, 0x12, 0xbb, 0x07, 0x87,
-	0x39, 0x23, 0x24, 0x61, 0x0d, 0xee, 0x66, 0x5f, 0x5e, 0x22, 0x2f, 0xe1, 0x4e, 0xe6, 0xb9, 0x12,
-	0x60, 0x72, 0xaf, 0x08, 0x05, 0x5e, 0xdc, 0xce, 0xd5, 0xee, 0x25, 0xe8, 0xe6, 0x17, 0x05, 0xf6,
-	0xd3, 0x8f, 0xf3, 0xcf, 0x19, 0x53, 0x2d, 0xde, 0xf8, 0xa3, 0x16, 0xd7, 0x3f, 0x6f, 0xc3, 0xa6,
-	0xc3, 0x7c, 0xf5, 0x1c, 0x8a, 0x53, 0x27, 0x3a, 0xb4, 0xe6, 0xfd, 0xcd, 0x92, 0x8f, 0xa0, 0xdf,
-	0xbf, 0x01, 0x94, 0xb7, 0x78, 0x0f, 0xbb, 0x59, 0xd7, 0x31, 0x73, 0xa3, 0x32, 0x1c, 0xfd, 0xf1,
-	0x72, 0x4e, 0x5a, 0x20, 0xeb, 0x37, 0xf9, 0x02, 0x19, 0xce, 0x02, 0x81, 0xdc, 0x59, 0x51, 0xdb,
-	0x50, 0xfe, 0xcd, 0x6b, 0x1e, 0xe4, 0xc6, 0xcf, 0xd3, 0xf4, 0xe3, 0x95, 0x68, 0x52, 0xe9, 0x0d,
-	0xec, 0xa4, 0xdd, 0xa6, 0x92, 0x1b, 0x9d, 0x62, 0xe8, 0xd5, 0x65, 0x0c, 0x99, 0xfa, 0x15, 0x40,
-	0xca, 0x63, 0x8e, 0x16, 0xd4, 0x95, 0x10, 0xf4, 0x47, 0x4b, 0x08, 0x32, 0xef, 0x05, 0x94, 0x52,
-	0xb6, 0x92, 0x1b, 0x25, 0x71, 0xfd, 0xe1, 0xcd, 0x78, 0x92, 0xb4, 0x71, 0x7e, 0x35, 0x32, 0x94,
-	0xeb, 0x91, 0xa1, 0xfc, 0x1c, 0x19, 0xca, 0xd7, 0xb1, 0x51, 0xb8, 0x1e, 0x1b, 0x85, 0xef, 0x63,
-	0xa3, 0xf0, 0xf6, 0x89, 0x1f, 0xf0, 0x76, 0xcf, 0xb5, 0x5a, 0xa4, 0x63, 0x8b, 0x5c, 0xc7, 0x5d,
-	0xcc, 0x07, 0x84, 0x7e, 0x8c, 0x37, 0x76, 0xbf, 0x6e, 0x5f, 0xce, 0x7e, 0xd3, 0x7c, 0x18, 0x61,
-	0xe6, 0x16, 0xe3, 0xff, 0xeb, 0xc9, 0xaf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x8b, 0xb0, 0x2d, 0x83,
-	0xc4, 0x07, 0x00, 0x00,
+	// 593 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x55, 0x4b, 0x6f, 0xd3, 0x4c,
+	0x14, 0x8d, 0xd3, 0x34, 0x4a, 0x6e, 0xbf, 0x4f, 0x14, 0xb7, 0x48, 0xa9, 0x01, 0x53, 0x99, 0x87,
+	0x2a, 0x04, 0x36, 0x49, 0x85, 0x58, 0xb1, 0x49, 0x91, 0x90, 0x02, 0x96, 0x50, 0xba, 0x40, 0x42,
+	0xe2, 0x31, 0x49, 0xae, 0xa6, 0x16, 0x4e, 0xc6, 0xcc, 0x4c, 0x92, 0x86, 0x5f, 0xc0, 0x92, 0xdf,
+	0xc4, 0xaa, 0xcb, 0x6e, 0x90, 0x58, 0x21, 0x94, 0xfc, 0x11, 0xe4, 0xd7, 0xe4, 0x81, 0x1b, 0x02,
+	0x28, 0xbb, 0x99, 0x7b, 0xce, 0xbd, 0x67, 0xe6, 0xce, 0xf5, 0x31, 0xec, 0xf5, 0xbb, 0x88, 0x8e,
+	0x8f, 0x03, 0xe4, 0x84, 0xa2, 0x33, 0xa8, 0x3a, 0xf2, 0xd4, 0x0e, 0x38, 0x93, 0x4c, 0xdf, 0x0e,
+	0x21, 0x3b, 0x85, 0xec, 0x41, 0xd5, 0x30, 0xdb, 0x4c, 0x74, 0x99, 0x70, 0x5a, 0x44, 0x84, 0xd4,
+	0x16, 0x4a, 0x52, 0x75, 0xda, 0xcc, 0xeb, 0xc5, 0x19, 0xc6, 0x2e, 0x65, 0x94, 0x45, 0x4b, 0x27,
+	0x5c, 0xc5, 0x51, 0xeb, 0x0d, 0x94, 0x5d, 0x41, 0x8f, 0xfb, 0x41, 0xe0, 0x8f, 0x74, 0x03, 0x4a,
+	0x22, 0x5c, 0x79, 0xc8, 0x2b, 0xda, 0xbe, 0x76, 0x50, 0x6e, 0xaa, 0xbd, 0xfe, 0x10, 0x36, 0x89,
+	0x10, 0x28, 0x2b, 0xf9, 0x7d, 0xed, 0x60, 0xab, 0xb6, 0x67, 0xc7, 0x72, 0x76, 0x28, 0x67, 0x27,
+	0x72, 0xf6, 0x11, 0xf3, 0x7a, 0xf5, 0xc2, 0xd9, 0xf7, 0x1b, 0xb9, 0x66, 0xcc, 0xb6, 0xde, 0xc1,
+	0x96, 0x2b, 0xe8, 0x4b, 0x4f, 0x9e, 0x74, 0x38, 0x19, 0xae, 0x43, 0xa1, 0x0d, 0xdb, 0xae, 0xa0,
+	0x47, 0xcc, 0xf7, 0x89, 0x44, 0x4e, 0x7c, 0xef, 0x23, 0x86, 0x32, 0x2d, 0xc6, 0x39, 0x1b, 0x4e,
+	0x65, 0xd2, 0xbd, 0x7e, 0x08, 0x85, 0xb0, 0x2b, 0xab, 0xaa, 0x44, 0x64, 0x0b, 0x41, 0x77, 0x05,
+	0x7d, 0x82, 0xed, 0xf5, 0xca, 0xc4, 0xaf, 0x51, 0x8f, 0x6a, 0x2c, 0xad, 0xfe, 0x97, 0xbd, 0x7a,
+	0x0d, 0x25, 0x57, 0xd0, 0x26, 0x06, 0x64, 0xb4, 0x8e, 0xf2, 0x5f, 0x34, 0xf8, 0xcf, 0x15, 0xf4,
+	0xb9, 0xf7, 0xa1, 0xef, 0x75, 0x88, 0x44, 0xdd, 0x04, 0xf0, 0x93, 0x0d, 0x4b, 0x55, 0x66, 0x22,
+	0x73, 0x67, 0xc8, 0x2f, 0x9c, 0xe1, 0x31, 0x94, 0x79, 0x78, 0xd0, 0x2e, 0xf6, 0x64, 0x65, 0x63,
+	0xb5, 0x73, 0x4c, 0x33, 0xf4, 0x47, 0x50, 0xe4, 0x38, 0x24, 0xbc, 0x53, 0x29, 0xac, 0x96, 0x9b,
+	0xd0, 0xad, 0x1d, 0xb8, 0xac, 0xbe, 0x88, 0x26, 0x8a, 0x80, 0xf5, 0x04, 0x5a, 0x57, 0x60, 0x67,
+	0x66, 0x8c, 0x55, 0xd8, 0x80, 0xca, 0xe2, 0xec, 0x29, 0xec, 0x1a, 0x18, 0xbf, 0x8e, 0x8c, 0x42,
+	0x63, 0x95, 0xf8, 0xa5, 0x55, 0xf0, 0x59, 0x34, 0xca, 0xd1, 0xf3, 0xa4, 0xb1, 0xf8, 0x1e, 0x01,
+	0xf1, 0x3a, 0x51, 0xfb, 0x56, 0xbb, 0x47, 0x48, 0xb7, 0x3e, 0x69, 0xb0, 0x3b, 0xfb, 0x18, 0xff,
+	0x5c, 0x71, 0xa6, 0xa5, 0xf9, 0x3f, 0x6a, 0x69, 0xed, 0x6b, 0x01, 0x36, 0x5c, 0x41, 0xf5, 0x06,
+	0x14, 0x13, 0xa7, 0xb9, 0x6a, 0x2f, 0xfa, 0x97, 0xad, 0x9a, 0x6e, 0xdc, 0x5c, 0x02, 0xaa, 0x5b,
+	0xbc, 0x80, 0x92, 0x72, 0x95, 0xeb, 0x99, 0x09, 0x29, 0x6c, 0xdc, 0x5e, 0x0a, 0xab, 0x8a, 0x6f,
+	0xe1, 0xff, 0x79, 0x17, 0xb1, 0x32, 0xf3, 0xe6, 0x38, 0xc6, 0xdd, 0xdf, 0x73, 0x94, 0x00, 0xc2,
+	0xa5, 0x45, 0x07, 0xb9, 0x95, 0x99, 0xbe, 0xc0, 0x32, 0xee, 0xad, 0xc2, 0x52, 0x32, 0x0d, 0x28,
+	0x26, 0x0e, 0x92, 0xdd, 0xe5, 0x18, 0xbc, 0xa0, 0xcb, 0xf3, 0x13, 0xa9, 0x3f, 0x85, 0xcd, 0xc4,
+	0x2d, 0x32, 0xd9, 0x11, 0x66, 0x58, 0x17, 0x63, 0xaa, 0xd0, 0x31, 0x94, 0x67, 0x6c, 0x21, 0x33,
+	0x41, 0xe1, 0xc6, 0x9d, 0xe5, 0x78, 0x5a, 0xb4, 0xde, 0x38, 0x1b, 0x9b, 0xda, 0xf9, 0xd8, 0xd4,
+	0x7e, 0x8c, 0x4d, 0xed, 0xf3, 0xc4, 0xcc, 0x9d, 0x4f, 0xcc, 0xdc, 0xb7, 0x89, 0x99, 0x7b, 0xf5,
+	0x80, 0x7a, 0xf2, 0xa4, 0xdf, 0xb2, 0xdb, 0xac, 0xeb, 0x84, 0xb5, 0xee, 0xf7, 0x50, 0x0e, 0x19,
+	0x7f, 0x1f, 0x6d, 0x9c, 0x41, 0xcd, 0x39, 0x9d, 0xfe, 0x56, 0xe5, 0x28, 0x40, 0xd1, 0x2a, 0x46,
+	0xff, 0xc3, 0xc3, 0x9f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x6e, 0x19, 0x4a, 0x4c, 0x74, 0x07, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -788,24 +788,23 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
-	// Supply moves tokens from user balance to the module balance for lending or collateral.
+	// Supply moves tokens from user balance to the module for lending or collateral.
+	// The user receives uTokens in return.
 	Supply(ctx context.Context, in *MsgSupply, opts ...grpc.CallOption) (*MsgSupplyResponse, error)
-	// WithdrawAsset defines a method for withdrawing previously supplied coins from
-	// the capital facility.
-	WithdrawAsset(ctx context.Context, in *MsgWithdrawAsset, opts ...grpc.CallOption) (*MsgWithdrawAssetResponse, error)
-	// AddCollateral defines a method for users to enable selected uTokens
-	// as collateral.
-	AddCollateral(ctx context.Context, in *MsgAddCollateral, opts ...grpc.CallOption) (*MsgAddCollateralResponse, error)
-	// RemoveCollateral defines a method for users to disable selected uTokens
-	// as collateral.
-	RemoveCollateral(ctx context.Context, in *MsgRemoveCollateral, opts ...grpc.CallOption) (*MsgRemoveCollateralResponse, error)
-	// BorrowAsset defines a method for borrowing coins from the capital facility.
-	BorrowAsset(ctx context.Context, in *MsgBorrowAsset, opts ...grpc.CallOption) (*MsgBorrowAssetResponse, error)
-	// RepayAsset defines a method for repaying borrowed coins to the capital
-	// facility.
-	RepayAsset(ctx context.Context, in *MsgRepayAsset, opts ...grpc.CallOption) (*MsgRepayAssetResponse, error)
-	// Liquidate defines a method for repaying a different user's borrowed coins
-	// to the capital facility in exchange for some of their collateral.
+	// Withdraw moves previously supplied tokens from the module back to the user balance in
+	// exchange for burning uTokens.
+	Withdraw(ctx context.Context, in *MsgWithdraw, opts ...grpc.CallOption) (*MsgWithdrawResponse, error)
+	// Collateralize enables selected uTokens as collateral, which moves them to the module.
+	Collateralize(ctx context.Context, in *MsgCollateralize, opts ...grpc.CallOption) (*MsgCollateralizeResponse, error)
+	// Decollateralize disables selected uTokens as collateral. They are returned to the user's
+	// balance from the module.
+	Decollateralize(ctx context.Context, in *MsgDecollateralize, opts ...grpc.CallOption) (*MsgDecollateralizeResponse, error)
+	// Borrow allows a user to borrow tokens from the module if they have sufficient collateral.
+	Borrow(ctx context.Context, in *MsgBorrow, opts ...grpc.CallOption) (*MsgBorrowResponse, error)
+	// Repay allows a user to repay previously borrowed tokens and interest.
+	Repay(ctx context.Context, in *MsgRepay, opts ...grpc.CallOption) (*MsgRepayResponse, error)
+	// Liquidate allows a user to repay a different user's borrowed coins in exchange for some
+	// of their collateral.
 	Liquidate(ctx context.Context, in *MsgLiquidate, opts ...grpc.CallOption) (*MsgLiquidateResponse, error)
 }
 
@@ -826,45 +825,45 @@ func (c *msgClient) Supply(ctx context.Context, in *MsgSupply, opts ...grpc.Call
 	return out, nil
 }
 
-func (c *msgClient) WithdrawAsset(ctx context.Context, in *MsgWithdrawAsset, opts ...grpc.CallOption) (*MsgWithdrawAssetResponse, error) {
-	out := new(MsgWithdrawAssetResponse)
-	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/WithdrawAsset", in, out, opts...)
+func (c *msgClient) Withdraw(ctx context.Context, in *MsgWithdraw, opts ...grpc.CallOption) (*MsgWithdrawResponse, error) {
+	out := new(MsgWithdrawResponse)
+	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/Withdraw", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *msgClient) AddCollateral(ctx context.Context, in *MsgAddCollateral, opts ...grpc.CallOption) (*MsgAddCollateralResponse, error) {
-	out := new(MsgAddCollateralResponse)
-	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/AddCollateral", in, out, opts...)
+func (c *msgClient) Collateralize(ctx context.Context, in *MsgCollateralize, opts ...grpc.CallOption) (*MsgCollateralizeResponse, error) {
+	out := new(MsgCollateralizeResponse)
+	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/Collateralize", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *msgClient) RemoveCollateral(ctx context.Context, in *MsgRemoveCollateral, opts ...grpc.CallOption) (*MsgRemoveCollateralResponse, error) {
-	out := new(MsgRemoveCollateralResponse)
-	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/RemoveCollateral", in, out, opts...)
+func (c *msgClient) Decollateralize(ctx context.Context, in *MsgDecollateralize, opts ...grpc.CallOption) (*MsgDecollateralizeResponse, error) {
+	out := new(MsgDecollateralizeResponse)
+	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/Decollateralize", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *msgClient) BorrowAsset(ctx context.Context, in *MsgBorrowAsset, opts ...grpc.CallOption) (*MsgBorrowAssetResponse, error) {
-	out := new(MsgBorrowAssetResponse)
-	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/BorrowAsset", in, out, opts...)
+func (c *msgClient) Borrow(ctx context.Context, in *MsgBorrow, opts ...grpc.CallOption) (*MsgBorrowResponse, error) {
+	out := new(MsgBorrowResponse)
+	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/Borrow", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *msgClient) RepayAsset(ctx context.Context, in *MsgRepayAsset, opts ...grpc.CallOption) (*MsgRepayAssetResponse, error) {
-	out := new(MsgRepayAssetResponse)
-	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/RepayAsset", in, out, opts...)
+func (c *msgClient) Repay(ctx context.Context, in *MsgRepay, opts ...grpc.CallOption) (*MsgRepayResponse, error) {
+	out := new(MsgRepayResponse)
+	err := c.cc.Invoke(ctx, "/umee.leverage.v1.Msg/Repay", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -882,24 +881,23 @@ func (c *msgClient) Liquidate(ctx context.Context, in *MsgLiquidate, opts ...grp
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
-	// Supply moves tokens from user balance to the module balance for lending or collateral.
+	// Supply moves tokens from user balance to the module for lending or collateral.
+	// The user receives uTokens in return.
 	Supply(context.Context, *MsgSupply) (*MsgSupplyResponse, error)
-	// WithdrawAsset defines a method for withdrawing previously supplied coins from
-	// the capital facility.
-	WithdrawAsset(context.Context, *MsgWithdrawAsset) (*MsgWithdrawAssetResponse, error)
-	// AddCollateral defines a method for users to enable selected uTokens
-	// as collateral.
-	AddCollateral(context.Context, *MsgAddCollateral) (*MsgAddCollateralResponse, error)
-	// RemoveCollateral defines a method for users to disable selected uTokens
-	// as collateral.
-	RemoveCollateral(context.Context, *MsgRemoveCollateral) (*MsgRemoveCollateralResponse, error)
-	// BorrowAsset defines a method for borrowing coins from the capital facility.
-	BorrowAsset(context.Context, *MsgBorrowAsset) (*MsgBorrowAssetResponse, error)
-	// RepayAsset defines a method for repaying borrowed coins to the capital
-	// facility.
-	RepayAsset(context.Context, *MsgRepayAsset) (*MsgRepayAssetResponse, error)
-	// Liquidate defines a method for repaying a different user's borrowed coins
-	// to the capital facility in exchange for some of their collateral.
+	// Withdraw moves previously supplied tokens from the module back to the user balance in
+	// exchange for burning uTokens.
+	Withdraw(context.Context, *MsgWithdraw) (*MsgWithdrawResponse, error)
+	// Collateralize enables selected uTokens as collateral, which moves them to the module.
+	Collateralize(context.Context, *MsgCollateralize) (*MsgCollateralizeResponse, error)
+	// Decollateralize disables selected uTokens as collateral. They are returned to the user's
+	// balance from the module.
+	Decollateralize(context.Context, *MsgDecollateralize) (*MsgDecollateralizeResponse, error)
+	// Borrow allows a user to borrow tokens from the module if they have sufficient collateral.
+	Borrow(context.Context, *MsgBorrow) (*MsgBorrowResponse, error)
+	// Repay allows a user to repay previously borrowed tokens and interest.
+	Repay(context.Context, *MsgRepay) (*MsgRepayResponse, error)
+	// Liquidate allows a user to repay a different user's borrowed coins in exchange for some
+	// of their collateral.
 	Liquidate(context.Context, *MsgLiquidate) (*MsgLiquidateResponse, error)
 }
 
@@ -910,20 +908,20 @@ type UnimplementedMsgServer struct {
 func (*UnimplementedMsgServer) Supply(ctx context.Context, req *MsgSupply) (*MsgSupplyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Supply not implemented")
 }
-func (*UnimplementedMsgServer) WithdrawAsset(ctx context.Context, req *MsgWithdrawAsset) (*MsgWithdrawAssetResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method WithdrawAsset not implemented")
+func (*UnimplementedMsgServer) Withdraw(ctx context.Context, req *MsgWithdraw) (*MsgWithdrawResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Withdraw not implemented")
 }
-func (*UnimplementedMsgServer) AddCollateral(ctx context.Context, req *MsgAddCollateral) (*MsgAddCollateralResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method AddCollateral not implemented")
+func (*UnimplementedMsgServer) Collateralize(ctx context.Context, req *MsgCollateralize) (*MsgCollateralizeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Collateralize not implemented")
 }
-func (*UnimplementedMsgServer) RemoveCollateral(ctx context.Context, req *MsgRemoveCollateral) (*MsgRemoveCollateralResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RemoveCollateral not implemented")
+func (*UnimplementedMsgServer) Decollateralize(ctx context.Context, req *MsgDecollateralize) (*MsgDecollateralizeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Decollateralize not implemented")
 }
-func (*UnimplementedMsgServer) BorrowAsset(ctx context.Context, req *MsgBorrowAsset) (*MsgBorrowAssetResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method BorrowAsset not implemented")
+func (*UnimplementedMsgServer) Borrow(ctx context.Context, req *MsgBorrow) (*MsgBorrowResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Borrow not implemented")
 }
-func (*UnimplementedMsgServer) RepayAsset(ctx context.Context, req *MsgRepayAsset) (*MsgRepayAssetResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RepayAsset not implemented")
+func (*UnimplementedMsgServer) Repay(ctx context.Context, req *MsgRepay) (*MsgRepayResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Repay not implemented")
 }
 func (*UnimplementedMsgServer) Liquidate(ctx context.Context, req *MsgLiquidate) (*MsgLiquidateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Liquidate not implemented")
@@ -951,92 +949,92 @@ func _Msg_Supply_Handler(srv interface{}, ctx context.Context, dec func(interfac
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Msg_WithdrawAsset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgWithdrawAsset)
+func _Msg_Withdraw_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgWithdraw)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServer).WithdrawAsset(ctx, in)
+		return srv.(MsgServer).Withdraw(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/umee.leverage.v1.Msg/WithdrawAsset",
+		FullMethod: "/umee.leverage.v1.Msg/Withdraw",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).WithdrawAsset(ctx, req.(*MsgWithdrawAsset))
+		return srv.(MsgServer).Withdraw(ctx, req.(*MsgWithdraw))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Msg_AddCollateral_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgAddCollateral)
+func _Msg_Collateralize_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgCollateralize)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServer).AddCollateral(ctx, in)
+		return srv.(MsgServer).Collateralize(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/umee.leverage.v1.Msg/AddCollateral",
+		FullMethod: "/umee.leverage.v1.Msg/Collateralize",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).AddCollateral(ctx, req.(*MsgAddCollateral))
+		return srv.(MsgServer).Collateralize(ctx, req.(*MsgCollateralize))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Msg_RemoveCollateral_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgRemoveCollateral)
+func _Msg_Decollateralize_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgDecollateralize)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServer).RemoveCollateral(ctx, in)
+		return srv.(MsgServer).Decollateralize(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/umee.leverage.v1.Msg/RemoveCollateral",
+		FullMethod: "/umee.leverage.v1.Msg/Decollateralize",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).RemoveCollateral(ctx, req.(*MsgRemoveCollateral))
+		return srv.(MsgServer).Decollateralize(ctx, req.(*MsgDecollateralize))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Msg_BorrowAsset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgBorrowAsset)
+func _Msg_Borrow_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgBorrow)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServer).BorrowAsset(ctx, in)
+		return srv.(MsgServer).Borrow(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/umee.leverage.v1.Msg/BorrowAsset",
+		FullMethod: "/umee.leverage.v1.Msg/Borrow",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).BorrowAsset(ctx, req.(*MsgBorrowAsset))
+		return srv.(MsgServer).Borrow(ctx, req.(*MsgBorrow))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Msg_RepayAsset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(MsgRepayAsset)
+func _Msg_Repay_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgRepay)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServer).RepayAsset(ctx, in)
+		return srv.(MsgServer).Repay(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/umee.leverage.v1.Msg/RepayAsset",
+		FullMethod: "/umee.leverage.v1.Msg/Repay",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServer).RepayAsset(ctx, req.(*MsgRepayAsset))
+		return srv.(MsgServer).Repay(ctx, req.(*MsgRepay))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1068,24 +1066,24 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Msg_Supply_Handler,
 		},
 		{
-			MethodName: "WithdrawAsset",
-			Handler:    _Msg_WithdrawAsset_Handler,
+			MethodName: "Withdraw",
+			Handler:    _Msg_Withdraw_Handler,
 		},
 		{
-			MethodName: "AddCollateral",
-			Handler:    _Msg_AddCollateral_Handler,
+			MethodName: "Collateralize",
+			Handler:    _Msg_Collateralize_Handler,
 		},
 		{
-			MethodName: "RemoveCollateral",
-			Handler:    _Msg_RemoveCollateral_Handler,
+			MethodName: "Decollateralize",
+			Handler:    _Msg_Decollateralize_Handler,
 		},
 		{
-			MethodName: "BorrowAsset",
-			Handler:    _Msg_BorrowAsset_Handler,
+			MethodName: "Borrow",
+			Handler:    _Msg_Borrow_Handler,
 		},
 		{
-			MethodName: "RepayAsset",
-			Handler:    _Msg_RepayAsset_Handler,
+			MethodName: "Repay",
+			Handler:    _Msg_Repay_Handler,
 		},
 		{
 			MethodName: "Liquidate",
@@ -1136,7 +1134,7 @@ func (m *MsgSupply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgWithdrawAsset) Marshal() (dAtA []byte, err error) {
+func (m *MsgWithdraw) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1146,12 +1144,12 @@ func (m *MsgWithdrawAsset) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgWithdrawAsset) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgWithdraw) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgWithdrawAsset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgWithdraw) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1176,7 +1174,7 @@ func (m *MsgWithdrawAsset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgAddCollateral) Marshal() (dAtA []byte, err error) {
+func (m *MsgCollateralize) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1186,12 +1184,12 @@ func (m *MsgAddCollateral) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgAddCollateral) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCollateralize) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgAddCollateral) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCollateralize) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1216,7 +1214,7 @@ func (m *MsgAddCollateral) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgRemoveCollateral) Marshal() (dAtA []byte, err error) {
+func (m *MsgDecollateralize) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1226,12 +1224,12 @@ func (m *MsgRemoveCollateral) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgRemoveCollateral) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgDecollateralize) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgRemoveCollateral) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgDecollateralize) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1256,7 +1254,7 @@ func (m *MsgRemoveCollateral) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgBorrowAsset) Marshal() (dAtA []byte, err error) {
+func (m *MsgBorrow) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1266,12 +1264,12 @@ func (m *MsgBorrowAsset) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgBorrowAsset) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgBorrow) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgBorrowAsset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgBorrow) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1296,7 +1294,7 @@ func (m *MsgBorrowAsset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgRepayAsset) Marshal() (dAtA []byte, err error) {
+func (m *MsgRepay) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1306,12 +1304,12 @@ func (m *MsgRepayAsset) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgRepayAsset) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgRepay) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgRepayAsset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgRepay) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1416,7 +1414,7 @@ func (m *MsgSupplyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgWithdrawAssetResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgWithdrawResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1426,12 +1424,12 @@ func (m *MsgWithdrawAssetResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgWithdrawAssetResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgWithdrawResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgWithdrawAssetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgWithdrawResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1439,7 +1437,7 @@ func (m *MsgWithdrawAssetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgAddCollateralResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgCollateralizeResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1449,12 +1447,12 @@ func (m *MsgAddCollateralResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgAddCollateralResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgCollateralizeResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgAddCollateralResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgCollateralizeResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1462,7 +1460,7 @@ func (m *MsgAddCollateralResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgRemoveCollateralResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgDecollateralizeResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1472,12 +1470,12 @@ func (m *MsgRemoveCollateralResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgRemoveCollateralResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgDecollateralizeResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgRemoveCollateralResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgDecollateralizeResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1485,7 +1483,7 @@ func (m *MsgRemoveCollateralResponse) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgBorrowAssetResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgBorrowResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1495,12 +1493,12 @@ func (m *MsgBorrowAssetResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgBorrowAssetResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgBorrowResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgBorrowAssetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgBorrowResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1508,7 +1506,7 @@ func (m *MsgBorrowAssetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
-func (m *MsgRepayAssetResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgRepayResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1518,12 +1516,12 @@ func (m *MsgRepayAssetResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *MsgRepayAssetResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgRepayResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *MsgRepayAssetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgRepayResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1610,7 +1608,7 @@ func (m *MsgSupply) Size() (n int) {
 	return n
 }
 
-func (m *MsgWithdrawAsset) Size() (n int) {
+func (m *MsgWithdraw) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1625,7 +1623,7 @@ func (m *MsgWithdrawAsset) Size() (n int) {
 	return n
 }
 
-func (m *MsgAddCollateral) Size() (n int) {
+func (m *MsgCollateralize) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1640,7 +1638,7 @@ func (m *MsgAddCollateral) Size() (n int) {
 	return n
 }
 
-func (m *MsgRemoveCollateral) Size() (n int) {
+func (m *MsgDecollateralize) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1655,7 +1653,7 @@ func (m *MsgRemoveCollateral) Size() (n int) {
 	return n
 }
 
-func (m *MsgBorrowAsset) Size() (n int) {
+func (m *MsgBorrow) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1670,7 +1668,7 @@ func (m *MsgBorrowAsset) Size() (n int) {
 	return n
 }
 
-func (m *MsgRepayAsset) Size() (n int) {
+func (m *MsgRepay) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1715,7 +1713,7 @@ func (m *MsgSupplyResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgWithdrawAssetResponse) Size() (n int) {
+func (m *MsgWithdrawResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1724,7 +1722,7 @@ func (m *MsgWithdrawAssetResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgAddCollateralResponse) Size() (n int) {
+func (m *MsgCollateralizeResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1733,7 +1731,7 @@ func (m *MsgAddCollateralResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgRemoveCollateralResponse) Size() (n int) {
+func (m *MsgDecollateralizeResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1742,7 +1740,7 @@ func (m *MsgRemoveCollateralResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgBorrowAssetResponse) Size() (n int) {
+func (m *MsgBorrowResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1751,7 +1749,7 @@ func (m *MsgBorrowAssetResponse) Size() (n int) {
 	return n
 }
 
-func (m *MsgRepayAssetResponse) Size() (n int) {
+func (m *MsgRepayResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1896,7 +1894,7 @@ func (m *MsgSupply) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgWithdrawAsset) Unmarshal(dAtA []byte) error {
+func (m *MsgWithdraw) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1919,10 +1917,10 @@ func (m *MsgWithdrawAsset) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgWithdrawAsset: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgWithdraw: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgWithdrawAsset: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgWithdraw: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2011,7 +2009,7 @@ func (m *MsgWithdrawAsset) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgAddCollateral) Unmarshal(dAtA []byte) error {
+func (m *MsgCollateralize) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2034,10 +2032,10 @@ func (m *MsgAddCollateral) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgAddCollateral: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCollateralize: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgAddCollateral: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCollateralize: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2126,7 +2124,7 @@ func (m *MsgAddCollateral) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgRemoveCollateral) Unmarshal(dAtA []byte) error {
+func (m *MsgDecollateralize) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2149,10 +2147,10 @@ func (m *MsgRemoveCollateral) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgRemoveCollateral: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgDecollateralize: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgRemoveCollateral: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgDecollateralize: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2241,7 +2239,7 @@ func (m *MsgRemoveCollateral) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgBorrowAsset) Unmarshal(dAtA []byte) error {
+func (m *MsgBorrow) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2264,10 +2262,10 @@ func (m *MsgBorrowAsset) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgBorrowAsset: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgBorrow: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgBorrowAsset: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgBorrow: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2356,7 +2354,7 @@ func (m *MsgBorrowAsset) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgRepayAsset) Unmarshal(dAtA []byte) error {
+func (m *MsgRepay) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2379,10 +2377,10 @@ func (m *MsgRepayAsset) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgRepayAsset: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgRepay: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgRepayAsset: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgRepay: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2701,7 +2699,7 @@ func (m *MsgSupplyResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgWithdrawAssetResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgWithdrawResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2724,10 +2722,10 @@ func (m *MsgWithdrawAssetResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgWithdrawAssetResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgWithdrawResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgWithdrawAssetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgWithdrawResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -2751,7 +2749,7 @@ func (m *MsgWithdrawAssetResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgAddCollateralResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgCollateralizeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2774,10 +2772,10 @@ func (m *MsgAddCollateralResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgAddCollateralResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgCollateralizeResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgAddCollateralResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgCollateralizeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -2801,7 +2799,7 @@ func (m *MsgAddCollateralResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgRemoveCollateralResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgDecollateralizeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2824,10 +2822,10 @@ func (m *MsgRemoveCollateralResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgRemoveCollateralResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgDecollateralizeResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgRemoveCollateralResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgDecollateralizeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -2851,7 +2849,7 @@ func (m *MsgRemoveCollateralResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgBorrowAssetResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgBorrowResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2874,10 +2872,10 @@ func (m *MsgBorrowAssetResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgBorrowAssetResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgBorrowResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgBorrowAssetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgBorrowResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -2901,7 +2899,7 @@ func (m *MsgBorrowAssetResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *MsgRepayAssetResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgRepayResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2924,10 +2922,10 @@ func (m *MsgRepayAssetResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: MsgRepayAssetResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgRepayResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: MsgRepayAssetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgRepayResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:


### PR DESCRIPTION
## Description

closes: #1101

| Old Name | New Name |
| - | - |
| MsgWithdrawAsset | MsgWithdraw |
| MsgBorrowAsset | MsgBorrow |
| MsgRepayAsset | MsgRepay |
| MsgAddCollateral | MsgCollateralize |
| MsgRemoveCollateral | MsgDecollateralize |

The associated grpc services are also renamed (e.g. `WithdrawAsset` -> `Withdraw`)

Note that `MsgSupply` and `MsgLiquidate` are unchanged in this PR.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] added appropriate labels to the PR
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed