### PR TITLE
fix: price-feeder module version

### DIFF
--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -50,7 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bugs
 
-- Fix module version
+- [1660](https://github.com/umee-network/umee/pull/1660) Fix module version
 
 ## [v2.0.1](https://github.com/umee-network/umee/releases/tag/price-feeder/v2.0.1) 2022-12-01
 

--- a/price-feeder/CHANGELOG.md
+++ b/price-feeder/CHANGELOG.md
@@ -46,6 +46,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## [v2.0.2](https://github.com/umee-network/umee/releases/tag/price-feeder/v2.0.2) 2022-12-14
+
+### Bugs
+
+- Fix module version
+
 ## [v2.0.1](https://github.com/umee-network/umee/releases/tag/price-feeder/v2.0.1) 2022-12-01
 
 ### Bugs

--- a/price-feeder/cmd/price-feeder.go
+++ b/price-feeder/cmd/price-feeder.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle"
-	"github.com/umee-network/umee/price-feeder/oracle/client"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	v1 "github.com/umee-network/umee/price-feeder/router/v1"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/client"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	v1 "github.com/umee-network/umee/price-feeder/v2/router/v1"
 )
 
 const (

--- a/price-feeder/config/config.go
+++ b/price-feeder/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
 )
 
 const (

--- a/price-feeder/config/config_test.go
+++ b/price-feeder/config/config_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
 )
 
 func TestValidate(t *testing.T) {

--- a/price-feeder/go.mod
+++ b/price-feeder/go.mod
@@ -1,4 +1,4 @@
-module github.com/umee-network/umee/price-feeder
+module github.com/umee-network/umee/price-feeder/v2
 
 go 1.19
 

--- a/price-feeder/main.go
+++ b/price-feeder/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/umee-network/umee/price-feeder/cmd"
+	"github.com/umee-network/umee/price-feeder/v2/cmd"
 )
 
 func main() {

--- a/price-feeder/oracle/convert.go
+++ b/price-feeder/oracle/convert.go
@@ -6,9 +6,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 // getUSDBasedProviders retrieves which providers for an asset have a USD-based pair,

--- a/price-feeder/oracle/convert_test.go
+++ b/price-feeder/oracle/convert_test.go
@@ -7,8 +7,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 var (

--- a/price-feeder/oracle/filter.go
+++ b/price-feeder/oracle/filter.go
@@ -3,8 +3,8 @@ package oracle
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 // defaultDeviationThreshold defines how many 𝜎 a provider can be away

--- a/price-feeder/oracle/filter_test.go
+++ b/price-feeder/oracle/filter_test.go
@@ -7,8 +7,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestSuccessFilterCandleDeviations(t *testing.T) {

--- a/price-feeder/oracle/oracle.go
+++ b/price-feeder/oracle/oracle.go
@@ -18,11 +18,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle/client"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
-	pfsync "github.com/umee-network/umee/price-feeder/pkg/sync"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/client"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
+	pfsync "github.com/umee-network/umee/price-feeder/v2/pkg/sync"
 	oracletypes "github.com/umee-network/umee/v3/x/oracle/types"
 )
 

--- a/price-feeder/oracle/oracle_test.go
+++ b/price-feeder/oracle/oracle_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle/client"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/client"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 type mockProvider struct {

--- a/price-feeder/oracle/prices.go
+++ b/price-feeder/oracle/prices.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
 )
 
 type (

--- a/price-feeder/oracle/provider/binance.go
+++ b/price-feeder/oracle/provider/binance.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/binance_test.go
+++ b/price-feeder/oracle/provider/binance_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestBinanceProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/bitget.go
+++ b/price-feeder/oracle/provider/bitget.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/bitget_test.go
+++ b/price-feeder/oracle/provider/bitget_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestBitgetProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/coinbase.go
+++ b/price-feeder/oracle/provider/coinbase.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rs/zerolog"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/coinbase_test.go
+++ b/price-feeder/oracle/provider/coinbase_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/crypto.go
+++ b/price-feeder/oracle/provider/crypto.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/crypto_test.go
+++ b/price-feeder/oracle/provider/crypto_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestCryptoProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/gate.go
+++ b/price-feeder/oracle/provider/gate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/gate_test.go
+++ b/price-feeder/oracle/provider/gate_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestGateProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/huobi.go
+++ b/price-feeder/oracle/provider/huobi.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/huobi_test.go
+++ b/price-feeder/oracle/provider/huobi_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 	"github.com/umee-network/umee/v3/util/coin"
 )
 

--- a/price-feeder/oracle/provider/kraken.go
+++ b/price-feeder/oracle/provider/kraken.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/kraken_test.go
+++ b/price-feeder/oracle/provider/kraken_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestKrakenProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/mexc.go
+++ b/price-feeder/oracle/provider/mexc.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 
 	"github.com/umee-network/umee/v3/util/coin"
 )

--- a/price-feeder/oracle/provider/mexc_test.go
+++ b/price-feeder/oracle/provider/mexc_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestMexcProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/mock.go
+++ b/price-feeder/oracle/provider/mock.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/mock_test.go
+++ b/price-feeder/oracle/provider/mock_test.go
@@ -7,7 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestMockProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/okx.go
+++ b/price-feeder/oracle/provider/okx.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/okx_test.go
+++ b/price-feeder/oracle/provider/okx_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestOkxProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/osmosis.go
+++ b/price-feeder/oracle/provider/osmosis.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 	"github.com/umee-network/umee/v3/util/coin"
 )
 

