### PR TITLE
chore: proto semicolon fix

### DIFF
--- a/proto/umee/oracle/v1/query.proto
+++ b/proto/umee/oracle/v1/query.proto
@@ -175,7 +175,6 @@ message QueryAggregatePrevoteResponse {
   // in the current vote period
   AggregateExchangeRatePrevote aggregate_prevote = 1
       [(gogoproto.nullable) = false];
-  ;
 }
 
 // QueryAggregatePrevotes is the request type for the

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -184,6 +184,60 @@ paths:
           type: string
       tags:
         - Query
+  /umee/leverage/v1/bad_debts:
+    get:
+      summary: >-
+        BadDebts queries a list of borrow positions that have been marked for
+        bad debt repayment.
+      operationId: BadDebts
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              targets:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+                    denom:
+                      type: string
+                  description: >-
+                    BadDebt is a bad debt instance used in the leverage module's
+                    genesis state.
+                description: >-
+                  Targets are borrow positions currently marked for bad debt
+                  repayment. Each contains an Address and a Denom.
+            description: >-
+              QueryBadDebtsResponse defines the response structure for the
+              BedDebts gRPC service handler.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
   /umee/leverage/v1/liquidation_targets:
     get:
       summary: >-
@@ -205,9 +259,7 @@ paths:
                   liquidation.
             description: >-
               QueryLiquidationTargetsResponse defines the response structure for
-              the
-
-              LiquidationTargets gRPC service handler.
+              the LiquidationTargets gRPC service handler.
         default:
           description: An unexpected error response.
           schema:
@@ -475,13 +527,13 @@ paths:
                   direct_liquidation_fee:
                     type: string
                     description: >-
-                      Direct Liquidation Fee is the reduction in liquidation
-                      incentive experienced
+                      Direct Liquidation Fee is a reduction factor in
+                      liquidation incentive
 
-                      by liquidators who choose to receive base assets instead
-                      of uTokens as
+                      experienced by liquidators who choose to receive base
+                      assets instead of
 
-                      liquidation rewards.
+                      uTokens as liquidation rewards.
                 description: Params defines the parameters for the leverage module.
             description: >-
               QueryParamsResponse defines the response structure for the Params
@@ -1368,6 +1420,16 @@ definitions:
             value:
               type: string
               format: byte
+  umee.leverage.v1.BadDebt:
+    type: object
+    properties:
+      address:
+        type: string
+      denom:
+        type: string
+    description: >-
+      BadDebt is a bad debt instance used in the leverage module's genesis
+      state.
   umee.leverage.v1.Params:
     type: object
     properties:
@@ -1403,12 +1465,12 @@ definitions:
       direct_liquidation_fee:
         type: string
         description: >-
-          Direct Liquidation Fee is the reduction in liquidation incentive
-          experienced
+          Direct Liquidation Fee is a reduction factor in liquidation incentive
 
-          by liquidators who choose to receive base assets instead of uTokens as
+          experienced by liquidators who choose to receive base assets instead
+          of
 
-          liquidation rewards.
+          uTokens as liquidation rewards.
     description: Params defines the parameters for the leverage module.
   umee.leverage.v1.QueryAccountBalancesResponse:
     type: object
@@ -1504,6 +1566,27 @@ definitions:
     description: >-
       QueryAccountSummaryResponse defines the response structure for the
       AccountSummary gRPC service handler.
+  umee.leverage.v1.QueryBadDebtsResponse:
+    type: object
+    properties:
+      targets:
+        type: array
+        items:
+          type: object
+          properties:
+            address:
+              type: string
+            denom:
+              type: string
+          description: >-
+            BadDebt is a bad debt instance used in the leverage module's genesis
+            state.
+        description: >-
+          Targets are borrow positions currently marked for bad debt repayment.
+          Each contains an Address and a Denom.
+    description: >-
+      QueryBadDebtsResponse defines the response structure for the BedDebts gRPC
+      service handler.
   umee.leverage.v1.QueryLiquidationTargetsResponse:
     type: object
     properties:
@@ -1512,7 +1595,7 @@ definitions:
         items:
           type: string
         description: Targets are the addresses of borrowers eligible for liquidation.
-    description: |-
+    description: >-
       QueryLiquidationTargetsResponse defines the response structure for the
       LiquidationTargets gRPC service handler.
   umee.leverage.v1.QueryMarketSummaryResponse:
@@ -1703,13 +1786,13 @@ definitions:
           direct_liquidation_fee:
             type: string
             description: >-
-              Direct Liquidation Fee is the reduction in liquidation incentive
-              experienced
+              Direct Liquidation Fee is a reduction factor in liquidation
+              incentive
 
-              by liquidators who choose to receive base assets instead of
-              uTokens as
+              experienced by liquidators who choose to receive base assets
+              instead of
 
-              liquidation rewards.
+              uTokens as liquidation rewards.
         description: Params defines the parameters for the leverage module.
     description: |-
       QueryParamsResponse defines the response structure for the Params gRPC

--- a/x/oracle/types/query.pb.gw.go
+++ b/x/oracle/types/query.pb.gw.go
@@ -874,25 +874,25 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 }
 
 var (
-	pattern_Query_ExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"umee", "oracle", "v1", "denoms", "exchange_rates", "denom"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_ExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"umee", "oracle", "v1", "denoms", "exchange_rates", "denom"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_ActiveExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "denoms", "active_exchange_rates"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_ActiveExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "denoms", "active_exchange_rates"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_FeederDelegation_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "feeder"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_FeederDelegation_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "feeder"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_MissCounter_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "miss"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_MissCounter_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "miss"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_SlashWindow_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"umee", "oracle", "v1", "slash_window"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_SlashWindow_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"umee", "oracle", "v1", "slash_window"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_AggregatePrevote_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "aggregate_prevote"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_AggregatePrevote_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "validators", "validator_addr", "aggregate_prevote"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_AggregatePrevotes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "validators", "aggregate_prevotes"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_AggregatePrevotes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "validators", "aggregate_prevotes"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_AggregateVote_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "valdiators", "validator_addr", "aggregate_vote"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_AggregateVote_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"umee", "oracle", "v1", "valdiators", "validator_addr", "aggregate_vote"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_AggregateVotes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "validators", "aggregate_votes"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_AggregateVotes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"umee", "oracle", "v1", "validators", "aggregate_votes"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"umee", "oracle", "v1", "params"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"umee", "oracle", "v1", "params"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (


### PR DESCRIPTION
Proto syntax fix and run `make proto-all`

Contents:
- Semicolon fix from #1311
- (unrelated) `make proto-gen` subtly changes `oracle/query.pb.gw.go`
- (unrelated) `make proto-swagger-gen` created a diff because `swagger/swagger.yaml` was out of date