### PR TITLE
fix: disable proto lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ proto-format:
 
 proto-lint:
 	@echo "Linting Protobuf files"
-	@$(DOCKER_BUF) lint --error-format=json
+#	@$(DOCKER_BUF) lint --error-format=json
 
 proto-check-breaking:
 	@echo "Checking for breaking changes"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

`make proto-lint` doesn't work due to missing dependency in buf repository. 
References:
* https://github.com/umee-network/umee/pull/1397  (this PR was reverted)

This should be reverted in https://github.com/umee-network/umee/pull/1408, but now we need to progress.
