### PR TITLE
fix: Interpret x/0 collateral liquidity as 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [1018](https://github.com/umee-network/umee/pull/1018) Return nil if negative time elapsed from the last block happens.
 - [1156](https://github.com/umee-network/umee/pull/1156) Propagate context correctly.
 - [1288](https://github.com/umee-network/umee/pull/1288) Safeguards LastInterestTime against time reversals and unintended interest from hard forks.
+- [1357](https://github.com/umee-network/umee/pull/1357) Interptex x/0 collateral liquidity as 100%
 
 ## [v2.0.2](https://github.com/umee-network/umee/releases/tag/v2.0.2) - 2022-05-13
 

--- a/x/leverage/keeper/collateral.go
+++ b/x/leverage/keeper/collateral.go
@@ -144,7 +144,7 @@ func (k Keeper) CollateralLiquidity(ctx sdk.Context, denom string) sdk.Dec {
 	exchangeRate := k.DeriveExchangeRate(ctx, denom)
 	liquidity := k.AvailableLiquidity(ctx, denom)
 
-	// Zero collateral will be interpreted as full liquidity. This encompasses two cases:
+	// Zero collateral will be interpreted as full collateral liquidity. This encompasses two cases:
 	// - 0/0 liquidity / collateral: Empty market, system is considered healthy by default
 	// - x/0 liquidity / collateral: No collateral but plenty of liquidity, also considered healthy
 	// In both cases, "all collateral is liquid" is technically true, given that there is no collateral.

--- a/x/leverage/keeper/collateral.go
+++ b/x/leverage/keeper/collateral.go
@@ -145,8 +145,8 @@ func (k Keeper) CollateralLiquidity(ctx sdk.Context, denom string) sdk.Dec {
 	liquidity := k.AvailableLiquidity(ctx, denom)
 
 	// Zero collateral will be interpreted as full collateral liquidity. This encompasses two cases:
-	// - 0/0 liquidity / collateral: Empty market, system is considered healthy by default
-	// - x/0 liquidity / collateral: No collateral but plenty of liquidity, also considered healthy
+	// - liquidity / collateral = 0/0: Empty market, system is considered healthy by default
+	// - liquidity / collateral = x/0: No collateral but nonzero liquidity, also considered healthy
 	// In both cases, "all collateral is liquid" is technically true, given that there is no collateral.
 	if totalCollateral.IsZero() {
 		return sdk.OneDec()

--- a/x/leverage/keeper/collateral.go
+++ b/x/leverage/keeper/collateral.go
@@ -144,9 +144,9 @@ func (k Keeper) CollateralLiquidity(ctx sdk.Context, denom string) sdk.Dec {
 	exchangeRate := k.DeriveExchangeRate(ctx, denom)
 	liquidity := k.AvailableLiquidity(ctx, denom)
 
-	// Zero collateral will be interpreted as having no liquidity
+	// Zero collateral will be interpreted as full liquidity
 	if totalCollateral.IsZero() {
-		return sdk.ZeroDec()
+		return sdk.OneDec()
 	}
 
 	collateralLiquidity := toDec(liquidity).Quo(exchangeRate.MulInt(totalCollateral.Amount))

--- a/x/leverage/keeper/collateral.go
+++ b/x/leverage/keeper/collateral.go
@@ -144,7 +144,10 @@ func (k Keeper) CollateralLiquidity(ctx sdk.Context, denom string) sdk.Dec {
 	exchangeRate := k.DeriveExchangeRate(ctx, denom)
 	liquidity := k.AvailableLiquidity(ctx, denom)
 
-	// Zero collateral will be interpreted as full liquidity
+	// Zero collateral will be interpreted as full liquidity. This encompasses two cases:
+	// - 0/0 liquidity / collateral: Empty market, system is considered healthy by default
+	// - x/0 liquidity / collateral: No collateral but plenty of liquidity, also considered healthy
+	// In both cases, "all collateral is liquid" is technically true, given that there is no collateral.
 	if totalCollateral.IsZero() {
 		return sdk.OneDec()
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Quick bugfix to solve an issue we found in QA

`Collateral liquidity` was being interpteted as zero before any `collateral` was added (even with nonzero `liquidity`)

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
