### PR TITLE
chore: bump Gravity-Bridge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-alpha7
 	github.com/cosmos/cosmos-sdk v0.46.1
 	github.com/cosmos/go-bip39 v1.0.0
-	github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30
+	github.com/cosmos/ibc-go/v5 v5.0.0-rc2
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
@@ -317,7 +317,7 @@ require (
 )
 
 replace (
-	github.com/Gravity-Bridge/Gravity-Bridge/module => github.com/umee-network/Gravity-Bridge/module v1.4.2-0.20220831213229-254615a7be1d
+	github.com/Gravity-Bridge/Gravity-Bridge/module => github.com/umee-network/Gravity-Bridge/module v1.5.3-umee-1
 	github.com/cosmos/cosmos-sdk => github.com/umee-network/cosmos-sdk v0.46.1-umee
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.1 h1:3gaq9b6SjiB0KBTygRnAvEGml2pQlu1TH8uma5g63Ys=
 github.com/cosmos/iavl v0.19.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30 h1:8K7TsPUeiWYdhA1xPUTeR96AfdzXkLAkB0FWmxafbXA=
-github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
+github.com/cosmos/ibc-go/v5 v5.0.0-rc2 h1:7rGkZwojUwK1Dvgze3ZP5K1upIKygudxU3WaeFFU2ts=
+github.com/cosmos/ibc-go/v5 v5.0.0-rc2/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
@@ -1293,8 +1293,8 @@ github.com/ultraware/funlen v0.0.3 h1:5ylVWm8wsNwH5aWo9438pwvsK0QiqVuUrt9bn7S/iL
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.5 h1:hh+/cpIcopyMYbZNVov9iSxvJU3OYQg78Sfaqzi/CzI=
 github.com/ultraware/whitespace v0.0.5/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
-github.com/umee-network/Gravity-Bridge/module v1.4.2-0.20220831213229-254615a7be1d h1:IYNYXNHyJBerOuFsPy9WuWOD5VoBuCkH/Y+XNCxb8iA=
-github.com/umee-network/Gravity-Bridge/module v1.4.2-0.20220831213229-254615a7be1d/go.mod h1:qSTpO1Yz4mdRELKGiOUvbNZkYUioDtLJ/jYhBqgRrO8=
+github.com/umee-network/Gravity-Bridge/module v1.5.3-umee-1 h1:a4OGAGfmZ+jcHH//HuQCLeDYpLy3282t3deVKRPt+RU=
+github.com/umee-network/Gravity-Bridge/module v1.5.3-umee-1/go.mod h1:UN4ehDuy5PA1YY7juvBMMulyiKv7uBMLUbTV/vONzH0=
 github.com/umee-network/bech32-ibc v0.3.0-rc1.0.20220831212913-42baad053f6e h1:RCxnO359ieolUDIT1cF7Ic3ms4epgmZxzNiz1a2IBeU=
 github.com/umee-network/bech32-ibc v0.3.0-rc1.0.20220831212913-42baad053f6e/go.mod h1:Prssr3u1p2ICcgkhtMaX55NZv7A7E2ernO6fKrpolSg=
 github.com/umee-network/cosmos-sdk v0.46.1-umee h1:htt48oCN/i0An5z8AS8ttXU3Dk7fiE/gWNvwQGGOJgs=

--- a/price-feeder/go.mod
+++ b/price-feeder/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.19.1 // indirect
-	github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30 // indirect
+	github.com/cosmos/ibc-go/v5 v5.0.0-rc2 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
 	github.com/cosmos/ledger-go v0.9.2 // indirect
 	github.com/creachadair/taskgroup v0.3.2 // indirect

--- a/price-feeder/go.sum
+++ b/price-feeder/go.sum
@@ -278,8 +278,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.1 h1:3gaq9b6SjiB0KBTygRnAvEGml2pQlu1TH8uma5g63Ys=
 github.com/cosmos/iavl v0.19.1/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30 h1:8K7TsPUeiWYdhA1xPUTeR96AfdzXkLAkB0FWmxafbXA=
-github.com/cosmos/ibc-go/v5 v5.0.0-rc1.0.20220831174724-8045fcccbd30/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
+github.com/cosmos/ibc-go/v5 v5.0.0-rc2 h1:7rGkZwojUwK1Dvgze3ZP5K1upIKygudxU3WaeFFU2ts=
+github.com/cosmos/ibc-go/v5 v5.0.0-rc2/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

In this update, Gravity Bridge `MsgValsetConfirm` and `MsgValsetUpdatedClaim` is active, and validators must update the validator set in Ethereum smart contract to fully enable Gravity Bridge and not get slashed.
This is the first step to fully enable Gravity Bridge, after we disabled it in `v1.1.x`