### PR TITLE
chore: price-feeder config update

### DIFF
--- a/price-feeder/price-feeder.example.toml
+++ b/price-feeder/price-feeder.example.toml
@@ -43,7 +43,7 @@ base = "UMEE"
 providers = [
   "okx",
   "gate",
-  "mexc"
+  "mexc",
 ]
 quote = "USDT"
 
@@ -99,7 +99,6 @@ quote = "USD"
 [[currency_pairs]]
 base = "ETH"
 providers = [
-  "binance",
   "okx",
   "bitget",
 ]
@@ -116,8 +115,8 @@ quote = "USD"
 base = "WBTC"
 providers = [
   "okx",
-  "mexc",
   "bitget",
+  "crypto",
 ]
 quote = "USDT"
 

--- a/price-feeder/price-feeder.example.toml
+++ b/price-feeder/price-feeder.example.toml
@@ -35,8 +35,8 @@ base = "ETH"
 threshold = "2"
 
 [[deviation_thresholds]]
-base = "BTC"
-threshold = "2"
+base = "WBTC"
+threshold = "1.5"
 
 [[currency_pairs]]
 base = "UMEE"
@@ -77,15 +77,6 @@ providers = [
   "okx",
   "bitget",
   "kraken",
-]
-quote = "USDT"
-
-[[currency_pairs]]
-base = "CRO"
-providers = [
-  "okx",
-  "bitget",
-  "huobi",
 ]
 quote = "USDT"
 


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

## Description

TLDR; Removes unnecessary CRO & adds a 1.5 deviation threshold to wbtc.

Updates the price feeder config in response to a huobi API issue which cause validators to miss votes on mainnet. The huobi API seemed to be unable to respond to getting CRO data, which caused that asset to not have a price. Price feeders will stop voting if they do not have a price for every asset, but this is not good on mainnet. So, for now, we've removed CRO.

Example of mainnet price feeder logs: 

```
8:02AM DBG starting oracle tick module=oracle
8:02AM DBG executing oracle tick module=oracle
8:02AM ERR failed to get ticker prices from provider error="huobi failed to get ticker price for CROUSDT" module=oracle
8:02AM ERR oracle tick failed error="unable to get prices for all exchange candles" module=oracle
8:02AM DBG starting oracle tick module=oracle
8:02AM DBG executing oracle tick module=oracle
8:02AM ERR failed to get ticker prices from provider error="huobi failed to get ticker price for CROUSDT" module=oracle
8:02AM ERR oracle tick failed error="unable to get prices for all exchange candles" module=oracle
8:02AM DBG starting oracle tick module=oracle
8:02AM DBG executing oracle tick module=oracle
8:02AM ERR failed to get ticker prices from provider error="huobi failed to get ticker price for CROUSDT" module=oracle
8:02AM ERR oracle tick failed error="unable to get prices for all exchange candles" module=oracle
8:02AM DBG starting oracle tick module=oracle
8:02AM DBG executing oracle tick module=oracle
8:02AM ERR failed to get ticker prices from provider error="huobi failed to get ticker price for CROUSDT" module=oracle
8:02AM ERR oracle tick failed error="unable to get prices for all exchange candles" module=oracle
8:02AM DBG sending websocket message module=oracle msg={"pong":1669536165105} provider=huobi
8:02AM DBG starting oracle tick module=oracle
8:02AM DBG executing oracle tick module=oracle
8:02AM ERR failed to get ticker prices from provider error="mexc failed to get candle price for UMEE_USDT" module=oracle
```

I also believe we should get rid of the line of code causing the error message `unable to get prices for all exchange candles`, which also stops validators from voting on prices.

I'll address this in another PR

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
