### PR TITLE
chore: speedup e2e by removing docker cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,15 +110,6 @@ jobs:
           go-version: "1.20"
           cache: true
 
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - name: cache docker layer
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        if: env.GIT_DIFF
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       - name: Test E2E
         if: env.GIT_DIFF
         run: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

cache is not reused in other actions, and adding it increases the setup time.