### PR TITLE
fix: make lint OSX compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,8 @@ endif
 
 lint:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
-	@cd price-feeder && go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m
+	@cd price-feeder && go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m
 
 cover-html: test-unit-cover
 	@echo "--> Opening in the browser"

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,8 @@ endif
 
 lint:
 	@echo "--> Running linter"
-	@find -name go.mod -execdir go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m \;
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
+	@cd price-feeder && go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
 
 cover-html: test-unit-cover
 	@echo "--> Opening in the browser"

--- a/price-feeder/Makefile
+++ b/price-feeder/Makefile
@@ -48,6 +48,6 @@ test-unit:
 
 lint:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m
 
 .PHONY: lint

--- a/price-feeder/Makefile
+++ b/price-feeder/Makefile
@@ -48,6 +48,6 @@ test-unit:
 
 lint:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix --timeout=8m;
 
 .PHONY: lint


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

#1221 introduced a `find -name` into the `make lint`, which does not work on OSX.

```
--> Running linter
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
make: *** [lint] Error 1
```

This removes the usage of find.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
