### PR TITLE
feat: adjust interest rate algorithm and associated token param rules

### DIFF
--- a/x/leverage/keeper/interest_test.go
+++ b/x/leverage/keeper/interest_test.go
@@ -69,12 +69,19 @@ func (s *IntegrationTestSuite) TestDynamicInterest() {
 	rate = app.LeverageKeeper.DeriveBorrowAPY(ctx, appparams.BondDenom)
 	require.Equal(sdk.MustNewDecFromStr("0.22"), rate)
 
-	// user borrows 100 more umee (ignores collateral), utilization 900/1000
-	s.forceBorrow(addr, coin.New(appparams.BondDenom, 100_000000))
+	// user borrows 50 more umee (ignores collateral), utilization 850/1000
+	s.forceBorrow(addr, coin.New(appparams.BondDenom, 50_000000))
 
-	// Between kink interest and max (90% utilization)
+	// Between kink and max interest rate (85% utilization)
 	rate = app.LeverageKeeper.DeriveBorrowAPY(ctx, appparams.BondDenom)
 	require.Equal(sdk.MustNewDecFromStr("0.87"), rate)
+
+	// user borrows 50 more umee (ignores collateral), utilization 900/1000 = max supply utilization
+	s.forceBorrow(addr, coin.New(appparams.BondDenom, 50_000000))
+
+	// Max interest rate (90% utilization)
+	rate = app.LeverageKeeper.DeriveBorrowAPY(ctx, appparams.BondDenom)
+	require.Equal(sdk.MustNewDecFromStr("1.52"), rate)
 
 	// user borrows 100 more umee (ignores collateral), utilization 1000/1000
 	s.forceBorrow(addr, coin.New(appparams.BondDenom, 100_000000))

--- a/x/leverage/keeper/msg_server_test.go
+++ b/x/leverage/keeper/msg_server_test.go
@@ -1976,9 +1976,10 @@ func (s *IntegrationTestSuite) TestMsgMaxBorrow_DecreasingMaxSupplyUtilization()
 	app, ctx, srv, require := s.app, s.ctx, s.msgSrvr, s.Require()
 
 	// overriding UMEE token settings, changing MinCollateralLiquidity to 0.2
-	// and MaxSupplyUtilization to 0.7
+	// and MaxSupplyUtilization to 0.7 (also adjusting kink for token validity)
 	umeeToken := newToken(umeeDenom, "UMEE", 6)
 	umeeToken.MinCollateralLiquidity = sdk.MustNewDecFromStr("0.2")
+	umeeToken.KinkUtilization = sdk.MustNewDecFromStr("0.6")
 	umeeToken.MaxSupplyUtilization = sdk.MustNewDecFromStr("0.7")
 	require.NoError(app.LeverageKeeper.SetTokenSettings(ctx, umeeToken))
 
@@ -2022,9 +2023,10 @@ func (s *IntegrationTestSuite) TestMsgMaxBorrow_ZeroAvailableBasedOnMaxSupplyUti
 	app, ctx, srv, require := s.app, s.ctx, s.msgSrvr, s.Require()
 
 	// overriding UMEE token settings, changing MinCollateralLiquidity to 0.2
-	// and MaxSupplyUtilization to 0.5
+	// and MaxSupplyUtilization to 0.5 (also adjusting kink for token validity)
 	umeeToken := newToken(umeeDenom, "UMEE", 6)
 	umeeToken.MinCollateralLiquidity = sdk.MustNewDecFromStr("0.2")
+	umeeToken.KinkUtilization = sdk.MustNewDecFromStr("0.45")
 	umeeToken.MaxSupplyUtilization = sdk.MustNewDecFromStr("0.5")
 	require.NoError(app.LeverageKeeper.SetTokenSettings(ctx, umeeToken))
 

--- a/x/leverage/types/token.go
+++ b/x/leverage/types/token.go
@@ -53,11 +53,32 @@ func (t Token) Validate() error {
 		)
 	}
 
-	// Kink utilization rate ranges between 0 and 1, exclusive. This prevents
-	// multiple interest rates being defined at exactly 0% or 100% utilization
-	// e.g. kink at 0%, 2% base borrow rate, 4% borrow rate at kink.
-	if !t.KinkUtilization.IsPositive() || t.KinkUtilization.GTE(one) {
+	// Kink utilization rate ranges between 0 and 1, inclusive.
+	if t.KinkUtilization.IsNegative() || t.KinkUtilization.GT(one) {
 		return fmt.Errorf("invalid kink utilization rate: %s", t.KinkUtilization)
+	}
+	// The following rules ensure the utilization:APY graph is continuous
+	if t.KinkUtilization.GT(t.MaxSupplyUtilization) {
+		return fmt.Errorf("kink utilization (%s) cannot be greater than than max supply utilization (%s)",
+			t.KinkUtilization, t.MaxSupplyUtilization)
+	}
+	if t.KinkUtilization.Equal(t.MaxSupplyUtilization) && !t.MaxBorrowRate.Equal(t.KinkBorrowRate) {
+		return fmt.Errorf(
+			"since kink utilization equals max supply utilization, kink borrow rate must equal max borrow rate (%s)",
+			t.MaxBorrowRate,
+		)
+	}
+	if t.KinkUtilization.IsZero() && !t.KinkBorrowRate.Equal(t.BaseBorrowRate) {
+		return fmt.Errorf(
+			"since kink utilization equals zero, kink borrow rate must equal base borrow rate (%s)",
+			t.BaseBorrowRate,
+		)
+	}
+	if t.MaxSupplyUtilization.IsZero() && !t.MaxBorrowRate.Equal(t.BaseBorrowRate) {
+		return fmt.Errorf(
+			"since max supply utilization equals zero, max borrow rate must equal base borrow rate (%s)",
+			t.BaseBorrowRate,
+		)
 	}
 
 	// interest rates are non-negative; they do not need to have a maximum value


### PR DESCRIPTION
This will also require a migration (or a preemptive registry update gov prop) on mainnet and canon to make existing tokens valid.

For example, mainnet UMEE has a max supply utilization below its kink utilization