### PR TITLE
style: remove prefix `GetCmd` from cli

### DIFF
--- a/x/incentive/client/cli/query.go
+++ b/x/incentive/client/cli/query.go
@@ -28,25 +28,25 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdQueryParams(),
-		GetCmdQueryAccountBonds(),
-		GetCmdQueryCurrentRates(),
-		GetCmdQueryActualRates(),
-		GetCmdQueryTotalBonded(),
-		GetCmdQueryTotalUnbonding(),
-		GetCmdQueryPendingRewards(),
-		GetCmdQueryUpcomingIncentivePrograms(),
-		GetCmdQueryOngoingIncentivePrograms(),
-		GetCmdQueryCompletedIncentivePrograms(),
-		GetCmdQueryIncentiveProgram(),
+		QueryParams(),
+		QueryAccountBonds(),
+		QueryCurrentRates(),
+		QueryActualRates(),
+		QueryTotalBonded(),
+		QueryTotalUnbonding(),
+		QueryPendingRewards(),
+		QueryUpcomingIncentivePrograms(),
+		QueryOngoingIncentivePrograms(),
+		QueryCompletedIncentivePrograms(),
+		QueryIncentiveProgram(),
 	)
 
 	return cmd
 }
 
-// GetCmdQueryParams creates a Cobra command to query for the x/incentive
+// QueryParams creates a Cobra command to query for the x/incentive
 // module parameters.
