### PR TITLE
chore: simplify upgrades

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -33,8 +33,8 @@ func (app UmeeApp) RegisterUpgradeHandlers(bool) {
 	app.registerUpgrade3_1to3_3(upgradeInfo)
 	app.registerUpgrade3_2to3_3(upgradeInfo)
 	app.registerUpgrade3_3to4_0(upgradeInfo)
-	app.registerUpgrade4_1(upgradeInfo)
 	app.registerUpgrade4_0_1(upgradeInfo)
+	app.registerUpgrade4_1(upgradeInfo)
 }
 
 // performs upgrade from v4.0 to v4.1
@@ -54,10 +54,7 @@ func (app *UmeeApp) registerUpgrade4_0_1(_ upgradetypes.Plan) {
 	const planName = "v4.0.1"
 	app.UpgradeKeeper.SetUpgradeHandler(
 		planName,
-		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			ctx.Logger().Info("Upgrade handler execution", "name", planName)
-			return fromVM, nil
-		})
+		onlyModuleMigrations(app, planName))
 }
 
 // performs upgrade from v3.3 -> v4


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
reuse `onlyModuleMigrations` in upgrade handler.