### PR TITLE
fix(oracle): historical iterator

### DIFF
--- a/util/bytes.go
+++ b/util/bytes.go
@@ -1,0 +1,17 @@
+package util
+
+// ConcatBytes creates a new slice by merging list of bytes and leaving empty amount of margin
+// bytes at the end
+func ConcatBytes(margin int, bzs ...[]byte) []byte {
+	l := 0
+	for _, bz := range bzs {
+		l += len(bz)
+	}
+	out := make([]byte, l+margin)
+	offset := 0
+	for _, bz := range bzs {
+		copy(out[offset:], bz)
+		offset += len(bz)
+	}
+	return out
+}

--- a/util/bytes_test.go
+++ b/util/bytes_test.go
@@ -1,0 +1,24 @@
+package util
+
+import "testing"
+import "github.com/stretchr/testify/require"
+
+func TestMergeBytes(t *testing.T) {
+	require := require.New(t)
+	tcs := []struct {
+		in       [][]byte
+		inMargin int
+		out      []byte
+	}{
+		{[][]byte{}, 0, []byte{}},
+		{[][]byte{}, 2, []byte{0, 0}},
+		{[][]byte{{1}}, 0, []byte{1}},
+		{[][]byte{{1}}, 1, []byte{1, 0}},
+		{[][]byte{{1, 2}, {2}}, 0, []byte{1, 2, 2}},
+		{[][]byte{{1, 2}, {2}}, 3, []byte{1, 2, 2, 0, 0, 0}},
+		{[][]byte{{1, 2}, {2}, {3, 3}, {4}}, 1, []byte{1, 2, 2, 3, 3, 4, 0}},
+	}
+	for i, tc := range tcs {
+		require.Equal(tc.out, ConcatBytes(tc.inMargin, tc.in...), i)
+	}
+}

--- a/x/oracle/keeper/historic_price.go
+++ b/x/oracle/keeper/historic_price.go
@@ -55,7 +55,7 @@ func (k Keeper) GetMedian(
 	blockNum uint64,
 ) (sdk.Dec, error) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetMedianKey(denom, blockNum))
+	bz := store.Get(types.MedianKey(denom, blockNum))
 	if bz == nil {
 		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrNoMedian, fmt.Sprintf("denom: %s block: %d", denom, blockNum))
 	}
@@ -78,7 +78,7 @@ func (k Keeper) SetMedian(
 	historicPrices := k.getHistoricPrices(ctx, denom)
 	median := median(historicPrices)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: median})
-	store.Set(types.GetMedianKey(denom, uint64(ctx.BlockHeight())), bz)
+	store.Set(types.MedianKey(denom, uint64(ctx.BlockHeight())), bz)
 	k.setMedianDeviation(ctx, denom, median, historicPrices)
 }
 
@@ -90,7 +90,7 @@ func (k Keeper) GetMedianDeviation(
 	blockNum uint64,
 ) (sdk.Dec, error) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetMedianDeviationKey(denom, blockNum))
+	bz := store.Get(types.MedianDeviationKey(denom, blockNum))
 	if bz == nil {
 		return sdk.ZeroDec(), sdkerrors.Wrap(types.ErrNoMedianDeviation, fmt.Sprintf("denom: %s block: %d", denom, blockNum))
 	}
@@ -112,7 +112,7 @@ func (k Keeper) setMedianDeviation(
 	store := ctx.KVStore(k.storeKey)
 	medianDeviation := medianDeviation(median, prices)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: medianDeviation})
-	store.Set(types.GetMedianDeviationKey(denom, uint64(ctx.BlockHeight())), bz)
+	store.Set(types.MedianDeviationKey(denom, uint64(ctx.BlockHeight())), bz)
 }
 
 // getHistoricPrices returns all the historic prices of a given denom.
@@ -171,7 +171,7 @@ func (k Keeper) AddHistoricPrice(
 		ExchangeRate: exchangeRate,
 		BlockNum:     block,
 	})
-	store.Set(types.GetHistoricPriceKey(denom, block), bz)
+	store.Set(types.HistoricPriceKey(denom, block), bz)
 }
 
 // DeleteHistoricPrice deletes the historic price of a denom at a
@@ -182,7 +182,7 @@ func (k Keeper) DeleteHistoricPrice(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetHistoricPriceKey(denom, blockNum))
+	store.Delete(types.HistoricPriceKey(denom, blockNum))
 }
 
 // DeleteMedian deletes a given denom's median price in the last prune
