### PR TITLE
fix: skip BNB migration instead of error if no BNB denom present

### DIFF
--- a/x/leverage/keeper/migrations.go
+++ b/x/leverage/keeper/migrations.go
@@ -29,7 +29,7 @@ func (m Migrator) MigrateBNB(ctx sdk.Context) (bool, error) {
 	}
 	token, err := m.keeper.GetTokenSettings(ctx, badDenom)
 	if err != nil {
-		ctx.Logger().Info("leverage migration skipped due to missing token", "err", err.Error())
+		ctx.Logger().Error("leverage migration skipped due to missing token", "err", err.Error())
 		// If it's not a registered token, then we don't need to run this migration
 		return false, nil
 	}

--- a/x/leverage/keeper/migrations.go
+++ b/x/leverage/keeper/migrations.go
@@ -29,7 +29,9 @@ func (m Migrator) MigrateBNB(ctx sdk.Context) (bool, error) {
 	}
 	token, err := m.keeper.GetTokenSettings(ctx, badDenom)
 	if err != nil {
-		return false, err
+		ctx.Logger().Info("leverage migration skipped due to missing token", "err", err.Error())
+		// If it's not a registered token, then we don't need to run this migration
+		return false, nil
 	}
 	// Delete previous entry in token registry
 	store := ctx.KVStore(m.keeper.storeKey)


### PR DESCRIPTION
If the BNB denom is not present in the leverage registry, skips the BNB migration instead of causing an error.

This shouldn't affect mainnet or `canon-2`, but is good form in case we ever run this migration on a different testnet.