### PR TITLE
tests(levelrage)!; liquidation_threshold must be bigger than collater…

### DIFF
--- a/proto/umee/leverage/v1/leverage.proto
+++ b/proto/umee/leverage/v1/leverage.proto
@@ -97,6 +97,7 @@ message Token {
   // Collateral Weight defines what portion of the total value of the asset
   // can contribute to a users borrowing power. If the collateral weight is
   // zero, using this asset as collateral against borrowing will be disabled.
+  // Must be smaller than `liquidation_threshold`.
   // Valid values: 0-1.
   string collateral_weight = 3 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
@@ -107,8 +108,9 @@ message Token {
   // Liquidation Threshold defines what amount of the total value of the
   // asset as a collateral can contribute to a user's liquidation threshold
   // (above which they become eligible for liquidation).
-  // See also: min_close_factor.
+  // Must be bigger than `collateral_weight`.
   // Valid values: 0-1.
+  // See also: min_close_factor.
   string liquidation_threshold = 4 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable)   = false,

--- a/x/leverage/types/token.go
+++ b/x/leverage/types/token.go
@@ -73,23 +73,24 @@ func (t Token) Validate() error {
 		return ErrUToken.Wrap(t.SymbolDenom)
 	}
 
+	one := sdk.OneDec()
+
 	// Reserve factor is non-negative and less than 1.
-	if t.ReserveFactor.IsNegative() || t.ReserveFactor.GTE(sdk.OneDec()) {
+	if t.ReserveFactor.IsNegative() || t.ReserveFactor.GTE(one) {
 		return fmt.Errorf("invalid reserve factor: %s", t.ReserveFactor)
 	}
 	// Collateral weight is non-negative and less than 1.
-	if t.CollateralWeight.IsNegative() || t.CollateralWeight.GTE(sdk.OneDec()) {
+	if t.CollateralWeight.IsNegative() || t.CollateralWeight.GTE(one) {
 		return fmt.Errorf("invalid collateral rate: %s", t.CollateralWeight)
 	}
-	// Liquidation threshold is at least collateral weight, but less than 1.
-	if t.LiquidationThreshold.LT(t.CollateralWeight) || t.LiquidationThreshold.GTE(sdk.OneDec()) {
-		return fmt.Errorf("invalid liquidation threshold: %s", t.LiquidationThreshold)
+	if !t.LiquidationThreshold.GT(t.CollateralWeight) || t.LiquidationThreshold.GTE(one) {
+		return fmt.Errorf("liquidation threshold must be bigger than collateral weight, got: %s", t.LiquidationThreshold)
 	}
 
 	// Kink utilization rate ranges between 0 and 1, exclusive. This prevents
 	// multiple interest rates being defined at exactly 0% or 100% utilization
 	// e.g. kink at 0%, 2% base borrow rate, 4% borrow rate at kink.
-	if !t.KinkUtilization.IsPositive() || t.KinkUtilization.GTE(sdk.OneDec()) {
+	if !t.KinkUtilization.IsPositive() || t.KinkUtilization.GTE(one) {
 		return fmt.Errorf("invalid kink utilization rate: %s", t.KinkUtilization)
 	}
 
@@ -119,15 +120,15 @@ func (t Token) Validate() error {
 		}
 	}
 
-	if t.MaxCollateralShare.IsNegative() || t.MaxCollateralShare.GT(sdk.OneDec()) {
+	if t.MaxCollateralShare.IsNegative() || t.MaxCollateralShare.GT(one) {
 		return sdkerrors.ErrInvalidRequest.Wrap("Token.MaxCollateralShare must be between 0 and 1")
 	}
 
-	if t.MaxSupplyUtilization.IsNegative() || t.MaxSupplyUtilization.GT(sdk.OneDec()) {
+	if t.MaxSupplyUtilization.IsNegative() || t.MaxSupplyUtilization.GT(one) {
 		return sdkerrors.ErrInvalidRequest.Wrap("Token.MaxSupplyUtilization must be between 0 and 1")
 	}
 
-	if t.MinCollateralLiquidity.IsNegative() || t.MinCollateralLiquidity.GT(sdk.OneDec()) {
+	if t.MinCollateralLiquidity.IsNegative() || t.MinCollateralLiquidity.GT(one) {
 		return sdkerrors.ErrInvalidRequest.Wrap("Token.MinCollateralLiquidity be between 0 and 1")
 	}
 

--- a/x/leverage/types/token_test.go
+++ b/x/leverage/types/token_test.go
@@ -46,7 +46,7 @@ func validToken() types.Token {
 		Exponent:               6,
 		ReserveFactor:          sdk.MustNewDecFromStr("0.25"),
 		CollateralWeight:       sdk.MustNewDecFromStr("0.5"),
-		LiquidationThreshold:   sdk.MustNewDecFromStr("0.5"),
+		LiquidationThreshold:   sdk.MustNewDecFromStr("0.51"),
 		BaseBorrowRate:         sdk.MustNewDecFromStr("0.01"),
 		KinkBorrowRate:         sdk.MustNewDecFromStr("0.05"),
 		MaxBorrowRate:          sdk.MustNewDecFromStr("1"),
@@ -79,7 +79,7 @@ addtokens:
     - base_denom: uumee
       reserve_factor: "40.000000000000000000"
       collateral_weight: "0.500000000000000000"
-      liquidation_threshold: "0.500000000000000000"
+      liquidation_threshold: "0.510000000000000000"
       base_borrow_rate: "0.010000000000000000"
       kink_borrow_rate: "0.050000000000000000"
       max_borrow_rate: "1.000000000000000000"
@@ -113,10 +113,16 @@ func TestToken_Validate(t *testing.T) {
 	invalidReserveFactor.ReserveFactor = sdk.MustNewDecFromStr("-0.25")
 
 	invalidCollateralWeight := validToken()
-	invalidCollateralWeight.CollateralWeight = sdk.MustNewDecFromStr("50.00")
+	invalidCollateralWeight.CollateralWeight = sdk.MustNewDecFromStr("1.1")
+
+	invalidCollateralWeight2 := validToken()
+	invalidCollateralWeight2.CollateralWeight = sdk.OneDec()
 
 	invalidLiquidationThreshold := validToken()
-	invalidLiquidationThreshold.LiquidationThreshold = sdk.MustNewDecFromStr("0.40")
+	invalidLiquidationThreshold.LiquidationThreshold = invalidLiquidationThreshold.CollateralWeight
+
+	invalidLiquidationThreshold2 := validToken()
+	invalidLiquidationThreshold2.LiquidationThreshold = sdk.OneDec()
 
 	invalidBaseBorrowRate := validToken()
 	invalidBaseBorrowRate.BaseBorrowRate = sdk.MustNewDecFromStr("-0.01")
@@ -179,8 +185,16 @@ func TestToken_Validate(t *testing.T) {
 			input:     invalidCollateralWeight,
 			expectErr: true,
 		},
+		"invalid collateral weight2": {
+			input:     invalidCollateralWeight2,
+			expectErr: true,
+		},
 		"invalid liquidation threshold": {
 			input:     invalidLiquidationThreshold,
+			expectErr: true,
+		},
+		"invalid liquidation threshold2": {
+			input:     invalidLiquidationThreshold2,
 			expectErr: true,
 		},
 		"invalid base borrow rate": {


### PR DESCRIPTION
…al_weight

<!-- markdownlint-disable MD041 -->

## Description

We must not accept `liquidation_threshold == collateral_weight` because that will trigger immediate liquidation.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
