### PR TITLE
fix: fix websocket reconnection logic

### DIFF
--- a/price-feeder/oracle/provider/bitget.go
+++ b/price-feeder/oracle/provider/bitget.go
@@ -234,8 +234,8 @@ func (p *BitgetProvider) handleWebSocketMsgs(ctx context.Context) {
 				p.logger.Err(err).Msg("failed to read message")
 				if err := p.ping(); err != nil {
 					p.logger.Err(err).Msg("failed to send ping")
-					if err := p.close(); err != nil {
-						p.logger.Err(err).Msg("error closing websocket")
+					if err := p.disconnect(); err != nil {
+						p.logger.Err(err).Msg("error disconnecting websocket")
 					}
 					if err := p.reconnect(); err != nil {
 						p.logger.Err(err).Msg("error reconnecting websocket")
@@ -251,8 +251,8 @@ func (p *BitgetProvider) handleWebSocketMsgs(ctx context.Context) {
 			p.messageReceived(messageType, bz, reconnectTicker)
 
 		case <-reconnectTicker.C:
-			if err := p.close(); err != nil {
-				p.logger.Err(err).Msg("error closing websocket")
+			if err := p.disconnect(); err != nil {
+				p.logger.Err(err).Msg("error disconnecting websocket")
 			}
 			if err := p.reconnect(); err != nil {
 				p.logger.Err(err).Msg("error reconnecting websocket")
@@ -417,8 +417,8 @@ func (p *BitgetProvider) setCandlePair(candle BitgetCandle) {
 	p.candles[candle.Arg.InstID] = candleList
 }
 
-// close closes the current websocket connection.
-func (p *BitgetProvider) close() error {
+// disconnect disconnects the existing websocket connection.
+func (p *BitgetProvider) disconnect() error {
 	err := p.wsClient.Close()
 	if err != nil {
 		return types.ErrProviderConnection.Wrapf("error closing Bitget websocket %v", err)

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -344,6 +344,9 @@ func (p *CoinbaseProvider) handleReceivedMessages(ctx context.Context) {
 			p.messageReceived(messageType, bz)
 
 		case <-p.reconnectTimer.C: // reset by the pongHandler.
+			if err := p.disconnect(); err != nil {
+				p.logger.Err(err).Msg("error disconnecting")
+			}
 			if err := p.reconnect(); err != nil {
 				p.logger.Err(err).Msg("error reconnecting")
 			}
@@ -469,7 +472,16 @@ func (p *CoinbaseProvider) resetReconnectTimer() {
 	p.reconnectTimer.Reset(coinbasePingCheck)
 }
 
-// reconnect closes the last WS connection and creates a new one. If there’s a
+// disconnect disconnects the existing websocket connection.
+func (p *CoinbaseProvider) disconnect() error {
+	err := p.wsClient.Close()
+	if err != nil {
+		return types.ErrProviderConnection.Wrapf("error closing Coinbase websocket %v", err)
+	}
+	return nil
+}
+
+// reconnect creates a new websocket connection. If there’s a
 // network problem, the system will automatically disable the connection. The
 // connection will break automatically if the subscription is not established or
 // data has not been pushed for more than 30 seconds. To keep the connection stable:
@@ -480,11 +492,6 @@ func (p *CoinbaseProvider) resetReconnectTimer() {
 // 3. Expect a 'pong' as a response. If the response message is not received within
 // N seconds, please raise an error or reconnect.
 func (p *CoinbaseProvider) reconnect() error {
-	err := p.wsClient.Close()
-	if err != nil {
-		return types.ErrProviderConnection.Wrapf("error closing Coinbase websocket %v", err)
-	}
-
 	p.logger.Debug().Msg("reconnecting websocket")
 	wsConn, resp, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
 	defer resp.Body.Close()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This updates all the providers' reconnection logic to be the same as bitget (introduced in #1328)

The issue with the existing connection logic was that, if the connection had been closed by the server unexpectedly, we would try to close an already-closed websocket. 

We'll still try to close this, but now we won't stop attempting to reconnect if that fails.
---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
