### PR TITLE
fix: update th buf cache to get proto deps

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,28 +4,16 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-proto
-    branch: main
     commit: 1935555c206d4afb9e94615dfd0fad31
-    digest: b1-TNqW6xj2Pjha5Uoj9a-5uOeRo4mwswKfyqMcN3I_gZ0=
-    create_time: 2021-12-02T22:04:00.31049Z
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    branch: main
-    commit: af8d763f189a4482b59f9f283b446293
-    digest: b1-_yAm1-e1B5X3nv4-_DX5VR8YY0C_A42zokN3WshF9IE=
-    create_time: 2022-01-05T19:59:53.846919Z
+    commit: 8cb30a2c4de74dc9bd8d260b1e75e176
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    branch: main
     commit: bee5511075b7499da6178d9e4aaa628b
-    digest: b1-rrBIustouD-S80cVoZ_rM0qJsmei9AgbXy9GPQu6vxg=
-    create_time: 2021-12-02T20:01:17.069307Z
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: c21d9ee7a8c74d6a8cce1338a2839547
-    digest: b1-Rdf7A_4QeTLvu6BdzORkijdmHsAyJd2MHEEZWBEUFIM=
-    create_time: 2022-01-15T15:04:23.382499Z
+    commit: 62f35d8aed1149c291d606d958a7ce32

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,10 +1,10 @@
 version: v1
 name: buf.build/umee-network/umee
 deps:
-  - buf.build/cosmos/cosmos-sdk
-  - buf.build/cosmos/cosmos-proto
-  - buf.build/cosmos/gogo-proto
-  - buf.build/googleapis/googleapis
+  - buf.build/cosmos/cosmos-sdk:8cb30a2c4de74dc9bd8d260b1e75e176
+  - buf.build/cosmos/cosmos-proto:1935555c206d4afb9e94615dfd0fad31
+  - buf.build/cosmos/gogo-proto:bee5511075b7499da6178d9e4aaa628b
+  - buf.build/googleapis/googleapis:62f35d8aed1149c291d606d958a7ce32
 breaking:
   use:
     - FILE


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

this pr will fix the `make proto-gen` , 

Note: 
**we need to update the commit for deps in buf config whenever  we bump the cosmos-sdk version** 

We can get the commits for deps of buf https://github.com/cosmos/cosmos-sdk/blob/v0.46.2/client/v2/internal/buf.lock

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
