### PR TITLE
fix: move metoken to experimental

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -37,8 +37,7 @@ import (
 )
 
 // RegisterUpgradeHandlersregisters upgrade handlers.
-// It takes a boolean parameter to enable or disable experimental features.
-func (app UmeeApp) RegisterUpgradeHandlers(bool) {
+func (app UmeeApp) RegisterUpgradeHandlers() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

`metoken` should be in the experimental mode only, and not be a part of the default v6.0 build.