### PR TITLE
refactor(price-feeder): Move TickerPrice and CandlePrice to types package

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#1032](https://github.com/umee-network/umee/pull/1032) Update the accepted tvwap period from 3 minutes to 5 minutes.
 - [#978](https://github.com/umee-network/umee/pull/978) Cleanup the oracle package by moving deviation & conversion logic.
 - [#1175](https://github.com/umee-network/umee/pull/1175) Add type ProviderName.
+- [#1255](https://github.com/umee-network/umee/pull/1255) Move TickerPrice and CandlePrice to types package
 
 ### Features
 

--- a/price-feeder/oracle/convert.go
+++ b/price-feeder/oracle/convert.go
@@ -68,7 +68,7 @@ func convertCandlesToUSD(
 						for base, candle := range candleSet {
 							if base == pair.Quote {
 								if _, ok := validCandleList[providerName]; !ok {
-									validCandleList[providerName] = make(map[string][]provider.CandlePrice)
+									validCandleList[providerName] = make(map[string][]types.CandlePrice)
 								}
 
 								validCandleList[providerName][base] = candle
@@ -157,7 +157,7 @@ func convertTickersToUSD(
 						for base, ticker := range candleSet {
 							if base == pair.Quote {
 								if _, ok := validTickerList[providerName]; !ok {
-									validTickerList[providerName] = make(map[string]provider.TickerPrice)
+									validTickerList[providerName] = make(map[string]types.TickerPrice)
 								}
 
 								validTickerList[providerName][base] = ticker
@@ -194,7 +194,7 @@ func convertTickersToUSD(
 	for providerName, assetMap := range tickers {
 		for asset := range assetMap {
 			if requiredConversions[providerName].Base == asset {
-				assetMap[asset] = provider.TickerPrice{
+				assetMap[asset] = types.TickerPrice{
 					Price: assetMap[asset].Price.Mul(
 						conversionRates[requiredConversions[providerName].Quote],
 					),

--- a/price-feeder/oracle/convert_test.go
+++ b/price-feeder/oracle/convert_test.go
@@ -76,7 +76,7 @@ func TestGetUSDBasedProviders(t *testing.T) {
 func TestConvertCandlesToUSD(t *testing.T) {
 	providerCandles := make(provider.AggregatedProviderCandles, 2)
 
-	binanceCandles := map[string][]provider.CandlePrice{
+	binanceCandles := map[string][]types.CandlePrice{
 		"ATOM": {{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -85,7 +85,7 @@ func TestConvertCandlesToUSD(t *testing.T) {
 	}
 	providerCandles[provider.ProviderBinance] = binanceCandles
 
-	krakenCandles := map[string][]provider.CandlePrice{
+	krakenCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
@@ -117,7 +117,7 @@ func TestConvertCandlesToUSD(t *testing.T) {
 func TestConvertCandlesToUSDFiltering(t *testing.T) {
 	providerCandles := make(provider.AggregatedProviderCandles, 2)
 
-	binanceCandles := map[string][]provider.CandlePrice{
+	binanceCandles := map[string][]types.CandlePrice{
 		"ATOM": {{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -126,7 +126,7 @@ func TestConvertCandlesToUSDFiltering(t *testing.T) {
 	}
 	providerCandles[provider.ProviderBinance] = binanceCandles
 
-	krakenCandles := map[string][]provider.CandlePrice{
+	krakenCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
@@ -135,7 +135,7 @@ func TestConvertCandlesToUSDFiltering(t *testing.T) {
 	}
 	providerCandles[provider.ProviderKraken] = krakenCandles
 
-	gateCandles := map[string][]provider.CandlePrice{
+	gateCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
@@ -144,7 +144,7 @@ func TestConvertCandlesToUSDFiltering(t *testing.T) {
 	}
 	providerCandles[provider.ProviderGate] = gateCandles
 
-	okxCandles := map[string][]provider.CandlePrice{
+	okxCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     sdk.MustNewDecFromStr("100.0"),
 			Volume:    usdtVolume,
@@ -178,7 +178,7 @@ func TestConvertCandlesToUSDFiltering(t *testing.T) {
 func TestConvertTickersToUSD(t *testing.T) {
 	providerPrices := make(provider.AggregatedProviderPrices, 2)
 
-	binanceTickers := map[string]provider.TickerPrice{
+	binanceTickers := map[string]types.TickerPrice{
 		"ATOM": {
 			Price:  atomPrice,
 			Volume: atomVolume,
@@ -186,7 +186,7 @@ func TestConvertTickersToUSD(t *testing.T) {
 	}
 	providerPrices[provider.ProviderBinance] = binanceTickers
 
-	krakenTicker := map[string]provider.TickerPrice{
+	krakenTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  usdtPrice,
 			Volume: usdtVolume,
@@ -217,7 +217,7 @@ func TestConvertTickersToUSD(t *testing.T) {
 func TestConvertTickersToUSDFiltering(t *testing.T) {
 	providerPrices := make(provider.AggregatedProviderPrices, 2)
 
-	binanceTickers := map[string]provider.TickerPrice{
+	binanceTickers := map[string]types.TickerPrice{
 		"ATOM": {
 			Price:  atomPrice,
 			Volume: atomVolume,
@@ -225,7 +225,7 @@ func TestConvertTickersToUSDFiltering(t *testing.T) {
 	}
 	providerPrices[provider.ProviderBinance] = binanceTickers
 
-	krakenTicker := map[string]provider.TickerPrice{
+	krakenTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  usdtPrice,
 			Volume: usdtVolume,
@@ -233,12 +233,12 @@ func TestConvertTickersToUSDFiltering(t *testing.T) {
 	}
 	providerPrices[provider.ProviderKraken] = krakenTicker
 
-	gateTicker := map[string]provider.TickerPrice{
+	gateTicker := map[string]types.TickerPrice{
 		"USDT": krakenTicker["USDT"],
 	}
 	providerPrices[provider.ProviderGate] = gateTicker
 
-	huobiTicker := map[string]provider.TickerPrice{
+	huobiTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  sdk.MustNewDecFromStr("10000"),
 			Volume: usdtVolume,

--- a/price-feeder/oracle/filter.go
+++ b/price-feeder/oracle/filter.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 // defaultDeviationThreshold defines how many 𝜎 a provider can be away
@@ -53,7 +54,7 @@ func FilterTickerDeviations(
 			if d, ok := deviations[base]; !ok || isBetween(tp.Price, means[base], d.Mul(t)) {
 				p, ok := filteredPrices[providerName]
 				if !ok {
-					p = map[string]provider.TickerPrice{}
+					p = map[string]types.TickerPrice{}
 					filteredPrices[providerName] = p
 				}
 				p[base] = tp
@@ -89,7 +90,7 @@ func FilterCandleDeviations(
 		for base, cp := range priceCandles {
 			p, ok := candlePrices[providerName]
 			if !ok {
-				p = map[string][]provider.CandlePrice{}
+				p = map[string][]types.CandlePrice{}
 				candlePrices[providerName] = p
 			}
 			p[base] = cp
@@ -127,7 +128,7 @@ func FilterCandleDeviations(
 			if d, ok := deviations[base]; !ok || isBetween(price, means[base], d.Mul(t)) {
 				p, ok := filteredCandles[providerName]
 				if !ok {
-					p = map[string][]provider.CandlePrice{}
+					p = map[string][]types.CandlePrice{}
 					filteredCandles[providerName] = p
 				}
 				p[base] = candles[providerName][base]

--- a/price-feeder/oracle/filter_test.go
+++ b/price-feeder/oracle/filter_test.go
@@ -21,7 +21,7 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("1994674.34000000")
 
-	atomCandlePrice := []provider.CandlePrice{
+	atomCandlePrice := []types.CandlePrice{
 		{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -29,16 +29,16 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 		},
 	}
 
-	providerCandles[provider.ProviderBinance] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderBinance] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[provider.ProviderHuobi] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderHuobi] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[provider.ProviderKraken] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderKraken] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[provider.ProviderCoinbase] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderCoinbase] = map[string][]types.CandlePrice{
 		pair.Base: {
 			{
 				Price:     sdk.MustNewDecFromStr("27.1"),
@@ -82,21 +82,21 @@ func TestSuccessFilterTickerDeviations(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("1994674.34000000")
 
-	atomTickerPrice := provider.TickerPrice{
+	atomTickerPrice := types.TickerPrice{
 		Price:  atomPrice,
 		Volume: atomVolume,
 	}
 
-	providerTickers[provider.ProviderBinance] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderBinance] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[provider.ProviderHuobi] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderHuobi] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[provider.ProviderKraken] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderKraken] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[provider.ProviderCoinbase] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderCoinbase] = map[string]types.TickerPrice{
 		pair.Base: {
 			Price:  sdk.MustNewDecFromStr("27.1"),
 			Volume: atomVolume,

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -190,8 +190,8 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 		}
 
 		g.Go(func() error {
-			prices := make(map[string]provider.TickerPrice, 0)
-			candles := make(map[string][]provider.CandlePrice, 0)
+			prices := make(map[string]types.TickerPrice, 0)
+			candles := make(map[string][]types.CandlePrice, 0)
 			ch := make(chan struct{})
 			errCh := make(chan error, 1)
 
@@ -344,15 +344,15 @@ func SetProviderTickerPricesAndCandles(
 	providerName provider.Name,
 	providerPrices provider.AggregatedProviderPrices,
 	providerCandles provider.AggregatedProviderCandles,
-	prices map[string]provider.TickerPrice,
-	candles map[string][]provider.CandlePrice,
+	prices map[string]types.TickerPrice,
+	candles map[string][]types.CandlePrice,
 	pair types.CurrencyPair,
 ) (success bool) {
 	if _, ok := providerPrices[providerName]; !ok {
-		providerPrices[providerName] = make(map[string]provider.TickerPrice)
+		providerPrices[providerName] = make(map[string]types.TickerPrice)
 	}
 	if _, ok := providerCandles[providerName]; !ok {
-		providerCandles[providerName] = make(map[string][]provider.CandlePrice)
+		providerCandles[providerName] = make(map[string][]types.CandlePrice)
 	}
 
 	tp, pricesOk := prices[pair.String()]

--- a/price-feeder/oracle/oracle_test.go
+++ b/price-feeder/oracle/oracle_test.go
@@ -18,17 +18,17 @@ import (
 )
 
 type mockProvider struct {
-	prices map[string]provider.TickerPrice
+	prices map[string]types.TickerPrice
 }
 
-func (m mockProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]provider.TickerPrice, error) {
+func (m mockProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	return m.prices, nil
 }
 
-func (m mockProvider) GetCandlePrices(_ ...types.CurrencyPair) (map[string][]provider.CandlePrice, error) {
-	candles := make(map[string][]provider.CandlePrice)
+func (m mockProvider) GetCandlePrices(_ ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candles := make(map[string][]types.CandlePrice)
 	for pair, price := range m.prices {
-		candles[pair] = []provider.CandlePrice{
+		candles[pair] = []types.CandlePrice{
 			{
 				Price:     price.Price,
 				TimeStamp: provider.PastUnixTime(1 * time.Minute),
@@ -48,14 +48,14 @@ func (m mockProvider) GetAvailablePairs() (map[string]struct{}, error) {
 }
 
 type failingProvider struct {
-	prices map[string]provider.TickerPrice
+	prices map[string]types.TickerPrice
 }
 
-func (m failingProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]provider.TickerPrice, error) {
+func (m failingProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	return nil, fmt.Errorf("unable to get ticker prices")
 }
 
-func (m failingProvider) GetCandlePrices(_ ...types.CurrencyPair) (map[string][]provider.CandlePrice, error) {
+func (m failingProvider) GetCandlePrices(_ ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
 	return nil, fmt.Errorf("unable to get candle prices")
 }
 
@@ -139,7 +139,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	// configuration.
 	ots.oracle.priceProviders = map[provider.Name]provider.Provider{
 		provider.ProviderBinance: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDX": {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
@@ -147,7 +147,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderKraken: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDX": {
 					Price:  sdk.MustNewDecFromStr("3.70"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -162,7 +162,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	// use a mock provider without a conversion rate for these stablecoins
 	ots.oracle.priceProviders = map[provider.Name]provider.Provider{
 		provider.ProviderBinance: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDT": {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
@@ -170,7 +170,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderKraken: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDC": {
 					Price:  sdk.MustNewDecFromStr("3.70"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -187,7 +187,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	// use a mock provider to provide prices for the configured exchange pairs
 	ots.oracle.priceProviders = map[provider.Name]provider.Provider{
 		provider.ProviderBinance: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDT": {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
@@ -195,7 +195,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderKraken: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDC": {
 					Price:  sdk.MustNewDecFromStr("3.70"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -203,7 +203,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderHuobi: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDCUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("2396974.34000000"),
@@ -211,7 +211,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderCoinbase: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDTUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -219,7 +219,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderOsmosis: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"XBTUSDT": {
 					Price:  sdk.MustNewDecFromStr("3.717"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -240,7 +240,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	// use one working provider and one provider with an incorrect exchange rate
 	ots.oracle.priceProviders = map[provider.Name]provider.Provider{
 		provider.ProviderBinance: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDX": {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
@@ -248,7 +248,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderKraken: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDC": {
 					Price:  sdk.MustNewDecFromStr("3.70"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -256,7 +256,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderHuobi: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDCUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("2396974.34000000"),
@@ -264,7 +264,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderCoinbase: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDTUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -272,7 +272,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderOsmosis: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"XBTUSDT": {
 					Price:  sdk.MustNewDecFromStr("3.717"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -292,7 +292,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	// use one working provider and one provider that fails
 	ots.oracle.priceProviders = map[provider.Name]provider.Provider{
 		provider.ProviderBinance: failingProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDC": {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
@@ -300,7 +300,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderKraken: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"UMEEUSDC": {
 					Price:  sdk.MustNewDecFromStr("3.71"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -308,7 +308,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderHuobi: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDCUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("2396974.34000000"),
@@ -316,7 +316,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderCoinbase: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"USDTUSD": {
 					Price:  sdk.MustNewDecFromStr("1"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -324,7 +324,7 @@ func (ots *OracleTestSuite) TestPrices() {
 			},
 		},
 		provider.ProviderOsmosis: mockProvider{
-			prices: map[string]provider.TickerPrice{
+			prices: map[string]types.TickerPrice{
 				"XBTUSDT": {
 					Price:  sdk.MustNewDecFromStr("3.717"),
 					Volume: sdk.MustNewDecFromStr("1994674.34000000"),
@@ -398,14 +398,14 @@ func TestSuccessSetProviderTickerPricesAndCandles(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("894123.00")
 
-	prices := make(map[string]provider.TickerPrice, 1)
-	prices[pair.String()] = provider.TickerPrice{
+	prices := make(map[string]types.TickerPrice, 1)
+	prices[pair.String()] = types.TickerPrice{
 		Price:  atomPrice,
 		Volume: atomVolume,
 	}
 
-	candles := make(map[string][]provider.CandlePrice, 1)
-	candles[pair.String()] = []provider.CandlePrice{
+	candles := make(map[string][]types.CandlePrice, 1)
+	candles[pair.String()] = []types.CandlePrice{
 		{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -432,8 +432,8 @@ func TestFailedSetProviderTickerPricesAndCandles(t *testing.T) {
 		provider.ProviderCoinbase,
 		make(provider.AggregatedProviderPrices, 1),
 		make(provider.AggregatedProviderCandles, 1),
-		make(map[string]provider.TickerPrice, 1),
-		make(map[string][]provider.CandlePrice, 1),
+		make(map[string]types.TickerPrice, 1),
+		make(map[string][]types.CandlePrice, 1),
 		types.CurrencyPair{
 			Base:  "ATOM",
 			Quote: "USDT",
@@ -453,8 +453,8 @@ func TestSuccessGetComputedPricesCandles(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("894123.00")
 
-	candles := make(map[string][]provider.CandlePrice, 1)
-	candles[pair.Base] = []provider.CandlePrice{
+	candles := make(map[string][]types.CandlePrice, 1)
+	candles[pair.Base] = []types.CandlePrice{
 		{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -489,8 +489,8 @@ func TestSuccessGetComputedPricesTickers(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("894123.00")
 
-	tickerPrices := make(map[string]provider.TickerPrice, 1)
-	tickerPrices[pair.Base] = provider.TickerPrice{
+	tickerPrices := make(map[string]types.TickerPrice, 1)
+	tickerPrices[pair.Base] = types.TickerPrice{
 		Price:  atomPrice,
 		Volume: atomVolume,
 	}
@@ -532,15 +532,15 @@ func TestGetComputedPricesCandlesConversion(t *testing.T) {
 	providerCandles := make(provider.AggregatedProviderCandles, 4)
 
 	// normal rates
-	binanceCandles := make(map[string][]provider.CandlePrice, 2)
-	binanceCandles[btcPair.Base] = []provider.CandlePrice{
+	binanceCandles := make(map[string][]types.CandlePrice, 2)
+	binanceCandles[btcPair.Base] = []types.CandlePrice{
 		{
 			Price:     btcEthPrice,
 			Volume:    volume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		},
 	}
-	binanceCandles[ethPair.Base] = []provider.CandlePrice{
+	binanceCandles[ethPair.Base] = []types.CandlePrice{
 		{
 			Price:     ethUsdPrice,
 			Volume:    volume,
@@ -550,15 +550,15 @@ func TestGetComputedPricesCandlesConversion(t *testing.T) {
 	providerCandles[provider.ProviderBinance] = binanceCandles
 
 	// normal rates
-	gateCandles := make(map[string][]provider.CandlePrice, 1)
-	gateCandles[ethPair.Base] = []provider.CandlePrice{
+	gateCandles := make(map[string][]types.CandlePrice, 1)
+	gateCandles[ethPair.Base] = []types.CandlePrice{
 		{
 			Price:     ethUsdPrice,
 			Volume:    volume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		},
 	}
-	gateCandles[btcPair.Base] = []provider.CandlePrice{
+	gateCandles[btcPair.Base] = []types.CandlePrice{
 		{
 			Price:     btcEthPrice,
 			Volume:    volume,
@@ -568,8 +568,8 @@ func TestGetComputedPricesCandlesConversion(t *testing.T) {
 	providerCandles[provider.ProviderGate] = gateCandles
 
 	// abnormal eth rate
-	okxCandles := make(map[string][]provider.CandlePrice, 1)
-	okxCandles[ethPair.Base] = []provider.CandlePrice{
+	okxCandles := make(map[string][]types.CandlePrice, 1)
+	okxCandles[ethPair.Base] = []types.CandlePrice{
 		{
 			Price:     sdk.MustNewDecFromStr("1.0"),
 			Volume:    volume,
@@ -579,8 +579,8 @@ func TestGetComputedPricesCandlesConversion(t *testing.T) {
 	providerCandles[provider.ProviderOkx] = okxCandles
 
 	// btc / usd rate
-	krakenCandles := make(map[string][]provider.CandlePrice, 1)
-	krakenCandles[btcUSDPair.Base] = []provider.CandlePrice{
+	krakenCandles := make(map[string][]types.CandlePrice, 1)
+	krakenCandles[btcUSDPair.Base] = []types.CandlePrice{
 		{
 			Price:     btcUSDPrice,
 			Volume:    volume,
@@ -634,40 +634,40 @@ func TestGetComputedPricesTickersConversion(t *testing.T) {
 	providerPrices := make(provider.AggregatedProviderPrices, 1)
 
 	// normal rates
-	binanceTickerPrices := make(map[string]provider.TickerPrice, 2)
-	binanceTickerPrices[btcPair.Base] = provider.TickerPrice{
+	binanceTickerPrices := make(map[string]types.TickerPrice, 2)
+	binanceTickerPrices[btcPair.Base] = types.TickerPrice{
 		Price:  btcEthPrice,
 		Volume: volume,
 	}
-	binanceTickerPrices[ethPair.Base] = provider.TickerPrice{
+	binanceTickerPrices[ethPair.Base] = types.TickerPrice{
 		Price:  ethUsdPrice,
 		Volume: volume,
 	}
 	providerPrices[provider.ProviderBinance] = binanceTickerPrices
 
 	// normal rates
-	gateTickerPrices := make(map[string]provider.TickerPrice, 4)
-	gateTickerPrices[btcPair.Base] = provider.TickerPrice{
+	gateTickerPrices := make(map[string]types.TickerPrice, 4)
+	gateTickerPrices[btcPair.Base] = types.TickerPrice{
 		Price:  btcEthPrice,
 		Volume: volume,
 	}
-	gateTickerPrices[ethPair.Base] = provider.TickerPrice{
+	gateTickerPrices[ethPair.Base] = types.TickerPrice{
 		Price:  ethUsdPrice,
 		Volume: volume,
 	}
 	providerPrices[provider.ProviderGate] = gateTickerPrices
 
 	// abnormal eth rate
-	okxTickerPrices := make(map[string]provider.TickerPrice, 1)
-	okxTickerPrices[ethPair.Base] = provider.TickerPrice{
+	okxTickerPrices := make(map[string]types.TickerPrice, 1)
+	okxTickerPrices[ethPair.Base] = types.TickerPrice{
 		Price:  sdk.MustNewDecFromStr("1.0"),
 		Volume: volume,
 	}
 	providerPrices[provider.ProviderOkx] = okxTickerPrices
 
 	// btc / usd rate
-	krakenTickerPrices := make(map[string]provider.TickerPrice, 1)
-	krakenTickerPrices[btcUSDPair.Base] = provider.TickerPrice{
+	krakenTickerPrices := make(map[string]types.TickerPrice, 1)
+	krakenTickerPrices[btcUSDPair.Base] = types.TickerPrice{
 		Price:  btcUSDPrice,
 		Volume: volume,
 	}

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -127,8 +127,8 @@ func NewBinanceProvider(
 }
 
 // GetTickerPrices returns the tickerPrices based on the provided pairs.
-func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
@@ -143,8 +143,8 @@ func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[stri
 }
 
 // GetCandlePrices returns the candlePrices based on the provided pairs.
-func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
@@ -211,32 +211,32 @@ func (p *BinanceProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	return types.MapPairsToSlice(p.subscribedPairs)
 }
 
-func (p *BinanceProvider) getTickerPrice(key string) (TickerPrice, error) {
+func (p *BinanceProvider) getTickerPrice(key string) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	ticker, ok := p.tickers[key]
 	if !ok {
-		return TickerPrice{}, fmt.Errorf("binance failed to get ticker price for %s", key)
+		return types.TickerPrice{}, fmt.Errorf("binance failed to get ticker price for %s", key)
 	}
 
 	return ticker.toTickerPrice()
 }
 
-func (p *BinanceProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+func (p *BinanceProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[key]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("binance failed to get candle prices for %s", key)
+		return []types.CandlePrice{}, fmt.Errorf("binance failed to get candle prices for %s", key)
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 		candleList = append(candleList, cp)
 	}
@@ -313,12 +313,12 @@ func (p *BinanceProvider) setCandlePair(candle BinanceCandle) {
 	p.candles[candle.Symbol] = candleList
 }
 
-func (ticker BinanceTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice(string(ProviderBinance), ticker.Symbol, ticker.LastPrice, ticker.Volume)
+func (ticker BinanceTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(string(ProviderBinance), ticker.Symbol, ticker.LastPrice, ticker.Volume)
 }
 
-func (candle BinanceCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(string(ProviderBinance), candle.Symbol, candle.Metadata.Close, candle.Metadata.Volume,
+func (candle BinanceCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(string(ProviderBinance), candle.Symbol, candle.Metadata.Close, candle.Metadata.Volume,
 		candle.Metadata.TimeStamp)
 }
 

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -138,8 +138,8 @@ func NewCoinbaseProvider(
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *CoinbaseProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *CoinbaseProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
@@ -155,7 +155,7 @@ func (p *CoinbaseProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[str
 
 // GetCandlePrices returns candles based off of the saved trades map.
 // Candles need to be cut up into one-minute intervals.
-func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
+func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
 	tradeMap := make(map[string][]CoinbaseTrade, len(pairs))
 
 	for _, cp := range pairs {
@@ -170,7 +170,7 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 		return nil, fmt.Errorf("no trades have been received")
 	}
 
-	candles := make(map[string][]CandlePrice)
+	candles := make(map[string][]types.CandlePrice)
 
 	for cp := range tradeMap {
 		trades := tradeMap[cp]
@@ -179,7 +179,7 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 			return time.Unix(trades[i].Time, 0).Before(time.Unix(trades[j].Time, 0))
 		})
 
-		candleSlice := []CandlePrice{
+		candleSlice := []types.CandlePrice{
 			{
 				Price:  sdk.ZeroDec(),
 				Volume: sdk.ZeroDec(),
@@ -194,7 +194,7 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 			if trade.Time-startTime > unixMinute {
 				index++
 				startTime = trade.Time
-				candleSlice = append(candleSlice, CandlePrice{
+				candleSlice = append(candleSlice, types.CandlePrice{
 					Price:  sdk.ZeroDec(),
 					Volume: sdk.ZeroDec(),
 				})
@@ -210,7 +210,7 @@ func (p *CoinbaseProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[str
 			}
 
 			volume := candleSlice[index].Volume.Add(size)
-			candleSlice[index] = CandlePrice{
+			candleSlice[index] = types.CandlePrice{
 				Volume:    volume,     // aggregate size
 				Price:     price,      // most recent price
 				TimeStamp: trade.Time, // most recent timestamp
@@ -296,7 +296,7 @@ func (p *CoinbaseProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	return types.MapPairsToSlice(p.subscribedPairs)
 }
 
-func (p *CoinbaseProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
+func (p *CoinbaseProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
@@ -305,7 +305,7 @@ func (p *CoinbaseProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, e
 		return tickerPair.toTickerPrice()
 	}
 
-	return TickerPrice{}, fmt.Errorf("coinbase failed to get ticker price for %s", gp)
+	return types.TickerPrice{}, fmt.Errorf("coinbase failed to get ticker price for %s", gp)
 }
 
 func (p *CoinbaseProvider) getTradePrices(key string) ([]CoinbaseTrade, error) {
@@ -516,8 +516,8 @@ func (p *CoinbaseProvider) pongHandler(appData string) error {
 	return nil
 }
 
-func (ticker CoinbaseTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice(
+func (ticker CoinbaseTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(
 		string(ProviderCoinbase),
 		coinbasePairToCurrencyPair(ticker.ProductID),
 		ticker.Price,

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -152,8 +152,8 @@ func NewGateProvider(
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
@@ -168,8 +168,8 @@ func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 }
 
 // GetCandlePrices returns the candlePrices based on the saved map
-func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		gp := currencyPairToGatePair(currencyPair)
@@ -184,20 +184,20 @@ func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string]
 	return candlePrices, nil
 }
 
-func (p *GateProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+func (p *GateProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[key]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("gate failed to get candle prices for %s", key)
+		return []types.CandlePrice{}, fmt.Errorf("gate failed to get candle prices for %s", key)
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 
 		candleList = append(candleList, cp)
@@ -276,7 +276,7 @@ func (p *GateProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	return types.MapPairsToSlice(p.subscribedPairs)
 }
 
-func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
+func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
@@ -285,7 +285,7 @@ func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error
 		return tickerPair.toTickerPrice()
 	}
 
-	return TickerPrice{}, fmt.Errorf("gate failed to get ticker price for %s", gp)
+	return types.TickerPrice{}, fmt.Errorf("gate failed to get ticker price for %s", gp)
 }
 
 func (p *GateProvider) handleReceivedTickers(ctx context.Context) {
@@ -607,12 +607,12 @@ func (p *GateProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	return availablePairs, nil
 }
 
-func (ticker GateTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice(string(ProviderGate), ticker.Symbol, ticker.Last, ticker.Vol)
+func (ticker GateTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(string(ProviderGate), ticker.Symbol, ticker.Last, ticker.Vol)
 }
 
-func (candle GateCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(
+func (candle GateCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(
 		string(ProviderGate),
 		candle.Symbol,
 		candle.Close,

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -139,8 +139,8 @@ func NewHuobiProvider(
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
 		price, err := p.getTickerPrice(cp)
@@ -154,8 +154,8 @@ func (p *HuobiProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *HuobiProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, cp := range pairs {
 		price, err := p.getCandlePrices(cp)
@@ -419,32 +419,32 @@ func (p *HuobiProvider) subscribeCandlePair(cp types.CurrencyPair) error {
 	return p.wsClient.WriteJSON(huobiSubscriptionCandleMsg)
 }
 
-func (p *HuobiProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
+func (p *HuobiProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	ticker, ok := p.tickers[currencyPairToHuobiTickerPair(cp)]
 	if !ok {
-		return TickerPrice{}, fmt.Errorf("huobi failed to get ticker price for %s", cp.String())
+		return types.TickerPrice{}, fmt.Errorf("huobi failed to get ticker price for %s", cp.String())
 	}
 
 	return ticker.toTickerPrice()
 }
 
-func (p *HuobiProvider) getCandlePrices(cp types.CurrencyPair) ([]CandlePrice, error) {
+func (p *HuobiProvider) getCandlePrices(cp types.CurrencyPair) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[currencyPairToHuobiCandlePair(cp)]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("failed to get candles price for %s", cp.String())
+		return []types.CandlePrice{}, fmt.Errorf("failed to get candles price for %s", cp.String())
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 		candleList = append(candleList, cp)
 	}
@@ -494,8 +494,8 @@ func decompressGzip(bz []byte) ([]byte, error) {
 }
 
 // toTickerPrice converts current HuobiTicker to TickerPrice.
-func (ticker HuobiTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice(
+func (ticker HuobiTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(
 		string(ProviderHuobi),
 		ticker.CH,
 		strconv.FormatFloat(ticker.Tick.LastPrice, 'f', -1, 64),
@@ -503,8 +503,8 @@ func (ticker HuobiTicker) toTickerPrice() (TickerPrice, error) {
 	)
 }
 
-func (candle HuobiCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(
+func (candle HuobiCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(
 		string(ProviderHuobi),
 		candle.CH,
 		strconv.FormatFloat(candle.Tick.Close, 'f', -1, 64),

--- a/price-feeder/oracle/provider/kraken_test.go
+++ b/price-feeder/oracle/provider/kraken_test.go
@@ -23,8 +23,8 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 		lastPrice := sdk.MustNewDecFromStr("34.69000000")
 		volume := sdk.MustNewDecFromStr("2396974.02000000")
 
-		tickerMap := map[string]TickerPrice{}
-		tickerMap["ATOMUSDT"] = TickerPrice{
+		tickerMap := map[string]types.TickerPrice{}
+		tickerMap["ATOMUSDT"] = types.TickerPrice{
 			Price:  lastPrice,
 			Volume: volume,
 		}
@@ -43,13 +43,13 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 		lastPriceLuna := sdk.MustNewDecFromStr("41.35000000")
 		volume := sdk.MustNewDecFromStr("2396974.02000000")
 
-		tickerMap := map[string]TickerPrice{}
-		tickerMap["ATOMUSDT"] = TickerPrice{
+		tickerMap := map[string]types.TickerPrice{}
+		tickerMap["ATOMUSDT"] = types.TickerPrice{
 			Price:  lastPriceAtom,
 			Volume: volume,
 		}
 
-		tickerMap["LUNAUSDT"] = TickerPrice{
+		tickerMap["LUNAUSDT"] = types.TickerPrice{
 			Price:  lastPriceLuna,
 			Volume: volume,
 		}

--- a/price-feeder/oracle/provider/mock.go
+++ b/price-feeder/oracle/provider/mock.go
@@ -40,8 +40,8 @@ func NewMockProvider() *MockProvider {
 	}
 }
 
-func (p MockProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p MockProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	resp, err := p.client.Get(p.baseURL)
 	if err != nil {
@@ -84,7 +84,7 @@ func (p MockProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]T
 			return nil, fmt.Errorf("found duplicate ticker: %s", ticker)
 		}
 
-		tickerPrices[ticker] = TickerPrice{Price: price, Volume: volume}
+		tickerPrices[ticker] = types.TickerPrice{Price: price, Volume: volume}
 	}
 
 	for t := range tickerMap {
@@ -96,14 +96,14 @@ func (p MockProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]T
 	return tickerPrices, nil
 }
 
-func (p MockProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
+func (p MockProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
 	price, err := p.GetTickerPrices(pairs...)
 	if err != nil {
 		return nil, err
 	}
-	candles := make(map[string][]CandlePrice)
+	candles := make(map[string][]types.CandlePrice)
 	for pair, price := range price {
-		candles[pair] = []CandlePrice{
+		candles[pair] = []types.CandlePrice{
 			{
 				Price:     price.Price,
 				Volume:    price.Volume,

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -150,8 +150,8 @@ func NewOkxProvider(
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *OkxProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *OkxProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
@@ -166,8 +166,8 @@ func (p *OkxProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]T
 }
 
 // GetCandlePrices returns the candlePrices based on the saved map
-func (p *OkxProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *OkxProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		candles, err := p.getCandlePrices(currencyPair)
@@ -242,33 +242,33 @@ func (p *OkxProvider) subscribedPairsToSlice() []types.CurrencyPair {
 	return types.MapPairsToSlice(p.subscribedPairs)
 }
 
-func (p *OkxProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
+func (p *OkxProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	instrumentID := currencyPairToOkxPair(cp)
 	tickerPair, ok := p.tickers[instrumentID]
 	if !ok {
-		return TickerPrice{}, fmt.Errorf("okx failed to get ticker price for %s", instrumentID)
+		return types.TickerPrice{}, fmt.Errorf("okx failed to get ticker price for %s", instrumentID)
 	}
 
 	return tickerPair.toTickerPrice()
 }
 
-func (p *OkxProvider) getCandlePrices(cp types.CurrencyPair) ([]CandlePrice, error) {
+func (p *OkxProvider) getCandlePrices(cp types.CurrencyPair) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	instrumentID := currencyPairToOkxPair(cp)
 	candles, ok := p.candles[instrumentID]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("okx failed to get candle prices for %s", instrumentID)
+		return []types.CandlePrice{}, fmt.Errorf("okx failed to get candle prices for %s", instrumentID)
 	}
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 		candleList = append(candleList, cp)
 	}
@@ -494,12 +494,12 @@ func (p *OkxProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	return availablePairs, nil
 }
 
-func (ticker OkxTickerPair) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice(string(ProviderOkx), ticker.InstID, ticker.Last, ticker.Vol24h)
+func (ticker OkxTickerPair) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(string(ProviderOkx), ticker.InstID, ticker.Last, ticker.Vol24h)
 }
 
-func (candle OkxCandlePair) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(string(ProviderOkx), candle.InstID, candle.Close, candle.Volume, candle.TimeStamp)
+func (candle OkxCandlePair) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(string(ProviderOkx), candle.InstID, candle.Close, candle.Volume, candle.TimeStamp)
 }
 
 // currencyPairToOkxPair returns the expected pair instrument ID for Okx

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -73,7 +73,7 @@ func NewOsmosisProvider(endpoint Endpoint) *OsmosisProvider {
 	}
 }
 
-func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	path := fmt.Sprintf("%s%s/all", p.baseURL, osmosisTokenEndpoint)
 
 	resp, err := p.client.Get(path)
@@ -102,7 +102,7 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		baseDenomIdx[strings.ToUpper(cp.Base)] = cp
 	}
 
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 	for _, tr := range tokensResp {
 		symbol := strings.ToUpper(tr.Symbol) // symbol == base in a currency pair
 
@@ -128,7 +128,7 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 			return nil, fmt.Errorf("failed to read Osmosis volume (%s) for %s", volumeRaw, symbol)
 		}
 
-		tickerPrices[cp.String()] = TickerPrice{Price: price, Volume: volume}
+		tickerPrices[cp.String()] = types.TickerPrice{Price: price, Volume: volume}
 	}
 
 	for _, cp := range pairs {
@@ -140,11 +140,11 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 	return tickerPrices, nil
 }
 
-func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candles := make(map[string][]CandlePrice)
+func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candles := make(map[string][]types.CandlePrice)
 	for _, pair := range pairs {
 		if _, ok := candles[pair.Base]; !ok {
-			candles[pair.String()] = []CandlePrice{}
+			candles[pair.String()] = []types.CandlePrice{}
 		}
 
 		path := fmt.Sprintf("%s%s/%s/chart?tf=5", p.baseURL, osmosisCandleEndpoint, pair.Base)
@@ -170,11 +170,11 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 			return nil, fmt.Errorf("failed to unmarshal Osmosis response body: %w", err)
 		}
 
-		candlePrices := []CandlePrice{}
+		candlePrices := []types.CandlePrice{}
 		for _, responseCandle := range candlesResp {
 			closeStr := fmt.Sprintf("%f", responseCandle.Close)
 			volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
-			candlePrices = append(candlePrices, CandlePrice{
+			candlePrices = append(candlePrices, types.CandlePrice{
 				Price:     sdk.MustNewDecFromStr(closeStr),
 				Volume:    sdk.MustNewDecFromStr(volumeStr),
 				TimeStamp: responseCandle.Time,

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -1,11 +1,9 @@
 package provider
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
@@ -33,23 +31,16 @@ type (
 	// Provider defines an interface an exchange price provider must implement.
 	Provider interface {
 		// GetTickerPrices returns the tickerPrices based on the provided pairs.
-		GetTickerPrices(...types.CurrencyPair) (map[string]TickerPrice, error)
+		GetTickerPrices(...types.CurrencyPair) (map[string]types.TickerPrice, error)
 
 		// GetCandlePrices returns the candlePrices based on the provided pairs.
-		GetCandlePrices(...types.CurrencyPair) (map[string][]CandlePrice, error)
+		GetCandlePrices(...types.CurrencyPair) (map[string][]types.CandlePrice, error)
 
 		// GetAvailablePairs return all available pairs symbol to susbscribe.
 		GetAvailablePairs() (map[string]struct{}, error)
 
 		// SubscribeCurrencyPairs subscribe to ticker and candle channels for all pairs.
 		SubscribeCurrencyPairs(...types.CurrencyPair) error
-	}
-
-	// TickerPrice defines price and volume information for a symbol or ticker
-	// exchange rate.
-	TickerPrice struct {
-		Price  sdk.Dec // last trade price
-		Volume sdk.Dec // 24h volume
 	}
 
 	// Name name of an oracle provider. Usually it is an exchange
@@ -59,19 +50,11 @@ type (
 
 	// AggregatedProviderPrices defines a type alias for a map
 	// of provider -> asset -> TickerPrice
-	AggregatedProviderPrices map[Name]map[string]TickerPrice
+	AggregatedProviderPrices map[Name]map[string]types.TickerPrice
 
 	// AggregatedProviderCandles defines a type alias for a map
-	// of provider -> asset -> []CandlePrice
-	AggregatedProviderCandles map[Name]map[string][]CandlePrice
-
-	// CandlePrice defines price, volume, and time information for an
-	// exchange rate.
-	CandlePrice struct {
-		Price     sdk.Dec // last trade price
-		Volume    sdk.Dec // volume
-		TimeStamp int64   // timestamp
-	}
+	// of provider -> asset -> []types.CandlePrice
+	AggregatedProviderCandles map[Name]map[string][]types.CandlePrice
 
 	// Endpoint defines an override setting in our config for the
 	// hardcoded rest and websocket api endpoints.
@@ -102,34 +85,6 @@ func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 		Timeout:       timeout,
 		CheckRedirect: preventRedirect,
 	}
-}
-
-func newTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
-	price, err := sdk.NewDecFromStr(lastPrice)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)
-	}
-
-	volumeDec, err := sdk.NewDecFromStr(volume)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s", provider, volume, symbol)
-	}
-
-	return TickerPrice{Price: price, Volume: volumeDec}, nil
-}
-
-func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64) (CandlePrice, error) {
-	price, err := sdk.NewDecFromStr(lastPrice)
-	if err != nil {
-		return CandlePrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)
-	}
-
-	volumeDec, err := sdk.NewDecFromStr(volume)
-	if err != nil {
-		return CandlePrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s", provider, volume, symbol)
-	}
-
-	return CandlePrice{Price: price, Volume: volumeDec, TimeStamp: timeStamp}, nil
 }
 
 // PastUnixTime returns a millisecond timestamp that represents the unix time

--- a/price-feeder/oracle/types/candle_price.go
+++ b/price-feeder/oracle/types/candle_price.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// CandlePrice defines price, volume, and time information for an exchange rate.
+type CandlePrice struct {
+	Price     sdk.Dec // last trade price
+	Volume    sdk.Dec // volume
+	TimeStamp int64   // timestamp
+}
+
+// NewCandlePrice parses the lastPrice and volume to a decimal and returns a CandlePrice
+func NewCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64) (CandlePrice, error) {
+	price, err := sdk.NewDecFromStr(lastPrice)
+	if err != nil {
+		return CandlePrice{}, fmt.Errorf("failed to parse %s price (%s) for %s: %w", provider, lastPrice, symbol, err)
+	}
+
+	volumeDec, err := sdk.NewDecFromStr(volume)
+	if err != nil {
+		return CandlePrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s: %w", provider, volume, symbol, err)
+	}
+
+	return CandlePrice{Price: price, Volume: volumeDec, TimeStamp: timeStamp}, nil
+}

--- a/price-feeder/oracle/types/candle_price_test.go
+++ b/price-feeder/oracle/types/candle_price_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCandlePrice(t *testing.T) {
+	price := "105473.43"
+	volume := "48394"
+	timeStamp := int64(1257894000)
+
+	t.Run("when the inputs are valid", func(t *testing.T) {
+		candlePrice, err := NewCandlePrice("binance", "BTC", price, volume, timeStamp)
+		require.Nil(t, err, "expected the returned error to be nil")
+
+		parsedPrice, _ := sdk.NewDecFromStr(price)
+		require.Equal(t, candlePrice.Price, parsedPrice)
+
+		parsedVolume, _ := sdk.NewDecFromStr(volume)
+		require.Equal(t, candlePrice.Volume, parsedVolume)
+
+		require.Equal(t, candlePrice.TimeStamp, timeStamp)
+	})
+
+	t.Run("when the lastPrice input is invalid", func(t *testing.T) {
+		_, err := NewCandlePrice("binance", "BTC", "bad_price", volume, timeStamp)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+
+	t.Run("when the volume input is invalid", func(t *testing.T) {
+		_, err := NewCandlePrice("binance", "BTC", price, "bad_volume", timeStamp)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+}

--- a/price-feeder/oracle/types/ticker_price.go
+++ b/price-feeder/oracle/types/ticker_price.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TickerPrice defines price and volume information for a symbol or ticker exchange rate.
+type TickerPrice struct {
+	Price  sdk.Dec // last trade price
+	Volume sdk.Dec // 24h volume
+}
+
+// NewTickerPrice parses the lastPrice and volume to a decimal and returns a TickerPrice
+func NewTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
+	price, err := sdk.NewDecFromStr(lastPrice)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s: %w", provider, lastPrice, symbol, err)
+	}
+
+	volumeDec, err := sdk.NewDecFromStr(volume)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s: %w", provider, volume, symbol, err)
+	}
+
+	return TickerPrice{Price: price, Volume: volumeDec}, nil
+}

--- a/price-feeder/oracle/types/ticker_price_test.go
+++ b/price-feeder/oracle/types/ticker_price_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTicketPrice(t *testing.T) {
+	price := "105473.43"
+	volume := "48394"
+
+	t.Run("when the inputs are valid", func(t *testing.T) {
+		tickerPrice, err := NewTickerPrice("binance", "BTC", price, volume)
+		require.Nil(t, err, "expected the returned error to be nil")
+
+		parsedPrice, _ := sdk.NewDecFromStr(price)
+		require.Equal(t, tickerPrice.Price, parsedPrice)
+
+		parsedVolume, _ := sdk.NewDecFromStr(volume)
+		require.Equal(t, tickerPrice.Volume, parsedVolume)
+	})
+
+	t.Run("when the lastPrice input is invalid", func(t *testing.T) {
+		_, err := NewTickerPrice("binance", "BTC", "bad_price", volume)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+
+	t.Run("when the volume input is invalid", func(t *testing.T) {
+		_, err := NewTickerPrice("binance", "BTC", price, "bad_volume")
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+}

--- a/price-feeder/oracle/util_test.go
+++ b/price-feeder/oracle/util_test.go
@@ -7,15 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/umee-network/umee/price-feeder/oracle"
 	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/oracle/types"
 )
 
 func TestComputeVWAP(t *testing.T) {
 	testCases := map[string]struct {
-		prices   map[provider.Name]map[string]provider.TickerPrice
+		prices   map[provider.Name]map[string]types.TickerPrice
 		expected map[string]sdk.Dec
 	}{
 		"empty prices": {
-			prices:   make(map[provider.Name]map[string]provider.TickerPrice),
+			prices:   make(map[provider.Name]map[string]types.TickerPrice),
 			expected: make(map[string]sdk.Dec),
 		},
 		"nil prices": {
@@ -23,33 +24,33 @@ func TestComputeVWAP(t *testing.T) {
 			expected: make(map[string]sdk.Dec),
 		},
 		"non empty prices": {
-			prices: map[provider.Name]map[string]provider.TickerPrice{
+			prices: map[provider.Name]map[string]types.TickerPrice{
 				provider.ProviderBinance: {
-					"ATOM": provider.TickerPrice{
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.21000000"),
 						Volume: sdk.MustNewDecFromStr("2749102.78000000"),
 					},
-					"UMEE": provider.TickerPrice{
+					"UMEE": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("1.13000000"),
 						Volume: sdk.MustNewDecFromStr("249102.38000000"),
 					},
-					"LUNA": provider.TickerPrice{
+					"LUNA": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87000000"),
 						Volume: sdk.MustNewDecFromStr("7854934.69000000"),
 					},
 				},
 				provider.ProviderKraken: {
-					"ATOM": provider.TickerPrice{
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.268700"),
 						Volume: sdk.MustNewDecFromStr("178277.53314385"),
 					},
-					"LUNA": provider.TickerPrice{
+					"LUNA": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87853000"),
 						Volume: sdk.MustNewDecFromStr("458917.46353577"),
 					},
 				},
 				"FOO": {
-					"ATOM": provider.TickerPrice{
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.168700"),
 						Volume: sdk.MustNewDecFromStr("4749102.53314385"),
 					},


### PR DESCRIPTION
The TickerPrice and CandlePrice types are used across the oracle package so they are being moved to the types package to cleanup the provider code 

- Move TickerPrice and CandlePrice to the types package
- Move the NewTickerPrice and NewCandlePrice functions to the type package
- Add tests for NewTickerPrice and NewCandlePrice

<!-- markdownlint-disable MD041 -->

## Description

closes: https://github.com/umee-network/umee/issues/936

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] added appropriate labels to the PR
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
