### PR TITLE
fix: metoken Index receiver

### DIFF
--- a/x/metoken/genesis.go
+++ b/x/metoken/genesis.go
@@ -103,7 +103,7 @@ func (ib IndexBalances) AssetBalance(denom string) (int, AssetBalance) {
 }
 
 // SetAssetBalance overrides an asset balance if exists in the list, otherwise add it to the list.
-func (ib IndexBalances) SetAssetBalance(balance AssetBalance) {
+func (ib *IndexBalances) SetAssetBalance(balance AssetBalance) {
 	i, _ := ib.AssetBalance(balance.Denom)
 
 	if i < 0 {

--- a/x/metoken/index.go
+++ b/x/metoken/index.go
@@ -191,7 +191,7 @@ func (i Index) HasAcceptedAsset(denom string) bool {
 }
 
 // SetAcceptedAsset overrides an accepted asset if exists in the list, otherwise add it to the list.
-func (i Index) SetAcceptedAsset(acceptedAsset AcceptedAsset) {
+func (i *Index) SetAcceptedAsset(acceptedAsset AcceptedAsset) {
 	index, _ := i.AcceptedAsset(acceptedAsset.Denom)
 	if index > 0 {
 		i.AcceptedAssets = append(i.AcceptedAssets, acceptedAsset)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description


```
ib.AssetBalances = append(ib.AssetBalances, balance)
```
this can assign new instance of `ibAssetBalance`, so if the function is not called by pointer, then the effect won't be seen. 

