### PR TITLE
fix: minor 5.2 message fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+- [21XX](https://github.com/umee-network/umee/pull/21XX) Fix MsgBeginUnbonding counting existing unbondings against max unbond twice.
+- [21XX](https://github.com/umee-network/umee/pull/21XX) Fix MsgLeverageLiquidate CLI not actually allowing wildcard denoms.
+
 ### Features
 
 - [2129](https://github.com/umee-network/umee/pull/2129) Emergency Group x/ugov proto.

--- a/x/incentive/keeper/msg_server.go
+++ b/x/incentive/keeper/msg_server.go
@@ -91,7 +91,7 @@ func (s msgServer) BeginUnbonding(
 	}
 
 	// get current account state for the requested uToken denom only
-	bonded, currentUnbonding, unbondings := k.BondSummary(ctx, addr, denom)
+	bonded, _, unbondings := k.BondSummary(ctx, addr, denom)
 
 	maxUnbondings := int(k.GetParams(ctx).MaxUnbondings)
 	if maxUnbondings > 0 && len(unbondings) >= maxUnbondings {
@@ -100,11 +100,10 @@ func (s msgServer) BeginUnbonding(
 	}
 
 	// reject unbondings greater than maximum available amount
-	if currentUnbonding.Add(msg.UToken).Amount.GT(bonded.Amount) {
+	if msg.UToken.Amount.GT(bonded.Amount) {
 		return nil, incentive.ErrInsufficientBonded.Wrapf(
-			"bonded: %s, unbonding: %s, requested: %s",
+			"bonded: %s, requested: %s",
 			bonded,
-			currentUnbonding,
 			msg.UToken,
 		)
 	}

--- a/x/incentive/keeper/scenario_test.go
+++ b/x/incentive/keeper/scenario_test.go
@@ -325,7 +325,7 @@ func TestZeroBondedAtProgramEnd(t *testing.T) {
 	require.Equal(k.t, aliceReward, rewards, "alice claimed rewards at time 175")
 
 	// fully unbond user at 75%, making her ineligible future rewards unless she bonds again
-	k.mustUnbond(alice, coin.New(uUmee, 100_000000))
+	k.mustBeginUnbond(alice, coin.New(uUmee, 50_000000))
 
 	// complete the program
 	k.advanceTimeTo(programStart + 110) // a bit past 100% duration

--- a/x/leverage/types/tx.go
+++ b/x/leverage/types/tx.go
@@ -269,13 +269,23 @@ func (msg MsgLeveragedLiquidate) Route() string { return sdk.MsgTypeURL(&msg) }
 func (msg MsgLeveragedLiquidate) Type() string  { return sdk.MsgTypeURL(&msg) }
 
 func (msg *MsgLeveragedLiquidate) ValidateBasic() error {
-	if err := validateSenderAndDenom(msg.Borrower, msg.RewardDenom); err != nil {
+	if msg.RepayDenom != "" {
+		err := sdk.ValidateDenom(msg.RepayDenom)
+		if err != nil {
+			return err
+		}
+	}
+	if msg.RewardDenom != "" {
+		err := sdk.ValidateDenom(msg.RewardDenom)
+		if err != nil {
+			return err
+		}
+	}
+	_, err := sdk.AccAddressFromBech32(msg.Borrower)
+	if err != nil {
 		return err
 	}
-	if err := sdk.ValidateDenom(msg.RepayDenom); err != nil {
-		return err
-	}
-	_, err := sdk.AccAddressFromBech32(msg.Liquidator)
+	_, err = sdk.AccAddressFromBech32(msg.Liquidator)
 	return err
 }
 


### PR DESCRIPTION
- MsgBeginUnbond max amount calculation (not currently affecting mainnet due to zero incentive unbonding period)
- MsgLeveragedLiquidate CLI was not accepting empty denoms