### PR TITLE
fix(price-feeder): Parse multiple candles from OsmosisV2 response

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -59,6 +59,7 @@ This was released as a part of [Umee Prop 27.](https://www.mintscan.io/umee/prop
 ### Bugs
 
 - [1428](https://github.com/umee-network/umee/pull/1428) Update umeed version to an actual tag.
+- [1615](https://github.com/umee-network/umee/pull/1615) Parse multiple candles from OsmosisV2 response
 
 ### Features
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -46,6 +46,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bugs
+
+- [1615](https://github.com/umee-network/umee/pull/1615) Parse multiple candles from OsmosisV2 response
+
 ### Improvements
 
 - [1602](https://github.com/umee-network/umee/pull/1602) Remove FTX provider.
@@ -59,7 +63,6 @@ This was released as a part of [Umee Prop 27.](https://www.mintscan.io/umee/prop
 ### Bugs
 
 - [1428](https://github.com/umee-network/umee/pull/1428) Update umeed version to an actual tag.
-- [1615](https://github.com/umee-network/umee/pull/1615) Parse multiple candles from OsmosisV2 response
 
 ### Features
 

--- a/price-feeder/oracle/provider/osmosisv2.go
+++ b/price-feeder/oracle/provider/osmosisv2.go
@@ -200,7 +200,7 @@ func (p *OsmosisV2Provider) messageReceived(messageType int, bz []byte) {
 		messageErr  error
 		tickerResp  OsmosisV2Ticker
 		tickerErr   error
-		candleResp  OsmosisV2Candle
+		candleResp  []OsmosisV2Candle
 		candleErr   error
 	)
 
@@ -242,7 +242,7 @@ func (p *OsmosisV2Provider) messageReceived(messageType int, bz []byte) {
 				if len(v) == 0 {
 					continue
 				}
-				candleString, _ := json.Marshal(v[len(v)-1].(map[string]interface{}))
+				candleString, _ := json.Marshal(v)
 				candleErr = json.Unmarshal(candleString, &candleResp)
 				if candleErr != nil {
 					p.logger.Error().
@@ -251,10 +251,12 @@ func (p *OsmosisV2Provider) messageReceived(messageType int, bz []byte) {
 						Msg("Error on receive message")
 					continue
 				}
-				p.setCandlePair(
-					osmosisV2Pair,
-					candleResp,
-				)
+				for _, singleCandle := range candleResp {
+					p.setCandlePair(
+						osmosisV2Pair,
+						singleCandle,
+					)
+				}
 				telemetryWebsocketMessage(ProviderOsmosisV2, MessageTypeCandle)
 				continue
 			}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

- Fixes only old candle prices in the price-feeder for the OsmosisV2 API

closes: [#87](https://github.com/umee-network/osmosis-api/issues/87)

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
