### PR TITLE
fix(price-feeder): add minimum candle volume

### DIFF
--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -113,6 +113,7 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 				if timePeriod < candle.TimeStamp {
 					// timeDiff = now - candle.TimeStamp
 					timeDiff := sdk.NewDec(now - candle.TimeStamp)
+					// set minimum candle volume for low-trading assets
 					if candle.Volume.Equal(sdk.ZeroDec()) {
 						candle.Volume = minimumCandleVolume
 					}

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -9,7 +9,10 @@ import (
 	"github.com/umee-network/umee/price-feeder/oracle/provider"
 )
 
-var minimumTimeWeight = sdk.MustNewDecFromStr("0.2")
+var (
+	minimumTimeWeight   = sdk.MustNewDecFromStr("0.2000")
+	minimumCandleVolume = sdk.MustNewDecFromStr("0.0001")
+)
 
 const (
 	// tvwapCandlePeriod represents the time period we use for tvwap in minutes
@@ -110,6 +113,10 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 				if timePeriod < candle.TimeStamp {
 					// timeDiff = now - candle.TimeStamp
 					timeDiff := sdk.NewDec(now - candle.TimeStamp)
+					if candle.Volume.Equal(sdk.ZeroDec()) {
+						candle.Volume = minimumCandleVolume
+					}
+
 					// volume = candle.Volume * (weightUnit * (period - timeDiff) + minimumTimeWeight)
 					volume := candle.Volume.Mul(
 						weightUnit.Mul(period.Sub(timeDiff).Add(minimumTimeWeight)),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This PR adds a minimum candle volume to the price feeder. 

This should assist with current issue on mainnet causing asset pairs to go down. Volume on Umee is zero for certain 5-minute time periods, making the price feeder unable to vote on the price of UMEE.

Due to this line of code, this causes downtime for all the other assets: 

https://github.com/umee-network/umee/blob/35a7d7dde4fb0ec34dbcf83fb5dd51e0f0159537/price-feeder/oracle/oracle.go#L268

This is addressed in https://github.com/umee-network/umee/pull/1635

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
