### PR TITLE
fix: increase pricefeeder e2e test timeout

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -1029,7 +1029,7 @@ func (s *IntegrationTestSuite) runPriceFeeder() {
 
 			return len(prices) > 0
 		},
-		time.Minute,
+		time.Second*90, // 1:30 min
 		time.Second,
 		"price-feeder not healthy",
 	)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

2e2 price feeder test is flaky - probably the timeout is too small.
Increasing from 1min to 1:30min

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
