### PR TITLE
chore: Add WAXL, DOT, and MATIC to example config

### DIFF
--- a/price-feeder/price-feeder.example.toml
+++ b/price-feeder/price-feeder.example.toml
@@ -62,6 +62,18 @@ threshold = "2"
 base = "IST"
 threshold = "2"
 
+[[deviation_thresholds]]
+base = "WAXL"
+threshold = "1.5"
+
+[[deviation_thresholds]]
+base = "MATIC"
+threshold = "1.5"
+
+[[deviation_thresholds]]
+base = "DOT"
+threshold = "1.5"
+
 [[currency_pairs]]
 base = "UMEE"
 providers = [
@@ -211,6 +223,56 @@ providers = [
   "osmosisv2",
 ]
 quote = "OSMO"
+
+[[currency_pairs]]
+base = "WAXL"
+providers = [
+  "kraken",
+]
+quote = "USD"
+
+[[currency_pairs]]
+base = "WAXL"
+providers = [
+  "huobi",
+  "bitget",
+  "gate",
+]
+quote = "USDT"
+
+[[currency_pairs]]
+base = "DOT"
+providers = [
+  "kraken",
+  "coinbase",
+  "crypto",
+]
+quote = "USD"
+
+[[currency_pairs]]
+base = "DOT"
+providers = [
+  "gate",
+  "bitget",
+]
+quote = "USDT"
+
+[[currency_pairs]]
+base = "MATIC"
+providers = [
+  "coinbase",
+  "kraken",
+]
+quote = "USD"
+
+[[currency_pairs]]
+base = "MATIC"
+providers = [
+  "gate",
+  "mexc",
+  "bitget",
+]
+quote = "USDT"
 
 [account]
 address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"

--- a/price-feeder/tests/integration/provider_test.go
+++ b/price-feeder/tests/integration/provider_test.go
@@ -43,6 +43,23 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 	for key, pairs := range cfg.ProviderPairs() {
 		providerName := key
 		currencyPairs := pairs
+
+		// Filter by provider
+		// if providerName != provider.ProviderBitget {
+		// 	continue
+		// }
+
+		// Filter by currency pair
+		// currencyPairs = []types.CurrencyPair{}
+		// for _, pair := range pairs {
+		// 	if pair.Base == "MATIC" {
+		// 		currencyPairs = append(currencyPairs, pair)
+		// 	}
+		// }
+		// if len(currencyPairs) == 0 {
+		// 	continue
+		// }
+
 		endpoint := endpoints[providerName]
 		s.T().Run(string(providerName), func(t *testing.T) {
 			t.Parallel()

--- a/price-feeder/tests/integration/provider_test.go
+++ b/price-feeder/tests/integration/provider_test.go
@@ -43,7 +43,6 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 	for key, pairs := range cfg.ProviderPairs() {
 		providerName := key
 		currencyPairs := pairs
-
 		endpoint := endpoints[providerName]
 		s.T().Run(string(providerName), func(t *testing.T) {
 			t.Parallel()

--- a/price-feeder/tests/integration/provider_test.go
+++ b/price-feeder/tests/integration/provider_test.go
@@ -44,22 +44,6 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 		providerName := key
 		currencyPairs := pairs
 
-		// Filter by provider
-		// if providerName != provider.ProviderBitget {
-		// 	continue
-		// }
-
-		// Filter by currency pair
-		// currencyPairs = []types.CurrencyPair{}
-		// for _, pair := range pairs {
-		// 	if pair.Base == "MATIC" {
-		// 		currencyPairs = append(currencyPairs, pair)
-		// 	}
-		// }
-		// if len(currencyPairs) == 0 {
-		// 	continue
-		// }
-
 		endpoint := endpoints[providerName]
 		s.T().Run(string(providerName), func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
- Add WAXL, DOT, and MATIC to example config

--- PASS: TestServiceTestSuite (120.00s)
    --- PASS: TestServiceTestSuite/TestWebsocketProviders (0.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/huobi (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/osmosisv2 (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/mexc (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/kraken (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/okx (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/crypto (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/gate (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/coinbase (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/binanceus (60.00s)
        --- PASS: TestServiceTestSuite/TestWebsocketProviders/bitget (60.00s)
PASS
ok      github.com/umee-network/umee/price-feeder/v2/tests/integration  120.065s