### PR TITLE
docs: v6.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## v6.2.0 - 2023-12-01
+
 ### Bug Fixes
 
 - [2315](https://github.com/umee-network/umee/pull/2215) Improve reliability of MaxBorrow, MaxWithdraw when special asset pairs present.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [Release procedure](CONTRIBUTING.md#release-procedure) for more information 
 |    v5.2.x    |    ✓    | v0.46.13+  | v6.2.x |   ---   |  umee/v2.1.6+  |   umee/v4 v1.5.3-umee-10   |  v1.2.4   |
 |    v6.0.x    |    ✓    | v0.46.14+  | v6.2.x |   ---   | umee/v2.1.6-1+ |            ---             |  v1.3.0   |
 |    v6.1.x    |    ✓    | v0.46.15+  | v6.2.x |   ---   |  umee/v2.1.7+  |            ---             |  v1.3.0   |
-|    v6.2.x    |    ✓    |  v0.47.5+  | v7.2.x |   ---   |  umee/v2.3.0   |            ---             |  v1.5.0   |
+|    v6.2.x    |    ✓    |  v0.47.6+  | v7.2.x |   ---   |  umee/v2.3.0   |            ---             |  v1.5.0   |
 
 #### Price Feeder
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 Release Procedure is defined in the [CONTRIBUTING](CONTRIBUTING.md#release-procedure) document.
 
-## v6.2.0-beta
+## v6.2.0
 
 Highlights:
 
@@ -31,7 +31,9 @@ Highlights:
 
 Price Feeder `< umee/v2.3.0` is not compatible with Cosmos SDK v0.47. Validators must update to `umee/v2.3.0` or newer.
 
-Please make sure your transactions are going through. If you see _out of gas_ in your transactions ([example](https://explorer.network.umee.cc/Canon-4/tx/74078158E2739CBF7EEA30D6BE673D207338E6686129717A4CED546F36F07CD7)). If you see out of gas errors, please increase `gas_adjustment` in your `price-feeder.toml`.
+During the testnet upgrade, we noticed miss counters increasing dramatically. Please make sure your transactions are going through. If you see _out of gas_ in your transactions ([example](https://explorer.network.umee.cc/Canon-4/tx/74078158E2739CBF7EEA30D6BE673D207338E6686129717A4CED546F36F07CD7)), please increase `gas_adjustment` to `2.0` in your `price-feeder.toml`. 
+
+We recommend to actively track your miss counters and making sure you follow the [latest currency-pairs config](https://github.com/ojo-network/price-feeder/blob/umee/umee-provider-config/currency-pairs.toml) (note the `umee` branch).
 
 #### libwasmvm update
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ Highlights:
   2. new lifting conditions is added: IBC outflows are possible if (1.) fails, but
      - sum outflows of all tokens <= `$1M +  InflowOutflowQuotaRate * sum_of_all_inflows`;
      - and token outflows <= `$0.9M + InflowOutflowQuotaRate * token_inflows`.
-  See [IBC Quota Design](./x/uibc/README.md#design) for more details.
+       See [IBC Quota Design](./x/uibc/README.md#design) for more details.
 
 [CHANGELOG](CHANGELOG.md)
 
@@ -31,7 +31,7 @@ Highlights:
 
 Price Feeder `< umee/v2.3.0` is not compatible with Cosmos SDK v0.47. Validators must update to `umee/v2.3.0` or newer.
 
-During the testnet upgrade, we noticed miss counters increasing dramatically. Please make sure your transactions are going through. If you see _out of gas_ in your transactions ([example](https://explorer.network.umee.cc/Canon-4/tx/74078158E2739CBF7EEA30D6BE673D207338E6686129717A4CED546F36F07CD7)), please increase `gas_adjustment` to `2.0` in your `price-feeder.toml`. 
+During the testnet upgrade, we noticed miss counters increasing dramatically. Please make sure your transactions are going through. If you see _out of gas_ in your transactions ([example](https://explorer.network.umee.cc/Canon-4/tx/74078158E2739CBF7EEA30D6BE673D207338E6686129717A4CED546F36F07CD7)), please increase `gas_adjustment` to `2.0` in your `price-feeder.toml`.
 
 We recommend to actively track your miss counters and making sure you follow the [latest currency-pairs config](https://github.com/ojo-network/price-feeder/blob/umee/umee-provider-config/currency-pairs.toml) (note the `umee` branch).
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to version `v6.2.0 - 2023-12-01`.
  - Revised the README to reflect the new version number for the Price Feeder in the v6.2.x release.

- **Release Notes**
  - Upgraded from "v6.2.0-beta" to the official "v6.2.0" release.
  - Recommended an increase in `gas_adjustment` to `2.0` in the configuration to prevent "out of gas" errors.
  - Advised on actively monitoring miss counters and updating to the latest currency-pairs configuration for optimal performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->