### PR TITLE
chore: change consensus.block.max_size to 4 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [2285](https://github.com/umee-network/umee/pull/2285) Upgrade Cosmos SDK to v0.46.15.
-- [2288](https://github.com/umee-network/umee/pull/2288) Change `consensus.block.max_size` to 6MB. 
+- [2288](https://github.com/umee-network/umee/pull/2288) Change `consensus.block.max_size` to 6MB.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [2285](https://github.com/umee-network/umee/pull/2285) Upgrade Cosmos SDK to v0.46.15.
+- [2288](https://github.com/umee-network/umee/pull/2288) Change `consensus.block.max_size` to 6MB. 
 
 ### Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,17 +15,15 @@ Highlights:
 - Add spot price fields to account summary, and ensure all other fields use leverage logic prices.
 - Fix avg params storage for x/oracle.
 - Emergency Groups are able to do security adjustments in x/metoken.
+- Reduced `consensus.block.max_size` to 6MB.
 
 [CHANGELOG](CHANGELOG.md)
 
-### Emergency Groups
+### meTokens
 
-Currently, any parameter update requires going through a standard governance process, which takes 4 days. In a critical situation we need to act immediately:
+_meTokens_ is an abbreviation for Multi-Variant Elastic Tokens. We describe them as a general-purpose packaged asset builder. Simply put, they are tools to index multiple assets, which allows holders to build composable indexes that spread the risk associated with each asset bundled in an index.
 
-- Control IBC Quota parameters (eg disable IBC)
-- apply safe updates to oracle, leverage or incentive module parameters.
-
-Emergency Group can trigger safe parameter updates at any time as a standard transaction. The Emergency Group address is controlled by the Umee Chain governance (`x/gov`) and can be disabled at any time.
+MeTokens offer a way to build DeFi alternatives to TradFi and Web2 financial products. Think of a better, more liquid version of ETFs or mortgage-backed securities. The scope of buildable products will vary from builder to builder as the protocol allows for the creation of some of the most diverse use cases in the Cosmos Ecosystem.
 
 ### Upgrade instructions
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ Highlights:
 - Add spot price fields to account summary, and ensure all other fields use leverage logic prices.
 - Fix avg params storage for x/oracle.
 - Emergency Groups are able to do security adjustments in x/metoken.
-- Reduced `consensus.block.max_size` to 6MB.
+- Reduced `consensus.block.max_size` to 4 MB.
 
 [CHANGELOG](CHANGELOG.md)
 
@@ -24,6 +24,15 @@ Highlights:
 _meTokens_ is an abbreviation for Multi-Variant Elastic Tokens. We describe them as a general-purpose packaged asset builder. Simply put, they are tools to index multiple assets, which allows holders to build composable indexes that spread the risk associated with each asset bundled in an index.
 
 MeTokens offer a way to build DeFi alternatives to TradFi and Web2 financial products. Think of a better, more liquid version of ETFs or mortgage-backed securities. The scope of buildable products will vary from builder to builder as the protocol allows for the creation of some of the most diverse use cases in the Cosmos Ecosystem.
+
+### Validators
+
+Following recent [asa-2023-002](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604) security advisory we decreased the max block size to 4 MB.
+Based on Notional [analysis](https://github.com/notional-labs/placid#reduce-the-size-of-your-chains-mempool-in-bytes), mempool size should be adjusted as well. We recommend to set it to `15 * 4 MB` (15 x block size):
+
+```toml
+max_txs_bytes = 60000000
+```
 
 ### Upgrade instructions
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -77,7 +77,7 @@ func (app *UmeeApp) registerUpgrade6_1(planName string, upgradeInfo upgradetypes
 			// reference: (today) avg block size in Ethereum is 170kb
 			// Cosmwasm binaries can be few hundreds KB up to 3MB
 			// our blocks with oracle txs as JSON are about 80kB, so protobuf should be less than 40kB.
-			var newMaxBytes int64 = 6_000_000 // 6 MB
+			var newMaxBytes int64 = 4_000_000 // 4 MB
 			p := app.GetConsensusParams(ctx)
 			ctx.Logger().Info("Changing consensus params", "prev", p.Block.MaxBytes, "new", newMaxBytes)
 			p.Block.MaxBytes = newMaxBytes

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -74,6 +74,12 @@ func (app *UmeeApp) registerUpgrade6_1(planName string, upgradeInfo upgradetypes
 			oracleUpgrader := oraclemigrator.NewMigrator(&app.OracleKeeper)
 			oracleUpgrader.ExgRatesWithTimestamp(ctx)
 
+			var newMaxBytes int64 = 10_000_000 // 10 MB
+			p := app.GetConsensusParams(ctx)
+			ctx.Logger().Info("Changing consensus params", "prev", p.Block.MaxBytes, "new", newMaxBytes)
+			p.Block.MaxBytes = newMaxBytes
+			app.StoreConsensusParams(ctx, p)
+
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		},
 	)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -74,7 +74,10 @@ func (app *UmeeApp) registerUpgrade6_1(planName string, upgradeInfo upgradetypes
 			oracleUpgrader := oraclemigrator.NewMigrator(&app.OracleKeeper)
 			oracleUpgrader.ExgRatesWithTimestamp(ctx)
 
-			var newMaxBytes int64 = 10_000_000 // 10 MB
+			// reference: (today) avg block size in Ethereum is 170kb
+			// Cosmwasm binaries can be few hundreds KB up to 3MB
+			// our blocks with oracle txs as JSON are about 80kB, so protobuf should be less than 40kB.
+			var newMaxBytes int64 = 6_000_000 // 6 MB
 			p := app.GetConsensusParams(ctx)
 			ctx.Logger().Info("Changing consensus params", "prev", p.Block.MaxBytes, "new", newMaxBytes)
 			p.Block.MaxBytes = newMaxBytes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

As per Amulet team analysis, the existing 21MB block size may expose security risk and teams should consider reducing it. In this PR we reduce it to 4 MB, giving enough room for Cosmowasm deployments and big transactions. Blocks full of oracle txs are less than 40kB.