### PR TITLE
fix: add missing v1.1.0 upgrade handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v1.1.1](https://github.com/umee-network/umee/releases/tag/v1.1.0) - 2022-09-13
+
+### Bug Fixes
+
+- [1376](https://github.com/umee-network/umee/pull/1376/files) Add "v1.1.0" upgrade handler.
+
 ## [v1.1.0](https://github.com/umee-network/umee/releases/tag/v1.1.0) - 2022-09-08
 
 ### State Machine Breaking

--- a/app/app.go
+++ b/app/app.go
@@ -232,7 +232,6 @@ func New(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *UmeeApp {
-
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
@@ -576,6 +575,8 @@ func New(
 
 	app.sm.RegisterStoreDecoders()
 
+	app.RegisterUpgradeHandlers(module.NewConfigurator(app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter()))
+
 	// initialize stores
 	app.MountKVStores(keys)
 	app.MountTransientStores(transientKeys)
@@ -778,7 +779,6 @@ func initParamsKeeper(
 	legacyAmino *codec.LegacyAmino,
 	key, tkey sdk.StoreKey,
 ) paramskeeper.Keeper {
-
 	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
 
 	paramsKeeper.Subspace(authtypes.ModuleName)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const UpgradeV110Plan = "v1.1.0"
+
+func (app UmeeApp) RegisterUpgradeHandlers(cfgr module.Configurator) {
+	// v1.1.0 upgrade is a no-op on state, but must be registered nonetheless
+	app.UpgradeKeeper.SetUpgradeHandler(
+		UpgradeV110Plan,
+		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			ctx.Logger().Info("Upgrade handler execution", "name", UpgradeV110Plan)
+
+			ctx.Logger().Info("Upgrade handler execution finished, running migrations", "name", UpgradeV110Plan)
+			return app.mm.RunMigrations(ctx, cfgr, fromVM)
+		})
+}


### PR DESCRIPTION
Fixes a chain halt on mainnet

```
ERR UPGRADE “v1.1.0” NEEDED at height: 3023282:
```