### PR TITLE
fix: export genesis tracks reserves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Fixes
 
+- [1650](https://github.com/umee-network/umee/pull/1650) Fixes bug with reserves in ExportGenesis
 - [1642](https://github.com/umee-network/umee/pull/1642) Added missing CLI for QueryBadDebts
 - [1633](https://github.com/umee-network/umee/pull/1633) Increases price calculation precision for high exponent assets.
 

--- a/x/leverage/types/genesis.go
+++ b/x/leverage/types/genesis.go
@@ -25,6 +25,7 @@ func NewGenesisState(
 		Registry:         tokens,
 		AdjustedBorrows:  adjustedBorrows,
 		Collateral:       collateral,
+		Reserves:         reserves,
 		LastInterestTime: lastInterestTime,
 		BadDebts:         badDebts,
 		InterestScalars:  interestScalars,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Conditions for bug:
- Starting chain from exported genesis (i.e. hard fork)
- Other genesis exports

Effects of bug:
- If we ever do a hard fork, reserves accumulated from borrow interest would not carry over.
- Other processes relying on exported genesis might arrive at a bad app hash due to disagreeing on state

This would essentially making it as if the `reserve_factor` had been zero instead of `~0.1` for all tokens:
- slightly benefitting suppliers
- but putting protocol bad debt repayment at risk

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
