### PR TITLE
chore: update upgrades structure

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -35,13 +35,12 @@ func (app UmeeApp) RegisterUpgradeHandlers(bool) {
 	app.registerUpgrade3_3to4_0(upgradeInfo)
 	app.registerUpgrade4_0_1(upgradeInfo)
 	app.registerUpgrade4_1(upgradeInfo)
-	app.registerUpgrade4_1_0rc3(upgradeInfo)
 	app.registerUpgrade4_2(upgradeInfo)
 }
 
 // performs upgrade from v4.1 to v4.2
 func (app *UmeeApp) registerUpgrade4_2(upgradeInfo upgradetypes.Plan) {
-	const planName = "v4.2"
+	const planName = "v4.2-beta1"
 	app.UpgradeKeeper.SetUpgradeHandler(planName, onlyModuleMigrations(app, planName))
 
 	app.storeUpgrade(planName, upgradeInfo, storetypes.StoreUpgrades{
@@ -49,12 +48,6 @@ func (app *UmeeApp) registerUpgrade4_2(upgradeInfo upgradetypes.Plan) {
 			uibc.ModuleName,
 		},
 	})
-}
-
-// performs upgrade from v4.1.0-rc2 to v4.1.0-rc3
-func (app *UmeeApp) registerUpgrade4_1_0rc3(_ upgradetypes.Plan) {
-	const planName = "v4.1.0-rc3"
-	app.UpgradeKeeper.SetUpgradeHandler(planName, onlyModuleMigrations(app, planName))
 }
 
 // performs upgrade from v4.0 to v4.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Proposal

In last two upgrades we had / have a sequence of rc releases, each of which is a breaking change, and require new upgrade handler. This is not relevant to the mainnet. Instead I propose:
1. Use `betaX` rather than `rcX`.
1. keep single handler and rename until we have successful, stable RC