### PR TITLE
fix: add peggo binary back to docker

### DIFF
--- a/umee.e2e.Dockerfile
+++ b/umee.e2e.Dockerfile
@@ -27,17 +27,17 @@ RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make install
 RUN cd price-feeder && LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make install
 
 # # Fetch peggo (gravity bridge) binary
-# FROM base-builder AS peggo-builder
-# ARG PEGGO_VERSION=v0.3.0
-# WORKDIR /downloads/
-# RUN git clone https://github.com/umee-network/peggo.git
-# RUN cd peggo && git checkout ${PEGGO_VERSION} && make build && cp ./build/peggo /usr/local/bin/
+FROM base-builder AS peggo-builder
+ARG PEGGO_VERSION=v0.3.0
+WORKDIR /downloads/
+RUN git clone https://github.com/umee-network/peggo.git
+RUN cd peggo && git checkout ${PEGGO_VERSION} && make build && cp ./build/peggo /usr/local/bin/
 
 # Add to a distroless container
 FROM gcr.io/distroless/cc:debug
 COPY --from=umeed-builder /go/bin/umeed /usr/local/bin/
 COPY --from=umeed-builder /go/bin/price-feeder /usr/local/bin/
-# COPY --from=peggo-builder /usr/local/bin/peggo /usr/local/bin/
+COPY --from=peggo-builder /usr/local/bin/peggo /usr/local/bin/
 EXPOSE 26656 26657 1317 9090 7171
 
 ENTRYPOINT ["umeed", "start"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
Small fix regarding the e2e test , adding peggo binary to docker image
closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
