### PR TITLE
DNM: oracle keeper enforces uppercase symbol denoms

### DIFF
--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -173,17 +173,17 @@ func (s *IntegrationTestSuite) TestEndBlockerVoteThreshold() {
 	// umee has 100% power, and atom has 30%
 	val1Tuples = types.ExchangeRateTuples{
 		types.ExchangeRateTuple{
-			Denom:        "umee",
+			Denom:        "UMEE",
 			ExchangeRate: sdk.MustNewDecFromStr("1.0"),
 		},
 	}
 	val2Tuples = types.ExchangeRateTuples{
 		types.ExchangeRateTuple{
-			Denom:        "umee",
+			Denom:        "UMEE",
 			ExchangeRate: sdk.MustNewDecFromStr("0.5"),
 		},
 		types.ExchangeRateTuple{
-			Denom:        "atom",
+			Denom:        "ATOM",
 			ExchangeRate: sdk.MustNewDecFromStr("0.5"),
 		},
 	}
@@ -199,11 +199,11 @@ func (s *IntegrationTestSuite) TestEndBlockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	rate, err := app.OracleKeeper.GetExchangeRate(ctx, "umee")
+	rate, err := app.OracleKeeper.GetExchangeRate(ctx, "UMEE")
 	s.Require().NoError(err)
 	s.Require().Equal(sdk.MustNewDecFromStr("1.0"), rate)
-	rate, err = app.OracleKeeper.GetExchangeRate(ctx, "atom")
-	s.Require().ErrorIs(err, sdkerrors.Wrap(types.ErrUnknownDenom, "atom"))
+	rate, err = app.OracleKeeper.GetExchangeRate(ctx, "ATOM")
+	s.Require().ErrorIs(err, sdkerrors.Wrap(types.ErrUnknownDenom, "ATOM"))
 	s.Require().Equal(sdk.ZeroDec(), rate)
 
 	ctx = ctx.WithBlockHeight(originalBlockHeight)
@@ -249,7 +249,7 @@ func (s *IntegrationTestSuite) TestEndblockerHistoracle() {
 			blockHeight += historicStampPeriod
 			ctx = ctx.WithBlockHeight(blockHeight)
 
-			var tuples = types.ExchangeRateTuples{}
+			tuples := types.ExchangeRateTuples{}
 			for denom, prices := range exchangeRates {
 				tuples = append(tuples, types.ExchangeRateTuple{
 					Denom:        denom,

--- a/x/oracle/keeper/end_blocker.go
+++ b/x/oracle/keeper/end_blocker.go
@@ -13,14 +13,14 @@ func (k *Keeper) PruneAllPrices(ctx sdk.Context) {
 	if k.IsPeriodLastBlock(ctx, params.HistoricStampPeriod) {
 		pruneHistoricPeriod := params.HistoricStampPeriod * params.MaximumPriceStamps
 		if pruneHistoricPeriod < blockHeight {
-			k.PruneHistoricPricesBeforeBlock(ctx, blockHeight-pruneHistoricPeriod)
+			k.PruneHistoricPricesBeforeBlock(ctx, blockHeight-pruneHistoricPeriod) // check
 		}
 
 		if k.IsPeriodLastBlock(ctx, params.MedianStampPeriod) {
 			pruneMedianPeriod := params.MedianStampPeriod * params.MaximumMedianStamps
 			if pruneMedianPeriod < blockHeight {
-				k.PruneMediansBeforeBlock(ctx, blockHeight-pruneMedianPeriod)
-				k.PruneMedianDeviationsBeforeBlock(ctx, blockHeight-pruneMedianPeriod)
+				k.PruneMediansBeforeBlock(ctx, blockHeight-pruneMedianPeriod)          // check
+				k.PruneMedianDeviationsBeforeBlock(ctx, blockHeight-pruneMedianPeriod) // check
 			}
 		}
 	}

--- a/x/oracle/keeper/end_blocker.go
+++ b/x/oracle/keeper/end_blocker.go
@@ -13,14 +13,14 @@ func (k *Keeper) PruneAllPrices(ctx sdk.Context) {
 	if k.IsPeriodLastBlock(ctx, params.HistoricStampPeriod) {
 		pruneHistoricPeriod := params.HistoricStampPeriod * params.MaximumPriceStamps
 		if pruneHistoricPeriod < blockHeight {
-			k.PruneHistoricPricesBeforeBlock(ctx, blockHeight-pruneHistoricPeriod) // check
+			k.PruneHistoricPricesBeforeBlock(ctx, blockHeight-pruneHistoricPeriod)
 		}
 
 		if k.IsPeriodLastBlock(ctx, params.MedianStampPeriod) {
 			pruneMedianPeriod := params.MedianStampPeriod * params.MaximumMedianStamps
 			if pruneMedianPeriod < blockHeight {
-				k.PruneMediansBeforeBlock(ctx, blockHeight-pruneMedianPeriod)          // check
-				k.PruneMedianDeviationsBeforeBlock(ctx, blockHeight-pruneMedianPeriod) // check
+				k.PruneMediansBeforeBlock(ctx, blockHeight-pruneMedianPeriod)
+				k.PruneMedianDeviationsBeforeBlock(ctx, blockHeight-pruneMedianPeriod)
 			}
 		}
 	}

--- a/x/oracle/keeper/genesis_test.go
+++ b/x/oracle/keeper/genesis_test.go
@@ -56,9 +56,9 @@ FOUND:
 func (s *IntegrationTestSuite) TestIterateAllMedianPrices() {
 	keeper, ctx := s.app.OracleKeeper, s.ctx
 	medians := []types.ExchangeRateTuple{
-		{Denom: "umee", ExchangeRate: sdk.MustNewDecFromStr("20.44")},
-		{Denom: "atom", ExchangeRate: sdk.MustNewDecFromStr("2.66")},
-		{Denom: "osmo", ExchangeRate: sdk.MustNewDecFromStr("13.64")},
+		{Denom: "UMEE", ExchangeRate: sdk.MustNewDecFromStr("20.44")},
+		{Denom: "ATOM", ExchangeRate: sdk.MustNewDecFromStr("2.66")},
+		{Denom: "OSMO", ExchangeRate: sdk.MustNewDecFromStr("13.64")},
 	}
 
 	for _, m := range medians {
@@ -90,9 +90,9 @@ FOUND:
 func (s *IntegrationTestSuite) TestIterateAllMedianDeviationPrices() {
 	keeper, ctx := s.app.OracleKeeper, s.ctx
 	medians := []types.ExchangeRateTuple{
-		{Denom: "umee", ExchangeRate: sdk.MustNewDecFromStr("21.44")},
-		{Denom: "atom", ExchangeRate: sdk.MustNewDecFromStr("3.66")},
-		{Denom: "osmo", ExchangeRate: sdk.MustNewDecFromStr("14.64")},
+		{Denom: "UMEE", ExchangeRate: sdk.MustNewDecFromStr("21.44")},
+		{Denom: "ATOM", ExchangeRate: sdk.MustNewDecFromStr("3.66")},
+		{Denom: "OSMO", ExchangeRate: sdk.MustNewDecFromStr("14.64")},
 	}
 
 	for _, m := range medians {

--- a/x/oracle/keeper/genesis_test.go
+++ b/x/oracle/keeper/genesis_test.go
@@ -11,16 +11,16 @@ func (s *IntegrationTestSuite) TestIterateAllHistoricPrices() {
 
 	historicPrices := []types.Price{
 		{BlockNum: 10, ExchangeRateTuple: types.ExchangeRateTuple{
-			Denom: "umee", ExchangeRate: sdk.MustNewDecFromStr("20.45"),
+			Denom: "UMEE", ExchangeRate: sdk.MustNewDecFromStr("20.45"),
 		}},
 		{BlockNum: 11, ExchangeRateTuple: types.ExchangeRateTuple{
-			Denom: "umee", ExchangeRate: sdk.MustNewDecFromStr("20.44"),
+			Denom: "UMEE", ExchangeRate: sdk.MustNewDecFromStr("20.44"),
 		}},
 		{BlockNum: 10, ExchangeRateTuple: types.ExchangeRateTuple{
-			Denom: "btc", ExchangeRate: sdk.MustNewDecFromStr("1200.56"),
+			Denom: "BTC", ExchangeRate: sdk.MustNewDecFromStr("1200.56"),
 		}},
 		{BlockNum: 11, ExchangeRateTuple: types.ExchangeRateTuple{
-			Denom: "btc", ExchangeRate: sdk.MustNewDecFromStr("1200.19"),
+			Denom: "BTC", ExchangeRate: sdk.MustNewDecFromStr("1200.19"),
 		}},
 	}
 

--- a/x/oracle/keeper/grpc_query_test.go
+++ b/x/oracle/keeper/grpc_query_test.go
@@ -205,10 +205,10 @@ func (s *IntegrationTestSuite) TestQuerier_AggregateVotesAppendVotes() {
 func (s *IntegrationTestSuite) TestQuerier_Medians() {
 	app, ctx := s.app, s.ctx
 
-	atomMedian0 := sdk.DecCoin{Denom: "atom", Amount: sdk.MustNewDecFromStr("49.99")}
-	umeeMedian0 := sdk.DecCoin{Denom: "umee", Amount: sdk.MustNewDecFromStr("6541.48")}
-	atomMedian1 := sdk.DecCoin{Denom: "atom", Amount: sdk.MustNewDecFromStr("51.09")}
-	umeeMedian1 := sdk.DecCoin{Denom: "umee", Amount: sdk.MustNewDecFromStr("6540.23")}
+	atomMedian0 := sdk.DecCoin{Denom: "ATOM", Amount: sdk.MustNewDecFromStr("49.99")}
+	umeeMedian0 := sdk.DecCoin{Denom: "UMEE", Amount: sdk.MustNewDecFromStr("6541.48")}
+	atomMedian1 := sdk.DecCoin{Denom: "ATOM", Amount: sdk.MustNewDecFromStr("51.09")}
+	umeeMedian1 := sdk.DecCoin{Denom: "UMEE", Amount: sdk.MustNewDecFromStr("6540.23")}
 
 	blockHeight0 := uint64(ctx.BlockHeight() - 4)
 	app.OracleKeeper.SetHistoricMedian(ctx, atomMedian0.Denom, blockHeight0, atomMedian0.Amount)
@@ -218,8 +218,8 @@ func (s *IntegrationTestSuite) TestQuerier_Medians() {
 	s.Require().NoError(err)
 
 	expected := []types.Price{
-		*types.NewPrice(atomMedian0.Amount, "atom", blockHeight0),
-		*types.NewPrice(umeeMedian0.Amount, "umee", blockHeight0),
+		*types.NewPrice(atomMedian0.Amount, "ATOM", blockHeight0),
+		*types.NewPrice(umeeMedian0.Amount, "UMEE", blockHeight0),
 	}
 	s.Require().Equal(res.Medians, expected)
 
@@ -227,7 +227,7 @@ func (s *IntegrationTestSuite) TestQuerier_Medians() {
 	s.Require().NoError(err)
 
 	expected = []types.Price{
-		*types.NewPrice(atomMedian0.Amount, "atom", blockHeight0),
+		*types.NewPrice(atomMedian0.Amount, "ATOM", blockHeight0),
 	}
 	s.Require().Equal(res.Medians, expected)
 
@@ -239,10 +239,10 @@ func (s *IntegrationTestSuite) TestQuerier_Medians() {
 	s.Require().NoError(err)
 
 	expected = []types.Price{
-		*types.NewPrice(atomMedian0.Amount, "atom", blockHeight0),
-		*types.NewPrice(umeeMedian0.Amount, "umee", blockHeight0),
-		*types.NewPrice(atomMedian1.Amount, "atom", blockHeight1),
-		*types.NewPrice(umeeMedian1.Amount, "umee", blockHeight1),
+		*types.NewPrice(atomMedian0.Amount, "ATOM", blockHeight0),
+		*types.NewPrice(umeeMedian0.Amount, "UMEE", blockHeight0),
+		*types.NewPrice(atomMedian1.Amount, "ATOM", blockHeight1),
+		*types.NewPrice(umeeMedian1.Amount, "UMEE", blockHeight1),
 	}
 	s.Require().Equal(res.Medians, expected)
 
@@ -250,8 +250,8 @@ func (s *IntegrationTestSuite) TestQuerier_Medians() {
 	s.Require().NoError(err)
 
 	expected = []types.Price{
-		*types.NewPrice(atomMedian0.Amount, "atom", blockHeight0),
-		*types.NewPrice(atomMedian1.Amount, "atom", blockHeight1),
+		*types.NewPrice(atomMedian0.Amount, "ATOM", blockHeight0),
+		*types.NewPrice(atomMedian1.Amount, "ATOM", blockHeight1),
 	}
 	s.Require().Equal(res.Medians, expected)
 

--- a/x/oracle/keeper/historic_avg.go
+++ b/x/oracle/keeper/historic_avg.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -107,7 +108,7 @@ func (k AvgKeeper) getAllAvgCounters(denom string) []types.AvgCounter {
 
 	for ; iter.Valid(); iter.Next() {
 		var av types.AvgCounter
-		k.cdc.MustUnmarshal(iter.Value(), &av)
+		k.cdc.MustUnmarshal(iter.Value(), &av) // SYGET
 		avs = append(avs, av)
 	}
 
@@ -117,12 +118,13 @@ func (k AvgKeeper) getAllAvgCounters(denom string) []types.AvgCounter {
 // setAvgCounters sets AllAvgCounter in the same order as in the slice.
 // Contract: MUST be the same order as returned from GetAllAvgCounters
 func (k AvgKeeper) setAvgCounters(denom string, acs []types.AvgCounter) {
+	denom = strings.ToUpper(denom) // setters enforce uppercase symbol denom
 	key := types.KeyAvgCounter(denom, 0)
 	lastIdx := len(key) - 1
 	for i := range acs {
 		key[lastIdx] = byte(i)
 		bz := k.cdc.MustMarshal(&acs[i])
-		k.store.Set(key, bz)
+		k.store.Set(key, bz) // SYSET
 	}
 }
 
@@ -134,7 +136,7 @@ func (k AvgKeeper) GetCurrentAvg(denom string) (sdk.Dec, error) {
 
 	key := types.KeyAvgCounter(denom, latestIdx)
 	var av types.AvgCounter
-	bz := k.store.Get(key)
+	bz := k.store.Get(key) // SYGET
 	if len(bz) == 0 {
 		return sdk.Dec{}, types.ErrNoLatestAvgPrice
 	}

--- a/x/oracle/keeper/historic_avg.go
+++ b/x/oracle/keeper/historic_avg.go
@@ -108,7 +108,7 @@ func (k AvgKeeper) getAllAvgCounters(denom string) []types.AvgCounter {
 
 	for ; iter.Valid(); iter.Next() {
 		var av types.AvgCounter
-		k.cdc.MustUnmarshal(iter.Value(), &av) // SYGET
+		k.cdc.MustUnmarshal(iter.Value(), &av)
 		avs = append(avs, av)
 	}
 
@@ -124,7 +124,7 @@ func (k AvgKeeper) setAvgCounters(denom string, acs []types.AvgCounter) {
 	for i := range acs {
 		key[lastIdx] = byte(i)
 		bz := k.cdc.MustMarshal(&acs[i])
-		k.store.Set(key, bz) // SYSET
+		k.store.Set(key, bz)
 	}
 }
 
@@ -136,7 +136,7 @@ func (k AvgKeeper) GetCurrentAvg(denom string) (sdk.Dec, error) {
 
 	key := types.KeyAvgCounter(denom, latestIdx)
 	var av types.AvgCounter
-	bz := k.store.Get(key) // SYGET
+	bz := k.store.Get(key)
 	if len(bz) == 0 {
 		return sdk.Dec{}, types.ErrNoLatestAvgPrice
 	}

--- a/x/oracle/keeper/historic_price.go
+++ b/x/oracle/keeper/historic_price.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"strings"
+
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -52,7 +54,8 @@ func (k Keeper) SetHistoricMedian(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: median})
-	store.Set(types.KeyMedian(denom, blockNum), bz)
+	denom = strings.ToUpper(denom)                  // setters enforce uppercase symbol denom
+	store.Set(types.KeyMedian(denom, blockNum), bz) // SYSET
 }
 
 // HistoricMedianDeviation returns a given denom's most recently stamped
@@ -64,7 +67,7 @@ func (k Keeper) HistoricMedianDeviation(
 	store := ctx.KVStore(k.storeKey)
 	blockDiff := uint64(ctx.BlockHeight())%k.MedianStampPeriod(ctx) + 1
 	blockNum := uint64(ctx.BlockHeight()) - blockDiff
-	bz := store.Get(types.KeyMedianDeviation(denom, blockNum))
+	bz := store.Get(types.KeyMedianDeviation(denom, blockNum)) // SYGET
 	if bz == nil {
 		return &types.Price{}, types.ErrNoMedianDeviation.Wrap("denom: " + denom)
 	}
@@ -131,7 +134,8 @@ func (k Keeper) SetHistoricMedianDeviation(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: medianDeviation})
-	store.Set(types.KeyMedianDeviation(denom, blockNum), bz)
+	denom = strings.ToUpper(denom)                           // setters enforce uppercase symbol denom
+	store.Set(types.KeyMedianDeviation(denom, blockNum), bz) // SYSET
 }
 
 // MedianOfHistoricMedians calculates and returns the median of the last stampNum
@@ -311,7 +315,8 @@ func (k Keeper) SetHistoricPrice(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: exchangeRate})
-	store.Set(types.KeyHistoricPrice(denom, blockNum), bz)
+	denom = strings.ToUpper(denom)                         // setters enforce uppercase symbol denom
+	store.Set(types.KeyHistoricPrice(denom, blockNum), bz) // SYSET
 }
 
 // DeleteHistoricPrice deletes the historic price of a denom at a
@@ -322,7 +327,7 @@ func (k Keeper) DeleteHistoricPrice(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyHistoricPrice(denom, blockNum))
+	store.Delete(types.KeyHistoricPrice(denom, blockNum)) // SYSET
 }
 
 // DeleteHistoricMedian deletes a given denom's median price at a given block.
@@ -332,7 +337,7 @@ func (k Keeper) DeleteHistoricMedian(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyMedian(denom, blockNum))
+	store.Delete(types.KeyMedian(denom, blockNum)) // SYSET
 }
 
 // DeleteHistoricMedianDeviation deletes a given denom's standard deviation
@@ -343,7 +348,7 @@ func (k Keeper) DeleteHistoricMedianDeviation(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyMedianDeviation(denom, blockNum))
+	store.Delete(types.KeyMedianDeviation(denom, blockNum)) // SYSET
 }
 
 func (k Keeper) PruneHistoricPricesBeforeBlock(ctx sdk.Context, blockNum uint64) {

--- a/x/oracle/keeper/historic_price.go
+++ b/x/oracle/keeper/historic_price.go
@@ -54,8 +54,8 @@ func (k Keeper) SetHistoricMedian(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: median})
-	denom = strings.ToUpper(denom)                  // setters enforce uppercase symbol denom
-	store.Set(types.KeyMedian(denom, blockNum), bz) // SYSET
+	denom = strings.ToUpper(denom) // setters enforce uppercase symbol denom
+	store.Set(types.KeyMedian(denom, blockNum), bz)
 }
 
 // HistoricMedianDeviation returns a given denom's most recently stamped
@@ -67,7 +67,7 @@ func (k Keeper) HistoricMedianDeviation(
 	store := ctx.KVStore(k.storeKey)
 	blockDiff := uint64(ctx.BlockHeight())%k.MedianStampPeriod(ctx) + 1
 	blockNum := uint64(ctx.BlockHeight()) - blockDiff
-	bz := store.Get(types.KeyMedianDeviation(denom, blockNum)) // SYGET
+	bz := store.Get(types.KeyMedianDeviation(denom, blockNum))
 	if bz == nil {
 		return &types.Price{}, types.ErrNoMedianDeviation.Wrap("denom: " + denom)
 	}
@@ -134,8 +134,8 @@ func (k Keeper) SetHistoricMedianDeviation(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: medianDeviation})
-	denom = strings.ToUpper(denom)                           // setters enforce uppercase symbol denom
-	store.Set(types.KeyMedianDeviation(denom, blockNum), bz) // SYSET
+	denom = strings.ToUpper(denom) // setters enforce uppercase symbol denom
+	store.Set(types.KeyMedianDeviation(denom, blockNum), bz)
 }
 
 // MedianOfHistoricMedians calculates and returns the median of the last stampNum
@@ -315,8 +315,8 @@ func (k Keeper) SetHistoricPrice(
 ) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: exchangeRate})
-	denom = strings.ToUpper(denom)                         // setters enforce uppercase symbol denom
-	store.Set(types.KeyHistoricPrice(denom, blockNum), bz) // SYSET
+	denom = strings.ToUpper(denom) // setters enforce uppercase symbol denom
+	store.Set(types.KeyHistoricPrice(denom, blockNum), bz)
 }
 
 // DeleteHistoricPrice deletes the historic price of a denom at a
@@ -327,7 +327,7 @@ func (k Keeper) DeleteHistoricPrice(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyHistoricPrice(denom, blockNum)) // SYSET
+	store.Delete(types.KeyHistoricPrice(denom, blockNum))
 }
 
 // DeleteHistoricMedian deletes a given denom's median price at a given block.
@@ -337,7 +337,7 @@ func (k Keeper) DeleteHistoricMedian(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyMedian(denom, blockNum)) // SYSET
+	store.Delete(types.KeyMedian(denom, blockNum))
 }
 
 // DeleteHistoricMedianDeviation deletes a given denom's standard deviation
@@ -348,7 +348,7 @@ func (k Keeper) DeleteHistoricMedianDeviation(
 	blockNum uint64,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.KeyMedianDeviation(denom, blockNum)) // SYSET
+	store.Delete(types.KeyMedianDeviation(denom, blockNum))
 }
 
 func (k Keeper) PruneHistoricPricesBeforeBlock(ctx sdk.Context, blockNum uint64) {

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -75,7 +75,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) GetExchangeRate(ctx sdk.Context, symbol string) (sdk.Dec, error) {
 	store := ctx.KVStore(k.storeKey)
 	symbol = strings.ToUpper(symbol)
-	b := store.Get(types.KeyExchangeRate(symbol))
+	b := store.Get(types.KeyExchangeRate(symbol)) // SYGET
 	if b == nil {
 		return sdk.ZeroDec(), types.ErrUnknownDenom.Wrap(symbol)
 	}
@@ -118,8 +118,8 @@ func (k Keeper) GetExchangeRateBase(ctx sdk.Context, denom string) (sdk.Dec, err
 func (k Keeper) SetExchangeRate(ctx sdk.Context, denom string, exchangeRate sdk.Dec) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: exchangeRate})
-	denom = strings.ToUpper(denom)
-	store.Set(types.KeyExchangeRate(denom), bz)
+	denom = strings.ToUpper(denom)              // setters enforce uppercase symbol denom
+	store.Set(types.KeyExchangeRate(denom), bz) // SYSET
 }
 
 // SetExchangeRateWithEvent sets an consensus

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -75,7 +75,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) GetExchangeRate(ctx sdk.Context, symbol string) (sdk.Dec, error) {
 	store := ctx.KVStore(k.storeKey)
 	symbol = strings.ToUpper(symbol)
-	b := store.Get(types.KeyExchangeRate(symbol)) // SYGET
+	b := store.Get(types.KeyExchangeRate(symbol))
 	if b == nil {
 		return sdk.ZeroDec(), types.ErrUnknownDenom.Wrap(symbol)
 	}
@@ -118,8 +118,8 @@ func (k Keeper) GetExchangeRateBase(ctx sdk.Context, denom string) (sdk.Dec, err
 func (k Keeper) SetExchangeRate(ctx sdk.Context, denom string, exchangeRate sdk.Dec) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&sdk.DecProto{Dec: exchangeRate})
-	denom = strings.ToUpper(denom)              // setters enforce uppercase symbol denom
-	store.Set(types.KeyExchangeRate(denom), bz) // SYSET
+	denom = strings.ToUpper(denom) // setters enforce uppercase symbol denom
+	store.Set(types.KeyExchangeRate(denom), bz)
 }
 
 // SetExchangeRateWithEvent sets an consensus

--- a/x/oracle/keeper/migrations.go
+++ b/x/oracle/keeper/migrations.go
@@ -32,3 +32,44 @@ func (m Migrator) HistoracleParams3x4(ctx sdk.Context) error {
 	m.keeper.SetMaximumMedianStamps(ctx, types.DefaultMaximumMedianStamps)
 	return nil
 }
+
+// Uppercase4_1 changes all symbol denoms in keeper keys and the accept list to uppercase
+func (m Migrator) Uppercase4_1(ctx sdk.Context) error {
+	m.keeper.IterateAllHistoricPrices(ctx,
+		func(price types.Price) bool {
+			// Delete at existing key
+			m.keeper.DeleteHistoricPrice(ctx, price.ExchangeRateTuple.Denom, price.BlockNum)
+			// Set at uppercase denom key (which may be the same)
+			m.keeper.SetHistoricPrice(ctx,
+				price.ExchangeRateTuple.Denom, price.BlockNum, price.ExchangeRateTuple.ExchangeRate)
+			return false
+		},
+	)
+	m.keeper.IterateAllMedianPrices(ctx,
+		func(price types.Price) bool {
+			// Delete at existing key
+			m.keeper.DeleteHistoricMedian(ctx, price.ExchangeRateTuple.Denom, price.BlockNum)
+			// Set at uppercase denom key (which may be the same)
+			m.keeper.SetHistoricMedian(ctx,
+				price.ExchangeRateTuple.Denom, price.BlockNum, price.ExchangeRateTuple.ExchangeRate)
+			return false
+		},
+	)
+	m.keeper.IterateAllMedianDeviationPrices(ctx,
+		func(price types.Price) bool {
+			// Delete at existing key
+			m.keeper.DeleteHistoricMedianDeviation(ctx, price.ExchangeRateTuple.Denom, price.BlockNum)
+			// Set at uppercase denom key (which may be the same)
+			m.keeper.SetHistoricMedianDeviation(ctx,
+				price.ExchangeRateTuple.Denom, price.BlockNum, price.ExchangeRateTuple.ExchangeRate)
+			return false
+		},
+	)
+	// Gets the existing accept list, but setter enforces uppercase symbol denoms
+	m.keeper.SetAcceptList(ctx, m.keeper.AcceptList(ctx))
+	// Note: denoms for exchange rates were already forced to uppercase, so no migration is needed
+	//
+	// TODO: iterate over AvgKeeper
+	//
+	return nil
+}

--- a/x/oracle/keeper/params.go
+++ b/x/oracle/keeper/params.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -49,6 +50,10 @@ func (k Keeper) AcceptList(ctx sdk.Context) (res types.DenomList) {
 // SetAcceptList updates the accepted list of assets supported by the x/oracle
 // module.
 func (k Keeper) SetAcceptList(ctx sdk.Context, acceptList types.DenomList) {
+	for i, t := range acceptList {
+		// setters enforce uppercase symbol denom
+		acceptList[i].SymbolDenom = strings.ToUpper(t.SymbolDenom)
+	}
 	k.paramSpace.Set(ctx, types.KeyAcceptList, acceptList)
 }
 
@@ -130,5 +135,9 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 
 // SetParams sets the total set of oracle parameters.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+	for i, t := range params.AcceptList {
+		// setters enforce uppercase symbol denom
+		params.AcceptList[i].SymbolDenom = strings.ToUpper(t.SymbolDenom)
+	}
 	k.paramSpace.SetParamSet(ctx, &params)
 }

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -8,14 +8,6 @@ import (
 	"github.com/umee-network/umee/v4/util"
 )
 
-// NOTES:
-// - Average counter
-// - Historic median
-// - Historic median deviation
-// - Historic price
-// - Exchange rate (no migration required)
-// - Accept list
-
 const (
 	// ModuleName is the name of the oracle module
 	ModuleName = "oracle"

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -8,6 +8,14 @@ import (
 	"github.com/umee-network/umee/v4/util"
 )
 
+// NOTES:
+// - Average counter
+// - Historic median
+// - Historic median deviation
+// - Historic price
+// - Exchange rate (no migration required)
+// - Accept list
+
 const (
 	// ModuleName is the name of the oracle module
 	ModuleName = "oracle"
@@ -77,7 +85,7 @@ func KeyHistoricPrice(denom string, blockNum uint64) (key []byte) {
 	return util.ConcatBytes(0, KeyPrefixHistoricPrice, []byte(denom), util.UintWithNullPrefix(blockNum))
 }
 
-// KeyHistoricPrice - stored by *denom* and *block*
+// KeyAvgCounter - stored by *denom* and *block*
 func KeyAvgCounter(denom string, counterID byte) (key []byte) {
 	return util.ConcatBytes(0, KeyPrefixAvgCounter, []byte(denom), []byte{counterID})
 }


### PR DESCRIPTION
This needs discussion to see if it's reasonable.

Adds a migration to turn all symbol denoms currently stored in the oracle keeper (generally as keys, but sometimes as values) into uppercase. Proceeds to enforce that rule in all `Set` functions.