-func GetCmdQueryParams() *cobra.Command {
+func QueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Args:  cobra.NoArgs,
@@ -67,8 +67,8 @@ func GetCmdQueryParams() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryAccountBonds creates a Cobra command to query all bonds and unbondings associated with a single account.
-func GetCmdQueryAccountBonds() *cobra.Command {
+// QueryAccountBonds creates a Cobra command to query all bonds and unbondings associated with a single account.
+func QueryAccountBonds() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-bonds [address]",
 		Args:  cobra.ExactArgs(1),
@@ -90,8 +90,8 @@ func GetCmdQueryAccountBonds() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryPendingRewards creates a Cobra command to query the pending incentive rewards of a single account.
-func GetCmdQueryPendingRewards() *cobra.Command {
+// QueryPendingRewards creates a Cobra command to query the pending incentive rewards of a single account.
+func QueryPendingRewards() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pending-rewards [address]",
 		Args:  cobra.ExactArgs(1),
@@ -112,9 +112,9 @@ func GetCmdQueryPendingRewards() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryCurrentRates creates a Cobra command to query current annual rewards for a reference amount
+// QueryCurrentRates creates a Cobra command to query current annual rewards for a reference amount
 // of a given bonded uToken.
-func GetCmdQueryCurrentRates() *cobra.Command {
+func QueryCurrentRates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "current-rates [denom]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -139,9 +139,9 @@ func GetCmdQueryCurrentRates() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryActualRates creates a Cobra command to query current annual rewards for a reference amount
+// QueryActualRates creates a Cobra command to query current annual rewards for a reference amount
 // of a given bonded uToken.
-func GetCmdQueryActualRates() *cobra.Command {
+func QueryActualRates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "actual-rates [denom]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -166,8 +166,8 @@ func GetCmdQueryActualRates() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryTotalBonded creates a Cobra command to query bonded tokens across all users.
-func GetCmdQueryTotalBonded() *cobra.Command {
+// QueryTotalBonded creates a Cobra command to query bonded tokens across all users.
+func QueryTotalBonded() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "total-bonded [denom]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -192,8 +192,8 @@ func GetCmdQueryTotalBonded() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryTotalUnbonding creates a Cobra command to query unbonding tokens across all users.
-func GetCmdQueryTotalUnbonding() *cobra.Command {
+// QueryTotalUnbonding creates a Cobra command to query unbonding tokens across all users.
+func QueryTotalUnbonding() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "total-unbonding [denom]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -218,9 +218,9 @@ func GetCmdQueryTotalUnbonding() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryUpcomingIncentivePrograms creates a Cobra command to query for all upcoming
+// QueryUpcomingIncentivePrograms creates a Cobra command to query for all upcoming
 // incentive programs.
-func GetCmdQueryUpcomingIncentivePrograms() *cobra.Command {
+func QueryUpcomingIncentivePrograms() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upcoming",
 		Args:  cobra.NoArgs,
@@ -242,9 +242,9 @@ func GetCmdQueryUpcomingIncentivePrograms() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryOngoingIncentivePrograms creates a Cobra command to query for all ongoing
+// QueryOngoingIncentivePrograms creates a Cobra command to query for all ongoing
 // incentive programs.
-func GetCmdQueryOngoingIncentivePrograms() *cobra.Command {
+func QueryOngoingIncentivePrograms() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ongoing",
 		Args:  cobra.NoArgs,
@@ -266,9 +266,9 @@ func GetCmdQueryOngoingIncentivePrograms() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryCompletedIncentivePrograms creates a Cobra command to query for all completed
+// QueryCompletedIncentivePrograms creates a Cobra command to query for all completed
 // incentive programs.
-func GetCmdQueryCompletedIncentivePrograms() *cobra.Command {
+func QueryCompletedIncentivePrograms() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completed",
 		Args:  cobra.NoArgs,
@@ -291,9 +291,9 @@ func GetCmdQueryCompletedIncentivePrograms() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryIncentiveProgram creates a Cobra command to query a single incentive program
+// QueryIncentiveProgram creates a Cobra command to query a single incentive program
 // by its ID.
-func GetCmdQueryIncentiveProgram() *cobra.Command {
+func QueryIncentiveProgram() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "program [id]",
 		Args:  cobra.ExactArgs(1),

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -24,19 +24,19 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdClaim(),
-		GetCmdBond(),
-		GetCmdBeginUnbonding(),
-		GetCmdEmergencyUnbond(),
-		GetCmdSponsor(),
+		Claim(),
+		Bond(),
+		BeginUnbonding(),
+		EmergencyUnbond(),
+		Sponsor(),
 	)
 
 	return cmd
 }
 
-// GetCmdClaim creates a Cobra command to generate or broadcast a
+// Claim creates a Cobra command to generate or broadcast a
 // transaction with a MsgClaim message.
-func GetCmdClaim() *cobra.Command {
+func Claim() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "claim",
 		Args:  cobra.ExactArgs(0),
@@ -59,7 +59,7 @@ func GetCmdClaim() *cobra.Command {
 }
 
 // transaction with a MsgBond message.
-func GetCmdBond() *cobra.Command {
+func Bond() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bond [utokens]",
 		Args:  cobra.ExactArgs(1),
@@ -87,7 +87,7 @@ func GetCmdBond() *cobra.Command {
 }
 
 // transaction with a MsgBeginUnbonding message.
-func GetCmdBeginUnbonding() *cobra.Command {
+func BeginUnbonding() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "begin-unbonding [utokens]",
 		Args:  cobra.ExactArgs(1),
@@ -115,7 +115,7 @@ func GetCmdBeginUnbonding() *cobra.Command {
 }
 
 // transaction with a MsgEmergencyUnbond message.
-func GetCmdEmergencyUnbond() *cobra.Command {
+func EmergencyUnbond() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "emergency-unbond [utokens]",
 		Args:  cobra.ExactArgs(1),
@@ -143,7 +143,7 @@ func GetCmdEmergencyUnbond() *cobra.Command {
 }
 
 // transaction with a MsgSponsor message.
-func GetCmdSponsor() *cobra.Command {
+func Sponsor() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sponsor [program-id]",
 		Args:  cobra.ExactArgs(1),

--- a/x/incentive/client/tests/tests.go
+++ b/x/incentive/client/tests/tests.go
@@ -15,7 +15,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 	invalidQueries := []itestsuite.TestQuery{
 		{
 			Name:    "query pending rewards (invalid address)",
-			Command: cli.GetCmdQueryPendingRewards(),
+			Command: cli.QueryPendingRewards(),
 			Args: []string{
 				"xyz",
 			},
@@ -25,7 +25,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query current rates (not uToken)",
-			Command: cli.GetCmdQueryCurrentRates(),
+			Command: cli.QueryCurrentRates(),
 			Args: []string{
 				"uumee",
 			},
@@ -35,7 +35,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query actual rates (not uToken)",
-			Command: cli.GetCmdQueryActualRates(),
+			Command: cli.QueryActualRates(),
 			Args: []string{
 				"uumee",
 			},
@@ -54,7 +54,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 	zeroQueries := []itestsuite.TestQuery{
 		{
 			Name:     "query params",
-			Command:  cli.GetCmdQueryParams(),
+			Command:  cli.QueryParams(),
 			Args:     []string{},
 			Response: &incentive.QueryParamsResponse{},
 			ExpectedResponse: &incentive.QueryParamsResponse{
@@ -64,7 +64,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:     "query upcoming incentive programs",
-			Command:  cli.GetCmdQueryUpcomingIncentivePrograms(),
+			Command:  cli.QueryUpcomingIncentivePrograms(),
 			Args:     []string{},
 			Response: &incentive.QueryUpcomingIncentiveProgramsResponse{},
 			ExpectedResponse: &incentive.QueryUpcomingIncentiveProgramsResponse{
@@ -74,7 +74,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:     "query ongoing incentive programs",
-			Command:  cli.GetCmdQueryUpcomingIncentivePrograms(),
+			Command:  cli.QueryUpcomingIncentivePrograms(),
 			Args:     []string{},
 			Response: &incentive.QueryOngoingIncentiveProgramsResponse{},
 			ExpectedResponse: &incentive.QueryOngoingIncentiveProgramsResponse{
@@ -84,7 +84,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:     "query completed incentive programs",
-			Command:  cli.GetCmdQueryCompletedIncentivePrograms(),
+			Command:  cli.QueryCompletedIncentivePrograms(),
 			Args:     []string{},
 			Response: &incentive.QueryCompletedIncentiveProgramsResponse{},
 			ExpectedResponse: &incentive.QueryCompletedIncentiveProgramsResponse{
@@ -94,7 +94,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:     "query total bonded - no denom",
-			Command:  cli.GetCmdQueryTotalBonded(),
+			Command:  cli.QueryTotalBonded(),
 			Args:     []string{},
 			Response: &incentive.QueryTotalBondedResponse{},
 			ExpectedResponse: &incentive.QueryTotalBondedResponse{
@@ -103,7 +103,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:    "query total bonded - specific denom",
-			Command: cli.GetCmdQueryTotalBonded(),
+			Command: cli.QueryTotalBonded(),
 			Args: []string{
 				"u/" + appparams.BondDenom,
 			},
@@ -114,7 +114,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:     "query total unbonding - no denom",
-			Command:  cli.GetCmdQueryTotalUnbonding(),
+			Command:  cli.QueryTotalUnbonding(),
 			Args:     []string{},
 			Response: &incentive.QueryTotalUnbondingResponse{},
 			ExpectedResponse: &incentive.QueryTotalUnbondingResponse{
@@ -123,7 +123,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:    "query total unbonding - specific denom",
-			Command: cli.GetCmdQueryTotalUnbonding(),
+			Command: cli.QueryTotalUnbonding(),
 			Args: []string{
 				"u/" + appparams.BondDenom,
 			},
@@ -134,7 +134,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:    "query current rates (zero)",
-			Command: cli.GetCmdQueryCurrentRates(),
+			Command: cli.QueryCurrentRates(),
 			Args: []string{
 				"u/" + appparams.BondDenom,
 			},
@@ -147,7 +147,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:    "query actual rates (zero)",
-			Command: cli.GetCmdQueryActualRates(),
+			Command: cli.QueryActualRates(),
 			Args: []string{
 				"u/" + appparams.BondDenom,
 			},
@@ -159,7 +159,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 		},
 		{
 			Name:    "query pending rewards (zero)",
-			Command: cli.GetCmdQueryPendingRewards(),
+			Command: cli.QueryPendingRewards(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -173,7 +173,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 
 	supplyCollateral := itestsuite.TestTransaction{
 		Name:    "(setup) supply collateral",
-		Command: leveragecli.GetCmdSupplyCollateral(),
+		Command: leveragecli.SupplyCollateral(),
 		Args: []string{
 			"300uumee",
 		},
@@ -182,7 +182,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 
 	bond := itestsuite.TestTransaction{
 		Name:    "bond",
-		Command: cli.GetCmdBond(),
+		Command: cli.Bond(),
 		Args: []string{
 			"300u/uumee",
 		},
@@ -191,7 +191,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 
 	beingUnbonding := itestsuite.TestTransaction{
 		Name:    "begin unbonding",
-		Command: cli.GetCmdBeginUnbonding(),
+		Command: cli.BeginUnbonding(),
 		Args: []string{
 			"100u/uumee",
 		},
@@ -200,7 +200,7 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 
 	emergencyUnbond := itestsuite.TestTransaction{
 		Name:    "emergency unbond",
-		Command: cli.GetCmdEmergencyUnbond(),
+		Command: cli.EmergencyUnbond(),
 		Args: []string{
 			"100u/uumee",
 		},
@@ -209,14 +209,14 @@ func (s *IntegrationTests) TestIncentiveScenario() {
 
 	claim := itestsuite.TestTransaction{
 		Name:        "claim",
-		Command:     cli.GetCmdClaim(),
+		Command:     cli.Claim(),
 		Args:        []string{},
 		ExpectedErr: nil,
 	}
 
 	sponsor := itestsuite.TestTransaction{
 		Name:        "sponsor (program does not exist)",
-		Command:     cli.GetCmdSponsor(),
+		Command:     cli.Sponsor(),
 		Args:        []string{"1"},
 		ExpectedErr: sdkerrors.ErrNotFound,
 	}

--- a/x/leverage/client/cli/query.go
+++ b/x/leverage/client/cli/query.go
@@ -28,25 +28,25 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdQueryParams(),
-		GetCmdQueryRegisteredTokens(),
-		GetCmdQuerySpecialAssets(),
-		GetCmdQueryMarketSummary(),
-		GetCmdQueryAccountBalances(),
-		GetCmdQueryAccountSummary(),
-		GetCmdQueryLiquidationTargets(),
-		GetCmdQueryBadDebts(),
-		GetCmdQueryMaxWithdraw(),
-		GetCmdQueryMaxBorrow(),
-		GetCmdQueryInspect(),
+		QueryParams(),
+		QueryRegisteredTokens(),
+		QuerySpecialAssets(),
+		QueryMarketSummary(),
+		QueryAccountBalances(),
+		QueryAccountSummary(),
+		QueryLiquidationTargets(),
+		QueryBadDebts(),
+		QueryMaxWithdraw(),
+		QueryMaxBorrow(),
+		QueryInspect(),
 	)
 
 	return cmd
 }
 
-// GetCmdQueryParams creates a Cobra command to query for the x/leverage
+// QueryParams creates a Cobra command to query for the x/leverage
 // module parameters.
-func GetCmdQueryParams() *cobra.Command {
+func QueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Args:  cobra.NoArgs,
@@ -68,9 +68,9 @@ func GetCmdQueryParams() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryRegisteredTokens creates a Cobra command to query for all
+// QueryRegisteredTokens creates a Cobra command to query for all
 // the registered tokens in the x/leverage module.
-func GetCmdQueryRegisteredTokens() *cobra.Command {
+func QueryRegisteredTokens() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registered-tokens [base_denom]",
 		Args:  cobra.MaximumNArgs(1),
@@ -96,9 +96,9 @@ func GetCmdQueryRegisteredTokens() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQuerySpecialAssets creates a Cobra command to query for all
+// QuerySpecialAssets creates a Cobra command to query for all
 // the special asset pairs in the x/leverage module.
-func GetCmdQuerySpecialAssets() *cobra.Command {
+func QuerySpecialAssets() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "special-assets",
 		Args:  cobra.RangeArgs(0, 1),
@@ -124,9 +124,9 @@ func GetCmdQuerySpecialAssets() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryMarketSummary creates a Cobra command to query for the
+// QueryMarketSummary creates a Cobra command to query for the
 // Market Summary of a specific token.
-func GetCmdQueryMarketSummary() *cobra.Command {
+func QueryMarketSummary() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "market-summary [denom]",
 		Args:  cobra.ExactArgs(1),
@@ -151,9 +151,9 @@ func GetCmdQueryMarketSummary() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryAccountBalances creates a Cobra command to query for the
+// QueryAccountBalances creates a Cobra command to query for the
 // supply, collateral, and borrow positions of an account.
-func GetCmdQueryAccountBalances() *cobra.Command {
+func QueryAccountBalances() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-balances [addr]",
 		Args:  cobra.ExactArgs(1),
@@ -178,9 +178,9 @@ func GetCmdQueryAccountBalances() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryAccountSummary creates a Cobra command to query for USD
+// QueryAccountSummary creates a Cobra command to query for USD
 // values representing an account's positions and borrowing limits.
-func GetCmdQueryAccountSummary() *cobra.Command {
+func QueryAccountSummary() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account-summary [addr]",
 		Args:  cobra.ExactArgs(1),
@@ -205,9 +205,9 @@ func GetCmdQueryAccountSummary() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryLiquidationTargets creates a Cobra command to query for
+// QueryLiquidationTargets creates a Cobra command to query for
 // all eligible liquidation targets.
-func GetCmdQueryLiquidationTargets() *cobra.Command {
+func QueryLiquidationTargets() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "liquidation-targets",
 		Args:  cobra.ExactArgs(0),
@@ -230,9 +230,9 @@ func GetCmdQueryLiquidationTargets() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryBadDebts creates a Cobra command to query for
+// QueryBadDebts creates a Cobra command to query for
 // all bad debts.
-func GetCmdQueryBadDebts() *cobra.Command {
+func QueryBadDebts() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bad-debts",
 		Args:  cobra.ExactArgs(0),
@@ -255,9 +255,9 @@ func GetCmdQueryBadDebts() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryMaxWithdraw creates a Cobra command to query for
+// QueryMaxWithdraw creates a Cobra command to query for
 // the maximum amount of a given token an address can withdraw.
-func GetCmdQueryMaxWithdraw() *cobra.Command {
+func QueryMaxWithdraw() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "max-withdraw [addr] [denom]",
 		Args:  cobra.RangeArgs(1, 2),
@@ -288,9 +288,9 @@ func GetCmdQueryMaxWithdraw() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryMaxBorrow creates a Cobra command to query for
+// QueryMaxBorrow creates a Cobra command to query for
 // the maximum amount of a given token an address can borrow.
-func GetCmdQueryMaxBorrow() *cobra.Command {
+func QueryMaxBorrow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "max-borrow [addr] [denom]",
 		Args:  cobra.RangeArgs(1, 2),
@@ -318,8 +318,8 @@ func GetCmdQueryMaxBorrow() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryInspect creates a Cobra command to query for the inspector command.
-func GetCmdQueryInspect() *cobra.Command {
+// QueryInspect creates a Cobra command to query for the inspector command.
+func QueryInspect() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "inspect [symbol] [borrowed] [collateral [danger] [ltv]",
 		Args:    cobra.MinimumNArgs(2),

--- a/x/leverage/client/cli/tx.go
+++ b/x/leverage/client/cli/tx.go
@@ -24,25 +24,25 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdSupply(),
-		GetCmdWithdraw(),
-		GetCmdMaxWithdraw(),
-		GetCmdCollateralize(),
-		GetCmdDecollateralize(),
-		GetCmdBorrow(),
-		GetCmdMaxBorrow(),
-		GetCmdRepay(),
-		GetCmdLiquidate(),
-		GetCmdLeveragedLiquidate(),
-		GetCmdSupplyCollateral(),
+		Supply(),
+		Withdraw(),
+		MaxWithdraw(),
+		Collateralize(),
+		Decollateralize(),
+		Borrow(),
+		MaxBorrow(),
+		Repay(),
+		Liquidate(),
+		LeveragedLiquidate(),
+		SupplyCollateral(),
 	)
 
 	return cmd
 }
 
-// GetCmdSupply creates a Cobra command to generate or broadcast a
+// Supply creates a Cobra command to generate or broadcast a
 // transaction with a MsgSupply message.
-func GetCmdSupply() *cobra.Command {
+func Supply() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "supply [amount]",
 		Args:  cobra.ExactArgs(1),
@@ -69,9 +69,9 @@ func GetCmdSupply() *cobra.Command {
 	return cmd
 }
 
-// GetCmdWithdraw creates a Cobra command to generate or broadcast a
+// Withdraw creates a Cobra command to generate or broadcast a
 // transaction with a MsgWithdraw message.
-func GetCmdWithdraw() *cobra.Command {
+func Withdraw() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "withdraw [amount]",
 		Args:  cobra.ExactArgs(1),
@@ -98,9 +98,9 @@ func GetCmdWithdraw() *cobra.Command {
 	return cmd
 }
 
-// GetCmdMaxWithdraw creates a Cobra command to generate or broadcast a
+// MaxWithdraw creates a Cobra command to generate or broadcast a
 // transaction with a MsgMaxWithdraw message.
-func GetCmdMaxWithdraw() *cobra.Command {
+func MaxWithdraw() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "withdraw-max [denom]",
 		Args:  cobra.ExactArgs(1),
@@ -124,9 +124,9 @@ func GetCmdMaxWithdraw() *cobra.Command {
 	return cmd
 }
 
-// GetCmdCollateralize creates a Cobra command to generate or broadcast a
+// Collateralize creates a Cobra command to generate or broadcast a
 // transaction with a MsgCollateralize message.
-func GetCmdCollateralize() *cobra.Command {
+func Collateralize() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collateralize [coin]",
 		Args:  cobra.ExactArgs(1),
@@ -155,9 +155,9 @@ func GetCmdCollateralize() *cobra.Command {
 	return cmd
 }
 
-// GetCmdDecollateralize returns a CLI command handler to generate or broadcast a
+// Decollateralize returns a CLI command handler to generate or broadcast a
 // transaction with a MsgDecollateralize message.
-func GetCmdDecollateralize() *cobra.Command {
+func Decollateralize() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decollateralize [coin]",
 		Args:  cobra.ExactArgs(1),
@@ -186,9 +186,9 @@ func GetCmdDecollateralize() *cobra.Command {
 	return cmd
 }
 
-// GetCmdBorrow creates a Cobra command to generate or broadcast a
+// Borrow creates a Cobra command to generate or broadcast a
 // transaction with a MsgBorrow message.
-func GetCmdBorrow() *cobra.Command {
+func Borrow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "borrow [amount]",
 		Args:  cobra.ExactArgs(1),
@@ -215,9 +215,9 @@ func GetCmdBorrow() *cobra.Command {
 	return cmd
 }
 
-// GetCmdMaxBorrow creates a Cobra command to generate or broadcast a
+// MaxBorrow creates a Cobra command to generate or broadcast a
 // transaction with a MsgBorrow message.
-func GetCmdMaxBorrow() *cobra.Command {
+func MaxBorrow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "max-borrow [denom]",
 		Args:  cobra.ExactArgs(1),
@@ -239,9 +239,9 @@ func GetCmdMaxBorrow() *cobra.Command {
 	return cmd
 }
 
-// GetCmdRepay creates a Cobra command to generate or broadcast a
+// Repay creates a Cobra command to generate or broadcast a
 // transaction with a MsgRepay message.
-func GetCmdRepay() *cobra.Command {
+func Repay() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repay [amount]",
 		Args:  cobra.ExactArgs(1),
@@ -268,9 +268,9 @@ func GetCmdRepay() *cobra.Command {
 	return cmd
 }
 
-// GetCmdLiquidate creates a Cobra command to generate or broadcast a
+// Liquidate creates a Cobra command to generate or broadcast a
 // transaction with a MsgLiquidate message.
-func GetCmdLiquidate() *cobra.Command {
+func Liquidate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "liquidate [borrower] [amount] [reward-denom]",
 		Args:  cobra.ExactArgs(3),
@@ -317,9 +317,9 @@ $ umeed tx leverage liquidate %s  50000000uumee u/uumee --from mykey`,
 	return cmd
 }
 
-// GetCmdLeveragedLiquidate creates a Cobra command to generate or broadcast a
+// LeveragedLiquidate creates a Cobra command to generate or broadcast a
 // transaction with a MsgLeveragedLiquidate message.
-func GetCmdLeveragedLiquidate() *cobra.Command {
+func LeveragedLiquidate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lev-liquidate [borrower] [repay-denom] [reward-denom]",
 		Args:  cobra.RangeArgs(1, 3),
@@ -372,9 +372,9 @@ $ umeed tx leverage lev-liquidate %s uumee uumee --from mykey`,
 	return cmd
 }
 
-// GetCmdSupplyCollateral creates a Cobra command to generate or broadcast a
+// SupplyCollateral creates a Cobra command to generate or broadcast a
 // transaction with a MsgSupply message.
-func GetCmdSupplyCollateral() *cobra.Command {
+func SupplyCollateral() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "supply-collateral [amount]",
 		Args:  cobra.ExactArgs(1),

--- a/x/leverage/client/tests/tests.go
+++ b/x/leverage/client/tests/tests.go
@@ -15,7 +15,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 	invalidQueries := []itestsuite.TestQuery{
 		{
 			Name:    "query market summary - denom not registered",
-			Command: cli.GetCmdQueryMarketSummary(),
+			Command: cli.QueryMarketSummary(),
 			Args: []string{
 				"abcd",
 			},
@@ -25,7 +25,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query account balances - invalid address",
-			Command: cli.GetCmdQueryAccountBalances(),
+			Command: cli.QueryAccountBalances(),
 			Args: []string{
 				"xyz",
 			},
@@ -35,7 +35,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query account summary - invalid address",
-			Command: cli.GetCmdQueryAccountSummary(),
+			Command: cli.QueryAccountSummary(),
 			Args: []string{
 				"xyz",
 			},
@@ -45,7 +45,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query max withdraw - invalid address",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				"xyz",
 				"uumee",
@@ -56,7 +56,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:             "query registered token - denom not registered",
-			Command:          cli.GetCmdQueryRegisteredTokens(),
+			Command:          cli.QueryRegisteredTokens(),
 			Args:             []string{"umm"},
 			Response:         nil,
 			ExpectedResponse: nil,
@@ -76,7 +76,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 	initialQueries := []itestsuite.TestQuery{
 		{
 			Name:     "query params",
-			Command:  cli.GetCmdQueryParams(),
+			Command:  cli.QueryParams(),
 			Args:     []string{},
 			Response: &types.QueryParamsResponse{},
 			ExpectedResponse: &types.QueryParamsResponse{
@@ -86,7 +86,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:     "query registered tokens",
-			Command:  cli.GetCmdQueryRegisteredTokens(),
+			Command:  cli.QueryRegisteredTokens(),
 			Args:     []string{},
 			Response: &types.QueryRegisteredTokensResponse{},
 			ExpectedResponse: &types.QueryRegisteredTokensResponse{
@@ -98,7 +98,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:     "query special assets",
-			Command:  cli.GetCmdQuerySpecialAssets(),
+			Command:  cli.QuerySpecialAssets(),
 			Args:     []string{"uumee"},
 			Response: &types.QuerySpecialAssetsResponse{},
 			ExpectedResponse: &types.QuerySpecialAssetsResponse{
@@ -108,7 +108,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:     "query registered token info by base_denom",
-			Command:  cli.GetCmdQueryRegisteredTokens(),
+			Command:  cli.QueryRegisteredTokens(),
 			Args:     []string{appparams.BondDenom},
 			Response: &types.QueryRegisteredTokensResponse{},
 			ExpectedResponse: &types.QueryRegisteredTokensResponse{
@@ -120,7 +120,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query market summary - zero supply",
-			Command: cli.GetCmdQueryMarketSummary(),
+			Command: cli.QueryMarketSummary(),
 			Args: []string{
 				appparams.BondDenom,
 			},
@@ -154,7 +154,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:     "query bad debts",
-			Command:  cli.GetCmdQueryBadDebts(),
+			Command:  cli.QueryBadDebts(),
 			Args:     []string{},
 			Response: &types.QueryBadDebtsResponse{},
 			ExpectedResponse: &types.QueryBadDebtsResponse{
@@ -164,7 +164,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max withdraw (zero)",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -178,7 +178,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max borrow (zero)",
-			Command: cli.GetCmdQueryMaxBorrow(),
+			Command: cli.QueryMaxBorrow(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -193,7 +193,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	supply := itestsuite.TestTransaction{
 		Name:    "supply",
-		Command: cli.GetCmdSupply(),
+		Command: cli.Supply(),
 		Args: []string{
 			"700uumee",
 		},
@@ -202,7 +202,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	addCollateral := itestsuite.TestTransaction{
 		Name:    "add collateral",
-		Command: cli.GetCmdCollateralize(),
+		Command: cli.Collateralize(),
 		Args: []string{
 			"700u/uumee",
 		},
@@ -211,7 +211,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	supplyCollateral := itestsuite.TestTransaction{
 		Name:    "supply collateral",
-		Command: cli.GetCmdSupplyCollateral(),
+		Command: cli.SupplyCollateral(),
 		Args: []string{
 			"300uumee",
 		},
@@ -220,7 +220,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	borrow := itestsuite.TestTransaction{
 		Name:    "borrow",
-		Command: cli.GetCmdBorrow(),
+		Command: cli.Borrow(),
 		Args: []string{
 			"150uumee",
 		},
@@ -229,7 +229,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	maxborrow := itestsuite.TestTransaction{
 		Name:    "max-borrow",
-		Command: cli.GetCmdMaxBorrow(),
+		Command: cli.MaxBorrow(),
 		Args: []string{
 			"uumee", // should borrow up to the max of 250 uumee, which will become 251 due to rounding
 		},
@@ -238,7 +238,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	liquidate := itestsuite.TestTransaction{
 		Name:    "liquidate",
-		Command: cli.GetCmdLiquidate(),
+		Command: cli.Liquidate(),
 		Args: []string{
 			val.Address.String(),
 			"5uumee", // borrower attempts to liquidate itself, but is ineligible
@@ -248,7 +248,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 	}
 	leveragedLiquidate := itestsuite.TestTransaction{
 		Name:    "liquidate",
-		Command: cli.GetCmdLeveragedLiquidate(),
+		Command: cli.LeveragedLiquidate(),
 		Args: []string{
 			val.Address.String(),
 			"uumee", // borrower attempts to liquidate itself, but is ineligible
@@ -259,7 +259,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	repay := itestsuite.TestTransaction{
 		Name:    "repay",
-		Command: cli.GetCmdRepay(),
+		Command: cli.Repay(),
 		Args: []string{
 			"255uumee", // repays only the remaining borrowed balance, reduced automatically from 255
 		},
@@ -268,7 +268,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	removeCollateral := itestsuite.TestTransaction{
 		Name:    "remove collateral",
-		Command: cli.GetCmdDecollateralize(),
+		Command: cli.Decollateralize(),
 		Args: []string{
 			"900u/uumee", // 100 u/uumee will remain
 		},
@@ -277,7 +277,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	withdraw := itestsuite.TestTransaction{
 		Name:    "withdraw",
-		Command: cli.GetCmdWithdraw(),
+		Command: cli.Withdraw(),
 		Args: []string{
 			"800u/uumee", // 200 u/uumee will remain
 		},
@@ -286,7 +286,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 	withdrawMax := itestsuite.TestTransaction{
 		Name:    "withdraw max",
-		Command: cli.GetCmdMaxWithdraw(),
+		Command: cli.MaxWithdraw(),
 		Args: []string{
 			"uumee",
 		},
@@ -298,7 +298,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 	nonzeroQueries := []itestsuite.TestQuery{
 		{
 			Name:    "query account balances",
-			Command: cli.GetCmdQueryAccountBalances(),
+			Command: cli.QueryAccountBalances(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -318,7 +318,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query account summary",
-			Command: cli.GetCmdQueryAccountSummary(),
+			Command: cli.QueryAccountSummary(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -342,7 +342,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max withdraw (borrow limit reached)",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -356,7 +356,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max borrow (borrow limit reached)",
-			Command: cli.GetCmdQueryMaxBorrow(),
+			Command: cli.QueryMaxBorrow(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -372,7 +372,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 	postQueries := []itestsuite.TestQuery{
 		{
 			Name:    "query account balances",
-			Command: cli.GetCmdQueryAccountBalances(),
+			Command: cli.QueryAccountBalances(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -390,7 +390,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max withdraw (after repay)",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -408,7 +408,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query max borrow (after repay)",
-			Command: cli.GetCmdQueryMaxBorrow(),
+			Command: cli.QueryMaxBorrow(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",
@@ -423,7 +423,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query all max withdraw (after repay)",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -440,7 +440,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 		},
 		{
 			Name:    "query all max borrow (after repay)",
-			Command: cli.GetCmdQueryMaxBorrow(),
+			Command: cli.QueryMaxBorrow(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -457,7 +457,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 	lastQueries := []itestsuite.TestQuery{
 		{
 			Name:    "query account balances (empty after withdraw max)",
-			Command: cli.GetCmdQueryAccountBalances(),
+			Command: cli.QueryAccountBalances(),
 			Args: []string{
 				val.Address.String(),
 			},
@@ -472,7 +472,7 @@ func (s *IntegrationTests) TestLeverageScenario() {
 
 		{
 			Name:    "query max withdraw (after withdraw max)",
-			Command: cli.GetCmdQueryMaxWithdraw(),
+			Command: cli.QueryMaxWithdraw(),
 			Args: []string{
 				val.Address.String(),
 				"uumee",

--- a/x/metoken/client/cli/query.go
+++ b/x/metoken/client/cli/query.go
@@ -22,19 +22,19 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdQueryParams(),
-		GetCmdIndexes(),
-		GetCmdIndexBalances(),
-		GetCmdSwapFee(),
-		GetCmdRedeemFee(),
-		GetCmdIndexPrice(),
+		QueryParams(),
+		Indexes(),
+		IndexBalances(),
+		SwapFee(),
+		RedeemFee(),
+		IndexPrice(),
 	)
 
 	return cmd
 }
 
-// GetCmdQueryParams creates a Cobra command to query for the x/metoken module parameters.
-func GetCmdQueryParams() *cobra.Command {
+// QueryParams creates a Cobra command to query for the x/metoken module parameters.
+func QueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Args:  cobra.NoArgs,
@@ -55,9 +55,9 @@ func GetCmdQueryParams() *cobra.Command {
 	return cmd
 }
 
-// GetCmdIndexes creates a Cobra command to query for the x/metoken module registered Indexes.
+// Indexes creates a Cobra command to query for the x/metoken module registered Indexes.
 // metoken_denom is optional, if it isn't provided then all the indexes will be returned.
-func GetCmdIndexes() *cobra.Command {
+func Indexes() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "indexes [metoken_denom]",
 		Args: cobra.MaximumNArgs(1),
@@ -84,10 +84,10 @@ func GetCmdIndexes() *cobra.Command {
 	return cmd
 }
 
-// GetCmdSwapFee creates a Cobra command to query for the SwapFee
+// SwapFee creates a Cobra command to query for the SwapFee
 // Both arguments are required:
 // coin: the coin that is taken as base for the fee calculation.
-func GetCmdSwapFee() *cobra.Command {
+func SwapFee() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "swap-fee [coin] [metoken_denom]",
 		Args:  cobra.ExactArgs(2),
@@ -113,10 +113,10 @@ func GetCmdSwapFee() *cobra.Command {
 	return cmd
 }
 
-// GetCmdRedeemFee creates a Cobra command to query for the RedeemFee
+// RedeemFee creates a Cobra command to query for the RedeemFee
 // Both arguments are required:
 // metoken: the meToken coin that is taken as base for the fee calculation.
-func GetCmdRedeemFee() *cobra.Command {
+func RedeemFee() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redeem-fee [metoken] [asset_denom]",
 		Args:  cobra.ExactArgs(2),
@@ -142,9 +142,9 @@ func GetCmdRedeemFee() *cobra.Command {
 	return cmd
 }
 
-// GetCmdIndexBalances creates a Cobra command to query for the x/metoken module Indexes assets balances
+// IndexBalances creates a Cobra command to query for the x/metoken module Indexes assets balances
 // metoken_denom is optional, if it isn't provided then all the balances will be returned.
-func GetCmdIndexBalances() *cobra.Command {
+func IndexBalances() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "index-balance [metoken_denom]",
 		Args: cobra.MaximumNArgs(1),
@@ -170,9 +170,9 @@ func GetCmdIndexBalances() *cobra.Command {
 	return cmd
 }
 
-// GetCmdIndexPrice creates a Cobra command to query for the x/metoken module Index Prices.
+// IndexPrice creates a Cobra command to query for the x/metoken module Index Prices.
 // metoken_denom is optional, if it isn't provided then prices for all the registered indexes will be returned.
-func GetCmdIndexPrice() *cobra.Command {
+func IndexPrice() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "index-price [metoken_denom]",
 		Args: cobra.MaximumNArgs(1),

--- a/x/metoken/client/cli/tx.go
+++ b/x/metoken/client/cli/tx.go
@@ -23,16 +23,16 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdSwap(),
-		GetCmdRedeem(),
+		Swap(),
+		Redeem(),
 	)
 
 	return cmd
 }
 
-// GetCmdSwap creates a Cobra command to generate or broadcast a transaction with a MsgSwap message.
+// Swap creates a Cobra command to generate or broadcast a transaction with a MsgSwap message.
 // Both arguments are required.
-func GetCmdSwap() *cobra.Command {
+func Swap() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "swap [coin] [metoken_denom]",
 		Args:  cobra.ExactArgs(2),
@@ -57,9 +57,9 @@ func GetCmdSwap() *cobra.Command {
 	return cmd
 }
 
-// GetCmdRedeem creates a Cobra command to generate or broadcast a transaction with a MsgRedeem message.
+// Redeem creates a Cobra command to generate or broadcast a transaction with a MsgRedeem message.
 // Both arguments are required.
-func GetCmdRedeem() *cobra.Command {
+func Redeem() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redeem [metoken] [redeem_denom]",
 		Args:  cobra.ExactArgs(2),

--- a/x/metoken/client/tests/tests.go
+++ b/x/metoken/client/tests/tests.go
@@ -18,7 +18,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		{
 
 			Name:    "query swap fee - invalid asset for swap",
-			Command: cli.GetCmdSwapFee(),
+			Command: cli.SwapFee(),
 			Args: []string{
 				"{abcd}{100000000}",
 				"xyz",
@@ -29,7 +29,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query swap fee - index not found",
-			Command: cli.GetCmdSwapFee(),
+			Command: cli.SwapFee(),
 			Args: []string{
 				"1000abcd",
 				"xyz",
@@ -40,7 +40,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query redeem fee - invalid meToken for redemption",
-			Command: cli.GetCmdRedeemFee(),
+			Command: cli.RedeemFee(),
 			Args: []string{
 				"{abcd}{100000000}",
 				"xyz",
@@ -51,7 +51,7 @@ func (s *IntegrationTests) TestInvalidQueries() {
 		},
 		{
 			Name:    "query redeem fee - index not found",
-			Command: cli.GetCmdRedeemFee(),
+			Command: cli.RedeemFee(),
 			Args: []string{
 				"1000xyz",
 				"abcd",
@@ -70,7 +70,7 @@ func (s *IntegrationTests) TestValidQueries() {
 	queries := []itestsuite.TestQuery{
 		{
 			Name:     "query params",
-			Command:  cli.GetCmdQueryParams(),
+			Command:  cli.QueryParams(),
 			Args:     []string{},
 			Response: &metoken.QueryParamsResponse{},
 			ExpectedResponse: &metoken.QueryParamsResponse{
@@ -80,7 +80,7 @@ func (s *IntegrationTests) TestValidQueries() {
 		},
 		{
 			Name:     "query indexes",
-			Command:  cli.GetCmdIndexes(),
+			Command:  cli.Indexes(),
 			Args:     []string{},
 			Response: &metoken.QueryIndexesResponse{},
 			ExpectedResponse: &metoken.QueryIndexesResponse{
@@ -90,7 +90,7 @@ func (s *IntegrationTests) TestValidQueries() {
 		},
 		{
 			Name:     "query balances",
-			Command:  cli.GetCmdIndexBalances(),
+			Command:  cli.IndexBalances(),
 			Args:     []string{},
 			Response: &metoken.QueryIndexBalancesResponse{},
 			ExpectedResponse: &metoken.QueryIndexBalancesResponse{
@@ -117,7 +117,7 @@ func (s *IntegrationTests) TestValidQueries() {
 		},
 		{
 			Name:    "query swap fee for 1876 uumee",
-			Command: cli.GetCmdSwapFee(),
+			Command: cli.SwapFee(),
 			Args: []string{
 				"1876000000uumee",
 				mfixtures.MeBondDenom,
@@ -134,7 +134,7 @@ func (s *IntegrationTests) TestValidQueries() {
 		},
 		{
 			Name:    "query redeem fee for 100 meUSD to uumee",
-			Command: cli.GetCmdRedeemFee(),
+			Command: cli.RedeemFee(),
 			Args: []string{
 				"100000000me/uumee",
 				"uumee",
@@ -170,7 +170,7 @@ func (s *IntegrationTests) TestTransactions() {
 	txs := []itestsuite.TestTransaction{
 		{
 			Name:    "swap index not found",
-			Command: cli.GetCmdSwap(),
+			Command: cli.Swap(),
 			Args: []string{
 				"300000000" + mfixtures.BondDenom,
 				"me/Test",
@@ -179,7 +179,7 @@ func (s *IntegrationTests) TestTransactions() {
 		},
 		{
 			Name:    "swap 300uumee",
-			Command: cli.GetCmdSwap(),
+			Command: cli.Swap(),
 			Args: []string{
 				"300000000" + mfixtures.BondDenom,
 				mfixtures.MeBondDenom,
@@ -188,7 +188,7 @@ func (s *IntegrationTests) TestTransactions() {
 		},
 		{
 			Name:    "swap index not found",
-			Command: cli.GetCmdRedeem(),
+			Command: cli.Redeem(),
 			Args: []string{
 				"300000000" + "me/Test",
 				mfixtures.BondDenom,
@@ -197,7 +197,7 @@ func (s *IntegrationTests) TestTransactions() {
 		},
 		{
 			Name:    "redeem 100me/uumee",
-			Command: cli.GetCmdRedeem(),
+			Command: cli.Redeem(),
 			Args: []string{
 				"100000000" + mfixtures.MeBondDenom,
 				mfixtures.BondDenom,

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -24,22 +24,22 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdQueryAggregatePrevote(),
-		GetCmdQueryAggregateVote(),
-		GetCmdQueryParams(),
-		GetCmdQueryExchangeRates(),
-		GetCmdQueryExchangeRate(),
-		GetCmdQueryFeederDelegation(),
-		GetCmdQueryMissCounter(),
-		GetCmdQuerySlashWindow(),
-		GetCmdQueryHistoricAvgPrice(),
+		QueryAggregatePrevote(),
+		QueryAggregateVote(),
+		QueryParams(),
+		QueryExchangeRates(),
+		QueryExchangeRate(),
+		QueryFeederDelegation(),
+		QueryMissCounter(),
+		QuerySlashWindow(),
+		QueryHistoricAvgPrice(),
 	)
 
 	return cmd
 }
 
-// GetCmdQueryParams implements the query params command.
-func GetCmdQueryParams() *cobra.Command {
+// QueryParams implements the query params command.
+func QueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Args:  cobra.NoArgs,
@@ -61,9 +61,9 @@ func GetCmdQueryParams() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryAggregateVote implements the query aggregate prevote of the
+// QueryAggregateVote implements the query aggregate prevote of the
 // validator command.
-func GetCmdQueryAggregateVote() *cobra.Command {
+func QueryAggregateVote() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aggregate-votes [validator]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -103,9 +103,9 @@ $ umeed query oracle aggregate-votes umeevaloper...
 	return cmd
 }
 
-// GetCmdQueryAggregatePrevote implements the query aggregate prevote of the
+// QueryAggregatePrevote implements the query aggregate prevote of the
 // validator command.
-func GetCmdQueryAggregatePrevote() *cobra.Command {
+func QueryAggregatePrevote() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aggregate-prevotes [validator]",
 		Args:  cobra.RangeArgs(0, 1),
@@ -145,8 +145,8 @@ $ umeed query oracle aggregate-prevotes umeevaloper...
 	return cmd
 }
 
-// GetCmdQueryExchangeRates implements the query rate command.
-func GetCmdQueryExchangeRates() *cobra.Command {
+// QueryExchangeRates implements the query rate command.
+func QueryExchangeRates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rates",
 		Args:  cobra.NoArgs,
@@ -172,8 +172,8 @@ $ umeed query oracle exchange-rates
 	return cmd
 }
 
-// GetCmdQueryExchangeRates implements the query rate command.
-func GetCmdQueryExchangeRate() *cobra.Command {
+// QueryExchangeRates implements the query rate command.
+func QueryExchangeRate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rate [denom]",
 		Args:  cobra.ExactArgs(1),
@@ -203,8 +203,8 @@ $ umeed query oracle exchange-rate ATOM
 	return cmd
 }
 
-// GetCmdQueryFeederDelegation implements the query feeder delegation command.
-func GetCmdQueryFeederDelegation() *cobra.Command {
+// QueryFeederDelegation implements the query feeder delegation command.
+func QueryFeederDelegation() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feeder-delegation [validator]",
 		Args:  cobra.ExactArgs(1),
@@ -230,8 +230,8 @@ func GetCmdQueryFeederDelegation() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryMissCounter implements the miss counter query command.
-func GetCmdQueryMissCounter() *cobra.Command {
+// QueryMissCounter implements the miss counter query command.
+func QueryMissCounter() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "miss-counter [validator]",
 		Args:  cobra.ExactArgs(1),
@@ -257,8 +257,8 @@ func GetCmdQueryMissCounter() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQuerySlashWindow implements the slash window query command.
-func GetCmdQuerySlashWindow() *cobra.Command {
+// QuerySlashWindow implements the slash window query command.
+func QuerySlashWindow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "slash-window",
 		Short: "Query the current slash window progress",
@@ -278,8 +278,8 @@ func GetCmdQuerySlashWindow() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryHistoricAvgPrice implements the historic avg price command.
-func GetCmdQueryHistoricAvgPrice() *cobra.Command {
+// QueryHistoricAvgPrice implements the historic avg price command.
+func QueryHistoricAvgPrice() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "avg-price [denom]",
 		Short:   "Query the historic avg price for denom",

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -23,17 +23,17 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdDelegateFeedConsent(),
-		GetCmdAggregateExchangeRatePrevote(),
-		GetCmdAggregateExchangeRateVote(),
+		DelegateFeedConsent(),
+		AggregateExchangeRatePrevote(),
+		AggregateExchangeRateVote(),
 	)
 
 	return cmd
 }
 
-// GetCmdDelegateFeedConsent creates a Cobra command to generate or
+// DelegateFeedConsent creates a Cobra command to generate or
 // broadcast a transaction with a MsgDelegateFeedConsent message.
-func GetCmdDelegateFeedConsent() *cobra.Command {
+func DelegateFeedConsent() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegate-feed-consent [operator] [feeder]",
 		Args:  cobra.ExactArgs(2),
@@ -68,9 +68,9 @@ func GetCmdDelegateFeedConsent() *cobra.Command {
 	return cmd
 }
 
-// GetCmdAggregateExchangeRatePrevote creates a Cobra command to generate or
+// AggregateExchangeRatePrevote creates a Cobra command to generate or
 // broadcast a transaction with a MsgAggregateExchangeRatePrevote message.
-func GetCmdAggregateExchangeRatePrevote() *cobra.Command {
+func AggregateExchangeRatePrevote() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rate-prevote [hash] [validator-address]",
 		Args:  cobra.MinimumNArgs(1),
@@ -117,9 +117,9 @@ func GetCmdAggregateExchangeRatePrevote() *cobra.Command {
 	return cmd
 }
 
-// GetCmdAggregateExchangeRateVote creates a Cobra command to generate or
+// AggregateExchangeRateVote creates a Cobra command to generate or
 // broadcast a transaction with a NewMsgAggregateExchangeRateVote message.
-func GetCmdAggregateExchangeRateVote() *cobra.Command {
+func AggregateExchangeRateVote() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rate-vote [salt] [exchange-rates] [validator-address]",
 		Args:  cobra.MinimumNArgs(2),

--- a/x/oracle/client/tests/suite.go
+++ b/x/oracle/client/tests/suite.go
@@ -95,7 +95,7 @@ func (s *IntegrationTestSuite) TestDelegateFeedConsent() {
 		s.Run(tc.name, func() {
 			clientCtx := val.ClientCtx
 
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdDelegateFeedConsent(), tc.args)
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.DelegateFeedConsent(), tc.args)
 			if tc.expectErr {
 				s.Require().Error(err)
 			} else {
@@ -151,7 +151,7 @@ func (s *IntegrationTestSuite) TestQueryFeedDelegate() {
 
 		s.Run(tc.name, func() {
 			tc.args = append(tc.args, fmt.Sprintf("--%s=json", tmcli.OutputFlag))
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdQueryFeederDelegation(), tc.args)
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.QueryFeederDelegation(), tc.args)
 			if tc.expectErr {
 				s.Require().Error(err)
 			} else {
@@ -169,7 +169,7 @@ func (s *IntegrationTestSuite) TestQueryExchangeRates() {
 	args := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 	}
-	out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdQueryExchangeRates(), args)
+	out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.QueryExchangeRates(), args)
 	s.Require().NoError(err)
 
 	var res types.QueryExchangeRatesResponse
@@ -187,7 +187,7 @@ func (s *IntegrationTestSuite) TestQueryParams() {
 	args := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 	}
-	out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdQueryParams(), args)
+	out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.QueryParams(), args)
 	s.Require().NoError(err)
 
 	var res types.QueryParamsResponse
@@ -221,7 +221,7 @@ func (s *IntegrationTestSuite) TestQueryExchangeRate() {
 		tc := tc
 
 		s.Run(tc.name, func() {
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.GetCmdQueryExchangeRate(), tc.args)
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cli.QueryExchangeRate(), tc.args)
 			if tc.expectErr {
 				s.Require().Error(err)
 			} else {

--- a/x/uibc/client/cli/query.go
+++ b/x/uibc/client/cli/query.go
@@ -21,16 +21,16 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		GetCmdQueryParams(),
+		QueryParams(),
 		GetOutflows(),
 	)
 
 	return cmd
 }
 
-// GetCmdQueryParams creates a Cobra command to query for the x/uibc
+// QueryParams creates a Cobra command to query for the x/uibc
 // module parameters.
-func GetCmdQueryParams() *cobra.Command {
+func QueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Args:  cobra.NoArgs,

--- a/x/uibc/client/tests/query_test.go
+++ b/x/uibc/client/tests/query_test.go
@@ -16,7 +16,7 @@ func (s *IntegrationTests) TestQueryParams(_ *testing.T) {
 	queries := []itestsuite.TestQuery{
 		{
 			Name:    "Query params",
-			Command: cli.GetCmdQueryParams(),
+			Command: cli.QueryParams(),
 			Args: []string{
 				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 			},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

closes: #2039 

Removes `GetCmd` prefix from cli commands' builders



