### PR TITLE
feat: add oracle telemetry

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -440,6 +440,7 @@ func New(
 		app.DistrKeeper,
 		app.StakingKeeper,
 		distrtypes.ModuleName,
+		cast.ToBool(appOpts.Get("telemetry.enabled")),
 	)
 	app.LeverageKeeper = leveragekeeper.NewKeeper(
 		appCodec,

--- a/tests/grpc/client/tx/key.go
+++ b/tests/grpc/client/tx/key.go
@@ -17,7 +17,7 @@ func CreateAccountFromMnemonic(name, mnemonic string) (*keyring.Record, keyring.
 	encodingConfig := umeeapp.MakeEncodingConfig()
 	cdc := encodingConfig.Codec
 
-	kb, err := keyring.New(keyringAppName, keyring.BackendTest, "", nil, cdc)
+	kb, err := keyring.New(keyringAppName, keyring.BackendMemory, "", nil, cdc)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -29,6 +29,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	}
 
 	k.PruneAllPrices(ctx)
+	go k.RecordEndBlockMetrics(ctx)
 
 	return nil
 }

--- a/x/oracle/keeper/end_blocker.go
+++ b/x/oracle/keeper/end_blocker.go
@@ -33,6 +33,10 @@ func (k *Keeper) IsPeriodLastBlock(ctx sdk.Context, blocksPerPeriod uint64) bool
 }
 
 func (k *Keeper) RecordEndBlockMetrics(ctx sdk.Context) {
+	if !k.telemetryEnabled {
+		return
+	}
+
 	k.IterateMissCounters(ctx, func(operator sdk.ValAddress, missCounter uint64) bool {
 		metrics.SetGaugeWithLabels(
 			[]string{"miss_counter"},

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -30,7 +30,8 @@ type Keeper struct {
 	distrKeeper   types.DistributionKeeper
 	StakingKeeper types.StakingKeeper
 
-	distrName string
+	distrName        string
+	telemetryEnabled bool
 }
 
 // NewKeeper constructs a new keeper for oracle
@@ -43,6 +44,7 @@ func NewKeeper(
 	distrKeeper types.DistributionKeeper,
 	stakingKeeper types.StakingKeeper,
 	distrName string,
+	telemetryEnabled bool,
 ) Keeper {
 	// ensure oracle module account is set
 	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
@@ -55,14 +57,15 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:           cdc,
-		storeKey:      storeKey,
-		paramSpace:    paramspace,
-		accountKeeper: accountKeeper,
-		bankKeeper:    bankKeeper,
-		distrKeeper:   distrKeeper,
-		StakingKeeper: stakingKeeper,
-		distrName:     distrName,
+		cdc:              cdc,
+		storeKey:         storeKey,
+		paramSpace:       paramspace,
+		accountKeeper:    accountKeeper,
+		bankKeeper:       bankKeeper,
+		distrKeeper:      distrKeeper,
+		StakingKeeper:    stakingKeeper,
+		distrName:        distrName,
+		telemetryEnabled: telemetryEnabled,
 	}
 }
 

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -126,6 +127,13 @@ func (k Keeper) SetExchangeRate(ctx sdk.Context, denom string, exchangeRate sdk.
 // exchange rate to the store with ABCI event
 func (k Keeper) SetExchangeRateWithEvent(ctx sdk.Context, denom string, exchangeRate sdk.Dec) {
 	k.SetExchangeRate(ctx, denom, exchangeRate)
+
+	go metrics.SetGaugeWithLabels(
+		[]string{"exchange_rate"},
+		float32(exchangeRate.MustFloat64()),
+		[]metrics.Label{{Name: "denom", Value: denom}},
+	)
+
 	sdkutil.Emit(&ctx, &types.EventSetFxRate{
 		Denom: denom, Rate: exchangeRate,
 	})

--- a/x/oracle/types/price.go
+++ b/x/oracle/types/price.go
@@ -59,3 +59,13 @@ func (p *Prices) Sort() *Prices {
 	)
 	return &prices
 }
+
+func (p *Prices) NewestBlockNum() uint64 {
+	blockNum := uint64(0)
+	for _, price := range *p {
+		if price.BlockNum > blockNum {
+			blockNum = price.BlockNum
+		}
+	}
+	return blockNum
+}


### PR DESCRIPTION
- Add metric gauge recording of miss_counters, medians, and median deviations at the end of each end_blocker run.
- Add metric gauge recording of exchange_rates each time they are set
- Check for Telemetry.Enabled app.toml setting before recording any end_block metrics

Since voting period are shorter than 60 seconds we can record each exchange_rate as it is saved to the KVStore. For the miss counters, median, and median deviation metrics they would be pruned before new ones are recorded so they need to be recorded each block.