--- a/price-feeder/oracle/provider/osmosis_test.go
+++ b/price-feeder/oracle/provider/osmosis_test.go
@@ -7,7 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestOsmosisProvider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/osmosisv2.go
+++ b/price-feeder/oracle/provider/osmosisv2.go
@@ -12,7 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/osmosisv2_test.go
+++ b/price-feeder/oracle/provider/osmosisv2_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestOsmosisV2Provider_GetTickerPrices(t *testing.T) {

--- a/price-feeder/oracle/provider/provider.go
+++ b/price-feeder/oracle/provider/provider.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/provider/websocket_controller.go
+++ b/price-feeder/oracle/provider/websocket_controller.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 const (

--- a/price-feeder/oracle/util.go
+++ b/price-feeder/oracle/util.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
 )
 
 var (

--- a/price-feeder/oracle/util_test.go
+++ b/price-feeder/oracle/util_test.go
@@ -6,9 +6,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	"github.com/umee-network/umee/price-feeder/oracle"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 func TestComputeVWAP(t *testing.T) {

--- a/price-feeder/router/middleware/middleware.go
+++ b/price-feeder/router/middleware/middleware.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 
-	"github.com/umee-network/umee/price-feeder/config"
+	"github.com/umee-network/umee/price-feeder/v2/config"
 )
 
 func Build(logger zerolog.Logger, cfg config.Config) alice.Chain {

--- a/price-feeder/router/v1/oracle.go
+++ b/price-feeder/router/v1/oracle.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/oracle"
+	"github.com/umee-network/umee/price-feeder/v2/oracle"
 )
 
 // Oracle defines the Oracle interface contract that the v1 router depends on.

--- a/price-feeder/router/v1/response.go
+++ b/price-feeder/router/v1/response.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
 )
 
 // Response constants

--- a/price-feeder/router/v1/router.go
+++ b/price-feeder/router/v1/router.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/pkg/httputil"
-	"github.com/umee-network/umee/price-feeder/router/middleware"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/pkg/httputil"
+	"github.com/umee-network/umee/price-feeder/v2/router/middleware"
 )
 
 const (

--- a/price-feeder/router/v1/router_test.go
+++ b/price-feeder/router/v1/router_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
-	"github.com/umee-network/umee/price-feeder/config"
-	"github.com/umee-network/umee/price-feeder/oracle"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	v1 "github.com/umee-network/umee/price-feeder/router/v1"
+	"github.com/umee-network/umee/price-feeder/v2/config"
+	"github.com/umee-network/umee/price-feeder/v2/oracle"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	v1 "github.com/umee-network/umee/price-feeder/v2/router/v1"
 )
 
 var (

--- a/price-feeder/tests/integration/fixtures.go
+++ b/price-feeder/tests/integration/fixtures.go
@@ -1,8 +1,8 @@
 package integration
 
 import (
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 var ProviderAndCurrencyPairsFixture = []struct {

--- a/price-feeder/tests/integration/provider_test.go
+++ b/price-feeder/tests/integration/provider_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/umee-network/umee/price-feeder/oracle"
-	"github.com/umee-network/umee/price-feeder/oracle/provider"
-	"github.com/umee-network/umee/price-feeder/oracle/types"
+	"github.com/umee-network/umee/price-feeder/v2/oracle"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/provider"
+	"github.com/umee-network/umee/price-feeder/v2/oracle/types"
 )
 
 type IntegrationTestSuite struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Peggo can't be updated, because the module version is not properly set.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
