### PR TITLE
refactor: add PrintOrErr util function and improve devux in cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [1096](https://github.com/umee-network/umee/pull/1096) Add `max_collateral_share` to the x/leverage token registry.
 - [1094](https://github.com/umee-network/umee/pull/1094) Added TotalCollateral query.
 - [1099](https://github.com/umee-network/umee/pull/1099) Added TotalBorrowed query.
+- [1157](https://github.com/umee-network/umee/pull/1157) Added `PrintOrErr` util function optimizing the CLI code flow.
 
 ### Improvements
 

--- a/util/cli/print.go
+++ b/util/cli/print.go
@@ -5,6 +5,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+// PrintOrErr formats and print proto message to the standard output, unless the error
+// is not nil.
 func PrintOrErr(resp proto.Message, err error, cctx client.Context) error {
 	if err != nil {
 		return err

--- a/util/cli/print.go
+++ b/util/cli/print.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/gogo/protobuf/proto"
+)
+
+func PrintOrErr(resp proto.Message, err error, cctx client.Context) error {
+	if err != nil {
+		return err
+	}
+	return cctx.PrintProto(resp)
+}

--- a/x/leverage/client/cli/query.go
+++ b/x/leverage/client/cli/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	"github.com/umee-network/umee/v2/util/cli"
 	"github.com/umee-network/umee/v2/x/leverage/types"
 )
 
@@ -65,13 +66,8 @@ func GetCmdQueryAllRegisteredTokens() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			resp, err := queryClient.RegisteredTokens(cmd.Context(), &types.QueryRegisteredTokens{})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -94,13 +90,8 @@ func GetCmdQueryParams() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			resp, err := queryClient.Params(cmd.Context(), &types.QueryParams{})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -123,20 +114,14 @@ func GetCmdQueryBorrowed() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryBorrowed{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.Borrowed(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -160,20 +145,14 @@ func GetCmdQueryBorrowedValue() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryBorrowedValue{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.BorrowedValue(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -197,20 +176,14 @@ func GetCmdQuerySupplied() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QuerySupplied{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.Supplied(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -234,20 +207,14 @@ func GetCmdQuerySuppliedValue() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QuerySuppliedValue{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.SuppliedValue(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -271,17 +238,11 @@ func GetCmdQueryReserveAmount() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryReserveAmount{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.ReserveAmount(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -304,20 +265,14 @@ func GetCmdQueryCollateral() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryCollateral{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.Collateral(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -341,20 +296,14 @@ func GetCmdQueryCollateralValue() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryCollateralValue{
 				Address: args[0],
 			}
 			if d, err := cmd.Flags().GetString(FlagDenom); len(d) > 0 && err == nil {
 				req.Denom = d
 			}
-
 			resp, err := queryClient.CollateralValue(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -378,17 +327,11 @@ func GetCmdQueryExchangeRate() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryExchangeRate{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.ExchangeRate(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -411,17 +354,11 @@ func GetCmdQueryAvailableBorrow() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryAvailableBorrow{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.AvailableBorrow(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -444,17 +381,11 @@ func GetCmdQuerySupplyAPY() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QuerySupplyAPY{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.SupplyAPY(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -477,17 +408,11 @@ func GetCmdQueryBorrowAPY() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryBorrowAPY{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.BorrowAPY(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -510,17 +435,11 @@ func GetCmdQueryTotalSuppliedValue() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryTotalSuppliedValue{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.TotalSuppliedValue(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -543,17 +462,11 @@ func GetCmdQueryTotalSupplied() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryTotalSupplied{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.TotalSupplied(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -576,17 +489,11 @@ func GetCmdQueryBorrowLimit() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryBorrowLimit{
 				Address: args[0],
 			}
-
 			resp, err := queryClient.BorrowLimit(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -609,17 +516,11 @@ func GetCmdQueryLiquidationThreshold() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryLiquidationThreshold{
 				Address: args[0],
 			}
-
 			resp, err := queryClient.LiquidationThreshold(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -642,17 +543,11 @@ func GetCmdQueryMarketSummary() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryMarketSummary{
 				Denom: args[0],
 			}
-
 			resp, err := queryClient.MarketSummary(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -675,15 +570,9 @@ func GetCmdQueryLiquidationTargets() *cobra.Command {
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)
-
 			req := &types.QueryLiquidationTargets{}
-
 			resp, err := queryClient.LiquidationTargets(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -710,11 +599,7 @@ func GetCmdQueryTotalCollateral() *cobra.Command {
 				Denom: args[0],
 			}
 			resp, err := queryClient.TotalCollateral(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 
@@ -741,11 +626,7 @@ func GetCmdQueryTotalBorrowed() *cobra.Command {
 				Denom: args[0],
 			}
 			resp, err := queryClient.TotalBorrowed(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(resp)
+			return cli.PrintOrErr(resp, err, clientCtx)
 		},
 	}
 

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
+	"github.com/umee-network/umee/v2/util/cli"
 	"github.com/umee-network/umee/v2/x/oracle/types"
 )
 
@@ -52,11 +53,7 @@ func GetCmdQueryParams() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			res, err := queryClient.Params(context.Background(), &types.QueryParams{})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -101,11 +98,7 @@ $ umeed query oracle aggregate-votes umeevaloper...
 			}
 
 			res, err := queryClient.AggregateVote(context.Background(), &query)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -150,11 +143,7 @@ $ umeed query oracle aggregate-prevotes umeevaloper...
 			}
 
 			res, err := queryClient.AggregatePrevote(context.Background(), &query)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -185,11 +174,7 @@ $ umeed query oracle exchange-rates
 				context.Background(),
 				&types.QueryExchangeRates{},
 			)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -221,11 +206,7 @@ $ umeed query oracle exchange-rate ATOM
 					Denom: args[0],
 				},
 			)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -254,11 +235,7 @@ func GetCmdQueryFeederDelegation() *cobra.Command {
 			res, err := queryClient.FeederDelegation(context.Background(), &types.QueryFeederDelegation{
 				ValidatorAddr: args[0],
 			})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -287,11 +264,7 @@ func GetCmdQueryMissCounter() *cobra.Command {
 			res, err := queryClient.MissCounter(context.Background(), &types.QueryMissCounter{
 				ValidatorAddr: args[0],
 			})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 
@@ -312,11 +285,7 @@ func GetCmdQuerySlashWindow() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			res, err := queryClient.SlashWindow(context.Background(), &types.QuerySlashWindow{})
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			return cli.PrintOrErr(res, err, clientCtx)
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

In cli code we have a lot of code repetition related to handling error and printing proto message.

This PR introduces a `PrintOrErr` util function to reduce repeated code.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
