### PR TITLE
fix: codecov file types

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -46,6 +46,7 @@ ignore:
   - "**/*.json"
   - "**/*.toml"
   - "**/*.rst"
+  - "**/*.md"
 # auto-generated files
   - "**/*.pb.go"
   - "**/*.pb.gw.go"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -40,14 +40,18 @@ flags:
       - "x/**/client/"
 
 ignore:
-  - "docs"
-  - "*.md"
-  - "*.rst"
+# ignore all files of these types
+  - "**/*.proto"
+  - "**/*.yml"
+  - "**/*.json"
+  - "**/*.toml"
+  - "**/*.rst"
+# auto-generated files
   - "**/*.pb.go"
-  - "types/*.pb.go"
-  - "tests/*"
-  - "tests/**/*"
-  - "x/**/*.pb.go"
-  - "x/**/test_common.go"
-  - "scripts/"
+  - "**/*.pb.gw.go"
+# ignore these folders and all their contents
+  - "docs"
+  - "tests"
+  - "scripts"
   - "contrib"
+  - "swagger"

--- a/x/incentive/keys.go
+++ b/x/incentive/keys.go
@@ -20,9 +20,11 @@ type (
 )
 
 const (
-	BondTierLong BondTier = iota
-	BondTierMiddle
+	// BondTierUnspecified is used in functions which query unbondings, to indicate that all tiers should be counted
+	BondTierUnspecified BondTier = iota
 	BondTierShort
+	BondTierMiddle
+	BondTierLong
 )
 
 const (
@@ -30,3 +32,17 @@ const (
 	ProgramStatusOngoing
 	ProgramStatusCompleted
 )
+
+func (p ProgramStatus) Validate() error {
+	if p > ProgramStatusCompleted {
+		return ErrInvalidProgramStatus.Wrapf("%d", p)
+	}
+	return nil
+}
+
+func (t BondTier) Validate(canBeUnspecified bool) error {
+	if t > BondTierLong || (!canBeUnspecified && t == BondTierUnspecified) {
+		return ErrInvalidTier.Wrapf("%d", t)
+	}
+	return nil
+}

--- a/x/incentive/keys_test.go
+++ b/x/incentive/keys_test.go
@@ -1,0 +1,54 @@
+package incentive
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateTier(t *testing.T) {
+	cases := []struct {
+		desc             string
+		tier             BondTier
+		canBeUnspecified bool
+		expectError      error
+	}{
+		{"valid unspecified tier", 0, true, nil},
+		{"invalid unspecified tier", 0, false, ErrInvalidTier},
+		{"short tier", BondTierShort, false, nil},
+		{"middle tier", BondTierMiddle, false, nil},
+		{"long tier", BondTierLong, false, nil},
+		{"invalid tier", BondTierLong + 1, false, ErrInvalidTier},
+	}
+
+	for _, c := range cases {
+		err := c.tier.Validate(c.canBeUnspecified)
+		if c.expectError == nil {
+			assert.NilError(t, err, c.desc)
+		} else {
+			assert.ErrorContains(t, err, c.expectError.Error(), c.desc)
+		}
+	}
+}
+
+func TestValidateProgramStatus(t *testing.T) {
+	cases := []struct {
+		desc        string
+		status      ProgramStatus
+		expectError error
+	}{
+		{"upcoming status", ProgramStatusUpcoming, nil},
+		{"ongoing status", ProgramStatusOngoing, nil},
+		{"completed status", ProgramStatusCompleted, nil},
+		{"invalid status", ProgramStatusCompleted + 1, ErrInvalidProgramStatus},
+	}
+
+	for _, c := range cases {
+		err := c.status.Validate()
+		if c.expectError == nil {
+			assert.NilError(t, err, c.desc)
+		} else {
+			assert.ErrorContains(t, err, c.expectError.Error(), c.desc)
+		}
+	}
+}

--- a/x/incentive/params_test.go
+++ b/x/incentive/params_test.go
@@ -6,7 +6,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestParams(t *testing.T) {
+func TestDefaultParams(t *testing.T) {
 	params := DefaultParams()
 	err := params.Validate()
 	assert.NilError(t, err)

--- a/x/incentive/params_test.go
+++ b/x/incentive/params_test.go
@@ -1,0 +1,13 @@
+package incentive
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParams(t *testing.T) {
+	params := DefaultParams()
+	err := params.Validate()
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
We were including `pb.gw.go` files in our coverage.

Note that I had to add some code changes to trigger the coverage report, so I grabbed some trivial ones with tests from an incentive module PR.