### PR TITLE
feat: increase free oracle gas limit to 140k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### State Machine Breaking
 
 - [#1326](https://github.com/umee-network/umee/pull/1326) Setting protocol controlled min gas price.
+- [#1401](https://github.com/umee-network/umee/pull/1401) Increased free gas oracle tx limit from 100k to 140k.
 
 ### API Breaking
 

--- a/ante/fee.go
+++ b/ante/fee.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MaxMsgGasUsage defines the maximum gas allowed for an oracle transaction.
-const MaxMsgGasUsage = uint64(100_000)
+const MaxMsgGasUsage = uint64(140_000)
 
 // FeeAndPriority ensures tx has enough fee coins to pay for the gas at the CheckTx time
 // to early remove transactions from the mempool without enough attached fee.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Gas feeder transactions, with increased gas adjustment, may go above 100k gas limit. For usability, we propose to increase the free gas from 100k to 140k.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
