### PR TITLE
chore: set codecov targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,13 +10,14 @@ coverage:
         target: 65.5%
         threshold: 2% # allow this much decrease on project
         if_ci_failed: error
+        if_not_found: success # if tests are not run
       modules:
         target: 62%
         paths:
           - "x/"
           - "!x/**/client/" # ignore client package
       client:
-        target: 80%
+        target: 96%
         paths:
           - client
           - "x/**/client/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,27 +1,22 @@
 coverage:
   precision: 2
   round: down
-  range: 70...100
+  range: 60...100
 
   status:
     # Learn more at https://docs.codecov.io/docs/commit-status
     project:
       default:
-        target: auto
-        threshold: 2% # # allow this much decrease on project
+        target: 65.5%
+        threshold: 2% # allow this much decrease on project
         if_ci_failed: error
-        if_not_found: success
-      app:
-        target: 70%
-        paths:
-          - "app/"
       modules:
-        target: 70%
+        target: 62%
         paths:
           - "x/"
           - "!x/**/client/" # ignore client package
       client:
-        target: 70%
+        target: 80%
         paths:
           - client
           - "x/**/client/"
@@ -32,17 +27,17 @@ comment:
   require_changes: true
 
 ignore:
-# ignore all files of these types
+  # ignore all files of these types
   - "**/*.proto"
   - "**/*.yml"
   - "**/*.json"
   - "**/*.toml"
   - "**/*.rst"
   - "**/*.md"
-# auto-generated files
+  # auto-generated files
   - "**/*.pb.go"
   - "**/*.pb.gw.go"
-# ignore these folders and all their contents
+  # ignore these folders and all their contents
   - "docs"
   - "tests"
   - "scripts"

--- a/util/bytes.go
+++ b/util/bytes.go
@@ -20,6 +20,8 @@ func ConcatBytes(margin int, bzs ...[]byte) []byte {
 	return out
 }
 
+// UintWithNullPrefix efficiently serializes uint using LittleEndian and
+// prepends zero byte (null prefix).
 func UintWithNullPrefix(n uint64) []byte {
 	bz := make([]byte, 9)
 	binary.LittleEndian.PutUint64(bz[1:], n)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

* removed `app` as a separate target - we can keep it in `project`
* still we need to verify if the client metric is correct there... sounds off that we currently meeting 99% there.