### PR TITLE
ci(backport): add v4.0.x backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,3 +44,12 @@ pull_request_rules:
       backport:
         branches:
           - release/price-feeder/v2.x.x
+
+  - name: Backport patches to the release/v4.0.x branch
+    conditions:
+      - base=main
+      - label=S:backport/v4.0.x
+    actions:
+      backport:
+        branches:
+          - release/v4.0.x


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Adds branch v4.0.x to backport rules 

Branch was made in anticipation of https://github.com/umee-network/umee/pull/1725 and not wanting to include it in our v4.0 release

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
