### PR TITLE
fix: v1.1.0 handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,17 +46,23 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v1.1.1](https://github.com/umee-network/umee/releases/tag/v1.1.0) - 2022-09-13
+## [v1.1.2](https://github.com/umee-network/umee/releases/tag/v1.1.1) - 2022-09-13
 
 ### Bug Fixes
 
-- [1376](https://github.com/umee-network/umee/pull/1376/files) Add "v1.1.0" upgrade handler.
+- [1377](https://github.com/umee-network/umee/pull/1377) Fix "v1.1.0" upgrade handler.
+
+## [v1.1.1](https://github.com/umee-network/umee/releases/tag/v1.1.1) - 2022-09-13
+
+### Bug Fixes
+
+- [1376](https://github.com/umee-network/umee/pull/1376) Add "v1.1.0" upgrade handler.
 
 ## [v1.1.0](https://github.com/umee-network/umee/releases/tag/v1.1.0) - 2022-09-08
 
 ### State Machine Breaking
 
-- [1358](https://github.com/umee-network/umee/pull/1358/files) Disable Gravity Bridge bridge messages.
+- [1358](https://github.com/umee-network/umee/pull/1358) Disable Gravity Bridge bridge messages.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v1.1.2](https://github.com/umee-network/umee/releases/tag/v1.1.1) - 2022-09-13
+## [v1.1.2](https://github.com/umee-network/umee/releases/tag/v1.1.2) - 2022-09-13
 
 ### Bug Fixes
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,8 +14,7 @@ func (app UmeeApp) RegisterUpgradeHandlers(cfgr module.Configurator) {
 		UpgradeV110Plan,
 		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			ctx.Logger().Info("Upgrade handler execution", "name", UpgradeV110Plan)
-
 			ctx.Logger().Info("Upgrade handler execution finished, running migrations", "name", UpgradeV110Plan)
-			return app.mm.RunMigrations(ctx, cfgr, fromVM)
+			return fromVM, nil
 		})
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

v1.1.0 upgrade handler tries to run updates for modules. But none module registered an upgrade handler, causing panic.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
