### PR TITLE
perf: linter merge queue workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "CodeQL"
 
 on:
   merge_group:
+    types: [checks_requested]
   pull_request:
     paths: ["**.go"]
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,10 +38,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          # Full git history is needed to get a proper list of changed files
-          # within `super-linter`.
-          fetch-depth: 0
       - name: Run super-linter
         uses: github/super-linter@v4
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
-          VALIDATE_GO: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 on:
   pull_request:
   merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
@@ -46,6 +47,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
+          VALIDATE_GO: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint
 on:
-  pull_request:
   merge_group:
     types: [checks_requested]
+  pull_request:
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -1,6 +1,7 @@
 name: Simulations
 on:
   merge_group:
+    types: [checks_requested]
   pull_request:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 on:
   pull_request:
   merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+
+
 ### Features
 
 - [1888](https://github.com/umee-network/umee/pull/1888) Created `/sdkclient` and `/client` (umee client) packages to easy the E2E tests and external tools. Essentially, you can import that client and broadcast transactions easily.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-#### [Unreleased]
-
-**check**
-
-something
+## [Unreleased]
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+
 ### Features
 
 - [1888](https://github.com/umee-network/umee/pull/1888) Created `/sdkclient` and `/client` (umee client) packages to easy the E2E tests and external tools. Essentially, you can import that client and broadcast transactions easily.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [Unreleased]
+#### [Unreleased]
 
+**check**
 
+something
 
 ### Features
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

trying to optimize the merge queue. I found that Super linter checks are performed by the merge queue, while other checks are correctly cashed and not executed. 

