### PR TITLE
chore: v5.1 release notes (#2131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v5.1.0-rc1](https://github.com/umee-network/umee/releases/tag/v5.0.0-rc1) - 2023-06-30
+## [v5.1.0](https://github.com/umee-network/umee/releases/tag/v5.1.0) - 2023-07-07
+
+### Bug Fixes
+
+- [2125](https://github.com/umee-network/umee/pull/2125) Fix v5.1 upgrade handler.
+
+## [v5.1.0-rc1](https://github.com/umee-network/umee/releases/tag/v5.1.0-rc1) - 2023-06-30
 
 ### Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,13 +15,13 @@ Highlights:
 - new x/leverage [`MsgLeveragedLiquidate`](proto/umee/leverage/v1/tx.proto#L59) was added. Allows suppliers to use their active collateral to absorb unhealthy debts. See [Liquidation](x/leverage/README.md#liquidation) for more details.
 - Gravity Bridge phase-4: the GB valset was correctly burned. Slashing is removed and there is no need to run Peggo any more.
 
-[v5.1.0-rc1 CHANGELOG](https://github.com/umee-network/umee/blob/v5.1.0-rc1/CHANGELOG.md).
+[v5.1.0 CHANGELOG](https://github.com/umee-network/umee/blob/v5.1.0/CHANGELOG.md).
 
 ### Validators
 
 #### Peggo
 
-You can kill Peggo.
+You can kill Peggo (there is no need to run it any more).
 
 #### Min Gas Prices
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

mergify doesn't work with release -> main: https://github.com/umee-network/umee/pull/2132
Reason: main requires signed commits. 
so doing it manually