### PR TITLE
fix: oracle accept list no longer automatically adds blacklisted tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixes
+
+- [1XXX](https://github.com/umee-network/umee/pull/1XXX) Blacklisted tokens no longer add themselves back to the oracle accept list.
+
 ## [v4.0.0](https://github.com/umee-network/umee/releases/tag/v4.0.0) - 2023-01-20
 
 ### API Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Fixes
 
-- [1XXX](https://github.com/umee-network/umee/pull/1XXX) Blacklisted tokens no longer add themselves back to the oracle accept list.
+- [1736](https://github.com/umee-network/umee/pull/1736) Blacklisted tokens no longer add themselves back to the oracle accept list.
 
 ## [v4.0.0](https://github.com/umee-network/umee/releases/tag/v4.0.0) - 2023-01-20
 

--- a/x/oracle/keeper/hooks.go
+++ b/x/oracle/keeper/hooks.go
@@ -24,12 +24,12 @@ func (k Keeper) Hooks() Hooks {
 // it checks if the provided Token should be added to the existing accepted list
 // of assets for the x/oracle module.
 func (h Hooks) AfterTokenRegistered(ctx sdk.Context, token leveragetypes.Token) {
-	acceptList := h.k.AcceptList(ctx)
-
 	if token.Blacklist {
 		// Blacklisted tokens should not trigger updates to the oracle accept list
 		return
 	}
+
+	acceptList := h.k.AcceptList(ctx)
 
 	var tokenExists bool
 	for _, t := range acceptList {

--- a/x/oracle/keeper/hooks.go
+++ b/x/oracle/keeper/hooks.go
@@ -26,6 +26,11 @@ func (k Keeper) Hooks() Hooks {
 func (h Hooks) AfterTokenRegistered(ctx sdk.Context, token leveragetypes.Token) {
 	acceptList := h.k.AcceptList(ctx)
 
+	if token.Blacklist {
+		// Blacklisted tokens should not trigger updates to the oracle accept list
+		return
+	}
+
 	var tokenExists bool
 	for _, t := range acceptList {
 		if t.BaseDenom == token.BaseDenom {

--- a/x/oracle/keeper/hooks_test.go
+++ b/x/oracle/keeper/hooks_test.go
@@ -24,4 +24,13 @@ func (s *IntegrationTestSuite) TestHooks_AfterTokenRegistered() {
 		Exponent:    6,
 	})
 	s.Require().Len(s.app.OracleKeeper.AcceptList(s.ctx), 3)
+
+	// require a blacklisted token does not update the accept list
+	h.AfterTokenRegistered(s.ctx, leveragetypes.Token{
+		BaseDenom:   "unope",
+		SymbolDenom: "NOPE",
+		Exponent:    6,
+		Blacklist:   true,
+	})
+	s.Require().Len(s.app.OracleKeeper.AcceptList(s.ctx), 3)
 }


### PR DESCRIPTION
## Description

This was the source of the reappearance of `CRO` and `ETH2` on the canon-2 testnet recently.