@@ -193,7 +193,7 @@ func (k Keeper) DeleteMedian(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetMedianKey(denom, blockNum))
+	store.Delete(types.MedianKey(denom, blockNum))
 }
 
 // DeleteMedianDeviation deletes a given denom's standard deviation around
@@ -204,5 +204,5 @@ func (k Keeper) DeleteMedianDeviation(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetMedianDeviationKey(denom, blockNum))
+	store.Delete(types.MedianDeviationKey(denom, blockNum))
 }

--- a/x/oracle/keeper/historic_price.go
+++ b/x/oracle/keeper/historic_price.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	"github.com/umee-network/umee/v3/util"
 	"github.com/umee-network/umee/v3/x/oracle/types"
 )
 
@@ -143,7 +144,9 @@ func (k Keeper) IterateHistoricPrices(
 ) {
 	store := ctx.KVStore(k.storeKey)
 
-	iter := sdk.KVStorePrefixIterator(store, append(types.KeyPrefixHistoricPrice, []byte(denom)...))
+	// make sure we have one zero byte to correctly separate denoms
+	prefix := util.ConcatBytes(1, types.KeyPrefixHistoricPrice, []byte(denom))
+	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -64,30 +64,27 @@ func GetAggregateExchangeRateVoteKey(v sdk.ValAddress) (key []byte) {
 // GetMedianKey - stored by *denom* and *block*
 func GetMedianKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixMedian...)
-	key = appendDenomAndBlockToKey(key, denom, blockNum)
-	return append(key, 0) // append 0 for null-termination
+	return appendDenomAndBlock(key, denom, blockNum)
 }
 
 // GetMedianDeviationKey - stored by *denom* and *block*
 func GetMedianDeviationKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixMedianDeviation...)
-	key = appendDenomAndBlockToKey(key, denom, blockNum)
-	return append(key, 0) // append 0 for null-termination
+	return appendDenomAndBlock(key, denom, blockNum)
 }
 
 // GetHistoricPriceKey - stored by *denom* and *block*
 func GetHistoricPriceKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixHistoricPrice...)
-	key = appendDenomAndBlockToKey(key, denom, blockNum)
-	return append(key, 0) // append 0 for null-termination
+	return appendDenomAndBlock(key, denom, blockNum)
 }
 
-func appendDenomAndBlockToKey(key []byte, denom string, blockNum uint64) []byte {
+func appendDenomAndBlock(key []byte, denom string, blockNum uint64) []byte {
 	key = append(key, []byte(denom)...)
+	key = append(key, 0) // null delimeter to avoid collision between different denoms
 	block := make([]byte, 8)
 	binary.LittleEndian.PutUint64(block, blockNum)
-	key = append(key, block...)
-	return key
+	return append(key, block...)
 }
 
 func ParseDemonFromHistoricPriceKey(key []byte) string {

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -61,20 +61,20 @@ func GetAggregateExchangeRateVoteKey(v sdk.ValAddress) (key []byte) {
 	return append(key, address.MustLengthPrefix(v)...)
 }
 
-// GetMedianKey - stored by *denom* and *block*
-func GetMedianKey(denom string, blockNum uint64) (key []byte) {
+// MedianKey - stored by *denom* and *block*
+func MedianKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixMedian...)
 	return appendDenomAndBlock(key, denom, blockNum)
 }
 
-// GetMedianDeviationKey - stored by *denom* and *block*
-func GetMedianDeviationKey(denom string, blockNum uint64) (key []byte) {
+// MedianDeviationKey - stored by *denom* and *block*
+func MedianDeviationKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixMedianDeviation...)
 	return appendDenomAndBlock(key, denom, blockNum)
 }
 
-// GetHistoricPriceKey - stored by *denom* and *block*
-func GetHistoricPriceKey(denom string, blockNum uint64) (key []byte) {
+// HistoricPriceKey - stored by *denom* and *block*
+func HistoricPriceKey(denom string, blockNum uint64) (key []byte) {
 	key = append(key, KeyPrefixHistoricPrice...)
 	return appendDenomAndBlock(key, denom, blockNum)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Historical prices stored in the x/oracle module can collide. More specifically, if we have tokens where one denom is a prefix of another token denom (eg `ETH` and `ETHW`), then an iterator for `ETH` will also return prices for `ETHW` as well and calculate the prices totally wrong. This is obviously a bug.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
