### PR TITLE
feat(oracle): validator address override option for cli prevotes & votes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [1220](https://github.com/umee-network/umee/pull/1220) Submit oracle prevotes / vote txs via the CLI.
 - [1222](https://github.com/umee-network/umee/pull/1222) Liquidation reward_denom can now be either token or uToken.
 - [1238](https://github.com/umee-network/umee/pull/1238) Added bad debts query.
+- [1323](https://github.com/umee-network/umee/pull/1323) Oracle cli - Add validator address override option.
 
 ### Improvements
 

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -72,8 +72,8 @@ func GetCmdDelegateFeedConsent() *cobra.Command {
 // broadcast a transaction with a MsgAggregateExchangeRatePrevote message.
 func GetCmdAggregateExchangeRatePrevote() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "exchange-rate-prevote [hash]",
-		Args:  cobra.ExactArgs(1),
+		Use:   "exchange-rate-prevote [hash] [validator-address]",
+		Args:  cobra.MinimumNArgs(1),
 		Short: "Submit an exchange rate prevote with a hash",
 		Long: fmt.Sprintf(`Submit an exchange rate prevote with a hash as a hex string
 			representation of a byte array.
@@ -90,10 +90,15 @@ func GetCmdAggregateExchangeRatePrevote() *cobra.Command {
 				return err
 			}
 
+			valAddress := sdk.ValAddress(clientCtx.GetFromAddress())
+			if len(args) > 1 {
+				valAddress = sdk.ValAddress(args[1])
+			}
+
 			msg := types.NewMsgAggregateExchangeRatePrevote(
 				hash,
 				clientCtx.GetFromAddress(),
-				sdk.ValAddress(clientCtx.GetFromAddress()),
+				valAddress,
 			)
 
 			if err := msg.ValidateBasic(); err != nil {
@@ -113,8 +118,8 @@ func GetCmdAggregateExchangeRatePrevote() *cobra.Command {
 // broadcast a transaction with a NewMsgAggregateExchangeRateVote message.
 func GetCmdAggregateExchangeRateVote() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "exchange-rate-vote [salt] [exchange-rates]",
-		Args:  cobra.ExactArgs(2),
+		Use:   "exchange-rate-vote [salt] [exchange-rates] [validator-address]",
+		Args:  cobra.MinimumNArgs(2),
 		Short: "Submit an exchange rate vote with the salt and exchange rate string",
 		Long: fmt.Sprintf(`Submit an exchange rate vote with the salt of the previous hash, and the
 			exchange rate string previously used in the hash.
@@ -128,11 +133,16 @@ func GetCmdAggregateExchangeRateVote() *cobra.Command {
 				return err
 			}
 
+			valAddress := sdk.ValAddress(clientCtx.GetFromAddress())
+			if len(args) > 2 {
+				valAddress = sdk.ValAddress(args[2])
+			}
+
 			msg := types.NewMsgAggregateExchangeRateVote(
 				args[0],
 				args[1],
 				clientCtx.GetFromAddress(),
-				sdk.ValAddress(clientCtx.GetFromAddress()),
+				valAddress,
 			)
 
 			if err := msg.ValidateBasic(); err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Adds the option to override the validator address option for votes & prevotes.

This is required for addresses which have been delegated to by validators to vote via the CLI 🥳  

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
