### PR TITLE
fix: proto generator

### DIFF
--- a/contrib/scripts/protocgen.sh
+++ b/contrib/scripts/protocgen.sh
@@ -19,4 +19,5 @@ cd ..
 cp -r github.com/umee-network/umee/v3/* .
 rm -rf github.com
 
-go mod tidy
+# we need to go mod manuall, because the docker image is still on go1.18
+# go mod tidy

--- a/contrib/scripts/protocgen.sh
+++ b/contrib/scripts/protocgen.sh
@@ -19,5 +19,5 @@ cd ..
 cp -r github.com/umee-network/umee/v3/* .
 rm -rf github.com
 
-# we need to go mod manuall, because the docker image is still on go1.18
+# we need to go mod manually, because the docker image is still on go1.18
 # go mod tidy

--- a/proto/buf.gen.gogo.yaml
+++ b/proto/buf.gen.gogo.yaml
@@ -2,7 +2,7 @@ version: v1
 plugins:
   - name: gocosmos
     out: ..
-    opt: plugins=grpc,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types
+    opt: plugins=grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types
   - name: grpc-gateway
     out: ..
     opt: logtostderr=true,allow_colon_final_segments=true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

* Cleans up buf gogo config 
* Comment out `go mod tidy` from proto generator because it's not compatible with the Docker image we are using (it's still using go1.18) 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
