### PR TITLE
fix: update deprecated osmosis api endpoint

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bugs
 
 - [1084](https://github.com/umee-network/umee/pull/1084) Initializes block height before subscription to fix an error message that appeared on the first few ticks.
+- [1177](https://github.com/umee-network/umee/pull/1177) Update a deprecated osmosis api endpoint.
 
 ### Improvements
 

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -81,6 +81,10 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to make Osmosis request: %w", err)
 	}
+	err = checkHTTPStatus(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	defer resp.Body.Close()
 
@@ -150,6 +154,10 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		if err != nil {
 			return nil, fmt.Errorf("failed to make Osmosis request: %w", err)
 		}
+		err = checkHTTPStatus(resp)
+		if err != nil {
+			return nil, err
+		}
 
 		defer resp.Body.Close()
 
@@ -187,6 +195,10 @@ func (p OsmosisProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = checkHTTPStatus(resp)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 
 	var pairsSummary OsmosisPairsSummary
@@ -208,5 +220,12 @@ func (p OsmosisProvider) GetAvailablePairs() (map[string]struct{}, error) {
 
 // SubscribeCurrencyPairs performs a no-op since osmosis does not use websockets
 func (p OsmosisProvider) SubscribeCurrencyPairs(pairs ...types.CurrencyPair) error {
+	return nil
+}
+
+func checkHTTPStatus(resp *http.Response) error {
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
 	return nil
 }

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	osmosisRestURL        = "https://api-osmosis.imperator.co"
-	osmosisTokenEndpoint  = "/tokens/v1"
+	osmosisTokenEndpoint  = "/tokens/v2"
 	osmosisCandleEndpoint = "/tokens/v2/historical"
 	osmosisPairsEndpoint  = "/pairs/v1/summary"
 )

--- a/price-feeder/oracle/provider/osmosis_test.go
+++ b/price-feeder/oracle/provider/osmosis_test.go
@@ -16,7 +16,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,
@@ -52,7 +52,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,
@@ -93,7 +93,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_bad_response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			rw.Write([]byte(`FOO`))
 		}))
 		defer server.Close()
@@ -108,7 +108,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

Update a deprecated osmosis endpoint that was causing the price feeder to be inaccurate

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
