### PR TITLE
fix: git diff file matching for go mod/sum

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: golang/govulncheck-action@v1.0.1

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4
@@ -58,6 +59,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4
@@ -87,6 +89,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4
@@ -115,6 +118,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - name: Setup go
@@ -71,6 +72,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4
@@ -102,6 +104,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
       - uses: actions/setup-go@v4
@@ -127,6 +130,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+          FILES: |
             go.mod
             go.sum
 


### PR DESCRIPTION
See actions like

https://github.com/umee-network/umee/actions/runs/7027225731/job/19121250001

Build tests are being skipped when only go.mod or go.sum are changed. This allows dependabot updates which cause build to fail to merge without warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced GitHub workflow configurations to include specific files for vulnerability checks and processing in automated jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->