### PR TITLE
fix(price-feeder): fix osmosis timestamp

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [1084](https://github.com/umee-network/umee/pull/1084) Initializes block height before subscription to fix an error message that appeared on the first few ticks.
 - [1244](https://github.com/umee-network/umee/pull/1244) Add verification for quote in conversion rate.
+- [1264](https://github.com/umee-network/umee/pull/1264) Convert osmosis candle timestamp from seconds to milliseconds.
 
 ### Improvements
 

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -498,7 +498,7 @@ func (p *GateProvider) setCandlePair(candle GateCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert gate timestamp seconds -> milliseconds
-	candle.TimeStamp *= int64(time.Second / time.Millisecond)
+	candle.TimeStamp = SecondsToMilli(candle.TimeStamp)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []GateCandle{}
 

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -367,7 +367,7 @@ func (p *HuobiProvider) setCandlePair(candle HuobiCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert huobi timestamp seconds -> milliseconds
-	candle.Tick.TimeStamp *= int64(time.Second / time.Millisecond)
+	candle.Tick.TimeStamp = SecondsToMilli(candle.Tick.TimeStamp)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []HuobiCandle{}
 	candleList = append(candleList, candle)

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -579,7 +579,7 @@ func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert kraken timestamp seconds -> milliseconds
-	candle.TimeStamp *= int64(time.Second / time.Millisecond)
+	candle.TimeStamp = SecondsToMilli(candle.TimeStamp)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []KrakenCandle{}
 

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/umee-network/umee/price-feeder/oracle/types"
@@ -177,8 +178,8 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 			candlePrices = append(candlePrices, types.CandlePrice{
 				Price:  sdk.MustNewDecFromStr(closeStr),
 				Volume: sdk.MustNewDecFromStr(volumeStr),
-				// Convert timestamp to milliseconds
-				TimeStamp: responseCandle.Time * 1000,
+				// convert osmosis timestamp seconds -> milliseconds
+				TimeStamp: responseCandle.Time * int64(time.Second/time.Millisecond),
 			})
 		}
 		candles[pair.String()] = candlePrices

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -175,9 +175,10 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 			closeStr := fmt.Sprintf("%f", responseCandle.Close)
 			volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
 			candlePrices = append(candlePrices, types.CandlePrice{
-				Price:     sdk.MustNewDecFromStr(closeStr),
-				Volume:    sdk.MustNewDecFromStr(volumeStr),
-				TimeStamp: responseCandle.Time,
+				Price:  sdk.MustNewDecFromStr(closeStr),
+				Volume: sdk.MustNewDecFromStr(volumeStr),
+				// Convert timestamp to milliseconds
+				TimeStamp: responseCandle.Time * 1000,
 			})
 		}
 		candles[pair.String()] = candlePrices

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -174,16 +174,17 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 
 		candlePrices := []types.CandlePrice{}
 		for _, responseCandle := range candlesResp {
-			if staleTime < responseCandle.Time {
-				closeStr := fmt.Sprintf("%f", responseCandle.Close)
-				volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
-				candlePrices = append(candlePrices, types.CandlePrice{
-					Price:  sdk.MustNewDecFromStr(closeStr),
-					Volume: sdk.MustNewDecFromStr(volumeStr),
-					// convert osmosis timestamp seconds -> milliseconds
-					TimeStamp: SecondsToMilli(responseCandle.Time),
-				})
+			if staleTime >= responseCandle.Time {
+			        continue
 			}
+			closeStr := fmt.Sprintf("%f", responseCandle.Close)
+			volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
+			candlePrices = append(candlePrices, types.CandlePrice{
+			        Price:  sdk.MustNewDecFromStr(closeStr),
+			        Volume: sdk.MustNewDecFromStr(volumeStr),
+			        // convert osmosis timestamp seconds -> milliseconds
+			        TimeStamp: SecondsToMilli(responseCandle.Time),
+			})
 		}
 		candles[pair.String()] = candlePrices
 	}

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -175,15 +175,15 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		candlePrices := []types.CandlePrice{}
 		for _, responseCandle := range candlesResp {
 			if staleTime >= responseCandle.Time {
-			        continue
+				continue
 			}
 			closeStr := fmt.Sprintf("%f", responseCandle.Close)
 			volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
 			candlePrices = append(candlePrices, types.CandlePrice{
-			        Price:  sdk.MustNewDecFromStr(closeStr),
-			        Volume: sdk.MustNewDecFromStr(volumeStr),
-			        // convert osmosis timestamp seconds -> milliseconds
-			        TimeStamp: SecondsToMilli(responseCandle.Time),
+				Price:  sdk.MustNewDecFromStr(closeStr),
+				Volume: sdk.MustNewDecFromStr(volumeStr),
+				// convert osmosis timestamp seconds -> milliseconds
+				TimeStamp: SecondsToMilli(responseCandle.Time),
 			})
 		}
 		candles[pair.String()] = candlePrices

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -14,6 +14,7 @@ const (
 	defaultReconnectTime     = time.Minute * 20
 	maxReconnectionTries     = 3
 	providerCandlePeriod     = 10 * time.Minute
+	convertSecToMilli        = int64(time.Second / time.Millisecond)
 
 	ProviderKraken   Name = "kraken"
 	ProviderBinance  Name = "binance"
@@ -91,4 +92,9 @@ func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 // minus t.
 func PastUnixTime(t time.Duration) int64 {
 	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
+}
+
+// SecondsToMilli converts seconds to milliseconds for our unix timestamps.
+func SecondsToMilli(t int64) int64 {
+	return int64(time.Second / time.Millisecond)
 }

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -96,5 +96,5 @@ func PastUnixTime(t time.Duration) int64 {
 
 // SecondsToMilli converts seconds to milliseconds for our unix timestamps.
 func SecondsToMilli(t int64) int64 {
-	return int64(time.Second / time.Millisecond)
+	return t * int64(time.Second/time.Millisecond)
 }

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -14,7 +14,6 @@ const (
 	defaultReconnectTime     = time.Minute * 20
 	maxReconnectionTries     = 3
 	providerCandlePeriod     = 10 * time.Minute
-	convertSecToMilli        = int64(time.Second / time.Millisecond)
 
 	ProviderKraken   Name = "kraken"
 	ProviderBinance  Name = "binance"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

This brings the osmosis candle timestamp from seconds to milliseconds, which keeps it on par with all the other unix timestamps.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
