### PR TITLE
fix(price-feeder): Update osmosisv2 wss scheme

### DIFF
--- a/price-feeder/oracle/provider/osmosisv2.go
+++ b/price-feeder/oracle/provider/osmosisv2.go
@@ -79,7 +79,7 @@ func NewOsmosisV2Provider(
 	}
 
 	wsURL := url.URL{
-		Scheme: "ws",
+		Scheme: "wss",
 		Host:   endpoints.Websocket,
 		Path:   osmosisV2WSPath,
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

The OsmosisV2 provider was unable to connect to our hosted server since it was using `ws` instead of `wss`. I was going to make this a config but I don't see needing to change this except when testing locally with just this provider.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
