### PR TITLE
fix: add amino support for MsgMaxWithdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Fixes
 
-- [XXXX](https://github.com/umee-network/umee/pull/XXXX) Add amino support for MsgMaxWithdraw.
+- [1680](https://github.com/umee-network/umee/pull/1680) Add amino support for MsgMaxWithdraw.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixes
+
+- [XXXX](https://github.com/umee-network/umee/pull/XXXX) Add amino support for MsgMaxWithdraw.
+
 ### Features
 
 - [1548](https://github.com/umee-network/umee/pull/1548) Historacle prices and medians keeper proof of concept.

--- a/x/leverage/types/codec.go
+++ b/x/leverage/types/codec.go
@@ -12,9 +12,8 @@ import (
 var (
 	amino = codec.NewLegacyAmino()
 
-	// ModuleCdc references the global x/leverage module codec. Note, the codec
-	// should ONLY be used in certain instances of tests and for JSON encoding as
-	// Amino is still used for that purpose.
+	// ModuleCdc references the global x/leverage module codec. Note, Amino
+	// is required for ledger signing of messages, and Kepler signing.
 	ModuleCdc = codec.NewAminoCodec(amino)
 )
 
@@ -37,6 +36,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgLiquidate{}, "umee/leverage/MsgLiquidate", nil)
 	cdc.RegisterConcrete(&MsgGovUpdateRegistry{}, "umee/leverage/MsgGovUpdateRegistry", nil)
 	cdc.RegisterConcrete(&MsgSupplyCollateral{}, "umee/leverage/MsgSupplyCollateral", nil)
+	cdc.RegisterConcrete(&MsgMaxWithdraw{}, "umee/leverage/MsgMaxWithdraw", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -51,6 +51,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgLiquidate{},
 		&MsgGovUpdateRegistry{},
 		&MsgSupplyCollateral{},
+		&MsgMaxWithdraw{},
 	)
 
 	registry.RegisterImplementations(


### PR DESCRIPTION
This is required for ledger signing - and for our Kepler integration, which uses amino (for all users) to support ledgers.