### PR TITLE
chore(CI): set merge groups

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,16 +1,12 @@
 name: "CodeQL"
 
 on:
+  merge_group:
   pull_request:
     paths: ["**.go"]
     branches:
       - main
       - release/**
-  push:
-    branches:
-      - main
-      - release/**
-    paths: ["**.go"]
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -2,11 +2,6 @@ name: Check Markdown links
 on:
   pull_request:
     paths: ["**.md"]
-  push:
-    branches:
-      - main
-      - release/**
-    paths: ["**.md"]
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,5 +1,6 @@
 name: Lint-Title
 on:
+  merge_group:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,7 @@
 name: Lint
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - release/**
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -1,10 +1,7 @@
 name: Simulations
 on:
+  merge_group:
   pull_request:
-  push:
-    branches:
-      - main
-      - release/**
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -207,7 +208,7 @@ jobs:
         if: env.GIT_DIFF
         run: |
           EXPERIMENTAL=true make test-unit
-  
+
   experimental-test-e2e:
     runs-on: ubuntu-latest
     needs: install-tparse


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

+ sets `merge-groups` targets in the workflows, to enable merge-group trigger to pass the required jobs
+ removes some push targes, which waist unnecessary CI cycles on merges to main. We don't need them, because we have all that checks on PR, and direct pushing to `main` is blocked anyway.
