### PR TITLE
ci(tests): fix historical e2e flaky test

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -9,7 +9,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appparams "github.com/umee-network/umee/v4/app/params"
-	"github.com/umee-network/umee/v4/tests/grpc"
 )
 
 func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
@@ -141,6 +140,7 @@ func (s *IntegrationTestSuite) TestUmeeTokenTransfers() {
 	})
 }
 
+/*
 func (s *IntegrationTestSuite) TestHistorical() {
 	err := grpc.MedianCheck(
 		s.chain.id,
@@ -150,3 +150,4 @@ func (s *IntegrationTestSuite) TestHistorical() {
 	)
 	s.Require().NoError(err)
 }
+*/

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appparams "github.com/umee-network/umee/v4/app/params"
+	"github.com/umee-network/umee/v4/tests/grpc"
 )
 
 func (s *IntegrationTestSuite) TestIBCTokenTransfer() {
@@ -140,7 +141,6 @@ func (s *IntegrationTestSuite) TestUmeeTokenTransfers() {
 	})
 }
 
-/*
 func (s *IntegrationTestSuite) TestHistorical() {
 	err := grpc.MedianCheck(
 		s.chain.id,
@@ -150,4 +150,3 @@ func (s *IntegrationTestSuite) TestHistorical() {
 	)
 	s.Require().NoError(err)
 }
-*/

--- a/tests/grpc/historical.go
+++ b/tests/grpc/historical.go
@@ -117,7 +117,3 @@ func listenForPrices(
 func isPeriodFirstBlock(height int64, blocksPerPeriod uint64) bool {
 	return uint64(height)%blocksPerPeriod == 0
 }
-
-func isPeriodLastBlock(height int64, blocksPerPeriod uint64) bool {
-	return uint64(height+1)%blocksPerPeriod == 0
-}

--- a/tests/grpc/historical.go
+++ b/tests/grpc/historical.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -48,7 +47,7 @@ func MedianCheck(
 		return err
 	}
 
-	fmt.Println("waiting for exchange rates")
+	// Wait for oracle exchange rates
 	for i := 0; i < 20; i++ {
 		<-chainHeight.HeightChanged
 		exchangeRates, err := val1Client.QueryExchangeRates()
@@ -89,7 +88,6 @@ func listenForPrices(
 		height := <-chainHeight.HeightChanged
 		if isPeriodFirstBlock(height, params.HistoricStampPeriod) {
 			exchangeRates, err := umeeClient.QueryExchangeRates()
-			fmt.Printf("rates at block %d: %+v\n", height, exchangeRates)
 			if err != nil {
 				return nil, err
 			}

--- a/tests/grpc/historical.go
+++ b/tests/grpc/historical.go
@@ -78,7 +78,7 @@ func listenForPrices(
 	var beginningHeight int64
 	for {
 		beginningHeight = <-chainHeight.HeightChanged
-		if isPeriodLastBlock(beginningHeight, params.MedianStampPeriod) {
+		if isPeriodFirstBlock(beginningHeight, params.MedianStampPeriod) {
 			break
 		}
 	}

--- a/tests/grpc/price_store.go
+++ b/tests/grpc/price_store.go
@@ -12,6 +12,13 @@ type PriceStore struct {
 	medians        map[string]sdk.Dec
 }
 
+func NewPriceStore() *PriceStore {
+	return &PriceStore{
+		historicStamps: map[string][]sdk.Dec{},
+		medians:        map[string]sdk.Dec{},
+	}
+}
+
 func (ps *PriceStore) addStamp(denom string, stamp sdk.Dec) {
 	if _, ok := ps.historicStamps[denom]; !ok {
 		ps.historicStamps[denom] = []sdk.Dec{}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- Fixed the flakiness of the historical e2e grpc tests by ensuring that the collection of prices starts at the beginning of a median period
- Updated the price store to include prices for all denoms; effectively checking all medians in parallel
- Actively check for existing exchange rates instead of waiting an arbitrary number of blocks

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
