### PR TITLE
feat: handle fallback address with memo execution and adjust message coins

### DIFF
--- a/x/uibc/gmp/gmp_middleware.go
+++ b/x/uibc/gmp/gmp_middleware.go
@@ -2,87 +2,69 @@ package gmp
 
 import (
 	"encoding/json"
-	"fmt"
 
-	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ics20types "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
-
-	"github.com/umee-network/umee/v6/x/uibc"
 )
 
 type Handler struct {
 }
 
-var _ GeneralMessageHandler = Handler{}
-
 func NewHandler() *Handler {
 	return &Handler{}
 }
 
-func (h Handler) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, data ics20types.FungibleTokenPacketData,
+func (h Handler) OnRecvPacket(ctx sdk.Context, coinReceived sdk.Coin, memo string, receiver sdk.AccAddress,
 ) error {
 	logger := ctx.Logger().With("handler", "gmp_handler")
 	var msg Message
 	var err error
 
-	if err = json.Unmarshal([]byte(data.GetMemo()), &msg); err != nil {
-		logger.With(err).Error("cannot unmarshal memo")
+	if err = json.Unmarshal([]byte(memo), &msg); err != nil {
+		logger.Error("cannot unmarshal memo", "err", err)
 		return err
 	}
 
 	switch msg.Type {
 	case TypeGeneralMessage:
-		err := h.HandleGeneralMessage(ctx, msg.SourceAddress, msg.SourceAddress, data.Receiver, msg.Payload)
+		err := h.HandleGeneralMessage(ctx, msg.SourceAddress, msg.SourceAddress, receiver, msg.Payload)
 		if err != nil {
 			logger.Error("err at HandleGeneralMessage", err)
 		}
 	case TypeGeneralMessageWithToken:
-		// parse the transfer amount
-		amt, ok := sdk.NewIntFromString(data.Amount)
-		if !ok {
-			return errors.Wrapf(
-				ics20types.ErrInvalidAmount,
-				"unable to parse transfer amount (%s) into sdk.Int",
-				data.Amount,
-			)
-		}
-		denom := uibc.ExtractDenomFromPacketOnRecv(packet, data.Denom)
-		err := h.HandleGeneralMessageWithToken(ctx, msg.SourceAddress, msg.SourceAddress, data.Receiver,
-			msg.Payload, sdk.NewCoin(denom, amt))
-
+		err := h.HandleGeneralMessageWithToken(
+			ctx, msg.SourceAddress, msg.SourceAddress, receiver, msg.Payload, coinReceived)
 		if err != nil {
 			logger.Error("err at HandleGeneralMessageWithToken", err)
 		}
 	default:
-		logger.With(fmt.Errorf("unrecognized message type: %d", msg.Type)).Error("unrecognized gmp message")
+		logger.Error("unrecognized gmp message type: %d", msg.Type)
 	}
 
 	return err
 }
 
-func (h Handler) HandleGeneralMessage(ctx sdk.Context, srcChain, srcAddress string, destAddress string,
+func (h Handler) HandleGeneralMessage(ctx sdk.Context, srcChain, srcAddress string, receiver sdk.AccAddress,
 	payload []byte) error {
 	ctx.Logger().Info("HandleGeneralMessage called",
 		"srcChain", srcChain,
 		"srcAddress", srcAddress,
-		"destAddress", destAddress,
+		"receiver", receiver,
 		"payload", payload,
 		"handler", "gmp-handler",
 	)
 	return nil
 }
 
-func (h Handler) HandleGeneralMessageWithToken(ctx sdk.Context, srcChain, srcAddress string, destAddress string,
-	payload []byte, coin sdk.Coin) error {
+func (h Handler) HandleGeneralMessageWithToken(ctx sdk.Context, srcChain, srcAddress string,
+	receiver sdk.AccAddress, payload []byte, coin sdk.Coin) error {
+
 	ctx.Logger().Info("HandleGeneralMessageWithToken called",
 		"srcChain", srcChain,
 		"srcAddress", srcAddress,
-		"destAddress", destAddress,
+		"receiver", receiver,
 		"payload", payload,
 		"coin", coin,
-		"handler", "gmp-handler",
+		"handler", "gmp-token-handler",
 	)
 	return nil
 }

--- a/x/uibc/gmp/types.go
+++ b/x/uibc/gmp/types.go
@@ -1,13 +1,5 @@
 package gmp
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
-
-type GeneralMessageHandler interface {
-	HandleGeneralMessage(ctx sdk.Context, srcChain, srcAddress string, destAddress string, payload []byte) error
-	HandleGeneralMessageWithToken(ctx sdk.Context, srcChain, srcAddress string, destAddress string,
-		payload []byte, coin sdk.Coin) error
-}
-
 const (
 	DefaultGMPAddress = "axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5"
 )

--- a/x/uibc/uics20/ibc_module.go
+++ b/x/uibc/uics20/ibc_module.go
@@ -69,13 +69,13 @@ func (im ICS20Module) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, 
 
 	mh := MemoHandler{cdc: im.cdc, leverage: im.leverage}
 	fallbackReceiver, events, err := mh.onRecvPacketPrepare(&ctx, packet, ftData)
-	if err != nil && err != memoValidationErr {
+	if err != nil && err != errMemoValidation {
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
 	var transferCtx = ctx
 	var ctxFlush func()
 	if fallbackReceiver != nil {
-		if err == memoValidationErr {
+		if err == errMemoValidation {
 			ftData.Receiver = fallbackReceiver.String()
 			events = append(events, "overwrite receiver to fallback_addr="+ftData.Receiver)
 			if packet.Data, err = json.Marshal(ftData); err != nil {

--- a/x/uibc/uics20/ibc_module.go
+++ b/x/uibc/uics20/ibc_module.go
@@ -67,32 +67,51 @@ func (im ICS20Module) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, 
 	// smaller than the amount originally sent (various fees). We need to be sure that there is
 	// no other middleware that can change packet data or amounts.
 
-	mh := MemoHandler{im.cdc, im.leverage}
-	msgs, overwriteReceiver, events, err := mh.onRecvPacketPre(&ctx, packet, ftData)
-	if err != nil {
+	mh := MemoHandler{cdc: im.cdc, leverage: im.leverage}
+	fallbackReceiver, events, err := mh.onRecvPacketPrepare(&ctx, packet, ftData)
+	if err != nil && err != memoValidationErr {
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
-	if overwriteReceiver != nil {
-		ftData.Receiver = overwriteReceiver.String()
-		msgs = nil // we don't want to execute hooks when we set fallback address.
-		events = append(events, "overwrite receiver to fallback_addr="+ftData.Receiver)
-		if packet.Data, err = json.Marshal(ftData); err != nil {
-			return channeltypes.NewErrorAcknowledgement(err)
+	var transferCtx = ctx
+	var ctxFlush func()
+	if fallbackReceiver != nil {
+		if err == memoValidationErr {
+			ftData.Receiver = fallbackReceiver.String()
+			events = append(events, "overwrite receiver to fallback_addr="+ftData.Receiver)
+			if packet.Data, err = json.Marshal(ftData); err != nil {
+				return channeltypes.NewErrorAcknowledgement(err)
+			}
+		} else {
+			// create a new cache context: we have a fallback receiver and memo is valid.
+			// we will discard it when the execution fails to move the funds to the fallbackAddress.
+			transferCtx, ctxFlush = ctx.CacheContext()
 		}
 	}
+	execCtx, execCtxFlush := transferCtx.CacheContext()
 
 	// call transfer module app
-	ack := im.IBCModule.OnRecvPacket(ctx, packet, relayer)
+	ack := im.IBCModule.OnRecvPacket(transferCtx, packet, relayer)
 	if !ack.Success() {
-		return ack
+		goto end
 	}
 
-	if err := mh.dispatchMemoMsgs(&ctx, msgs); err != nil {
+	if err = mh.execute(&execCtx); err != nil {
 		events = append(events, "can't handle ICS20 memo err = "+err.Error())
+		// if we created a new cache context, then we can discard it, and repeate the transfer to
+		// the fallback address
+		if ctxFlush != nil {
+			ctxFlush = nil // discard the context
+			ack = im.IBCModule.OnRecvPacket(ctx, packet, relayer)
+		}
+	} else {
+		execCtxFlush()
 	}
 
+end:
+	if ctxFlush != nil {
+		ctxFlush()
+	}
 	im.emitEvents(ctx.EventManager(), recvPacketLogger(&ctx), "ics20-memo-hook", events)
-
 	return ack
 }
 

--- a/x/uibc/uics20/memo_handler.go
+++ b/x/uibc/uics20/memo_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/umee-network/umee/v6/x/uibc/gmp"
 )
 
-var memoValidationErr = errors.New("ics20 memo validation error")
+var errMemoValidation = errors.New("ics20 memo validation error")
 
 type MemoHandler struct {
 	cdc      codec.JSONCodec
@@ -81,7 +81,7 @@ func (mh *MemoHandler) onRecvPacketPrepare(
 
 	if err := mh.validateMemoMsg(); err != nil {
 		events = append(events, "memo.messages are not valid, err: "+err.Error())
-		return fallbackReceiver, events, memoValidationErr
+		return fallbackReceiver, events, errMemoValidation
 	}
 
 	return fallbackReceiver, events, nil

--- a/x/uibc/uics20/memo_handler.go
+++ b/x/uibc/uics20/memo_handler.go
@@ -37,6 +37,7 @@ func (mh *MemoHandler) onRecvPacketPrepare(
 	ctx *sdk.Context, packet ibcexported.PacketI, ftData ics20types.FungibleTokenPacketData,
 ) (sdk.AccAddress, []string, error) {
 	var events []string
+	var err error
 	mh.memo = ftData.Memo
 	amount, ok := sdk.NewIntFromString(ftData.Amount)
 	if !ok { // must not happen

--- a/x/uibc/uics20/memo_handler_test.go
+++ b/x/uibc/uics20/memo_handler_test.go
@@ -93,7 +93,10 @@ func TestValidateMemoMsg(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		err := mh.validateMemoMsg(receiver, sent, tc.msgs)
+		mh.receiver = receiver
+		mh.received = sent
+		mh.msgs = tc.msgs
+		err := mh.validateMemoMsg()
 		if tc.errstr != "" {
 			assert.ErrorContains(err, tc.errstr, "test: %d", i)
 		} else {

--- a/x/uibc/uics20/memo_handler_test.go
+++ b/x/uibc/uics20/memo_handler_test.go
@@ -140,3 +140,23 @@ func TestMsgMarshalling(t *testing.T) {
 	memo2, err = deserializeMemo(cdc, bz)
 	assert.Error(err)
 }
+
+func TestAdjustOperatedCoin(t *testing.T) {
+	received := sdk.NewInt64Coin("atom", 10)
+	tcs := []struct {
+		operated       sdk.Coin
+		expectedAmount int64
+		err            error
+	}{
+		{sdk.NewInt64Coin("other", 1), 1, errNoSubCoins},
+		{sdk.NewInt64Coin("atom", 1), 1, nil},
+		{sdk.NewInt64Coin("atom", 10), 10, nil},
+		{sdk.NewInt64Coin("atom", 12), 10, nil},
+	}
+
+	for i, tc := range tcs {
+		err := adjustOperatedCoin(received, &tc.operated)
+		assert.ErrorIs(t, err, tc.err, "tc %d", i)
+		assert.Equal(t, tc.expectedAmount, tc.operated.Amount.Int64())
+	}
+}

--- a/x/uibc/uics20/memo_handler_test.go
+++ b/x/uibc/uics20/memo_handler_test.go
@@ -56,11 +56,13 @@ func TestValidateMemoMsg(t *testing.T) {
 		{[]sdk.Msg{goodMsgSupplyColl}, ""},
 		{[]sdk.Msg{goodMsgLiquidate}, ""}, // in handlers v2 this will be a good message
 
-		// messages[0] use more assets than the transfer
-		{[]sdk.Msg{goodMsgSupply11}, errNoSubCoins},
-		{[]sdk.Msg{goodMsgSupplyColl11}, errNoSubCoins},
-		{[]sdk.Msg{goodMsgSupplyColl11}, errNoSubCoins},
-		{[]sdk.Msg{goodMsgLiquidate11}, errNoSubCoins},
+		// messages[0] use more assets than the transfer -> OK
+		{[]sdk.Msg{goodMsgSupply11}, ""},
+		{[]sdk.Msg{goodMsgSupplyColl11}, ""},
+		{[]sdk.Msg{goodMsgSupplyColl11}, ""},
+		{[]sdk.Msg{goodMsgLiquidate11}, ""},
+
+		{[]sdk.Msg{ltypes.NewMsgSupply(receiver, coin.New("other", 1))}, errNoSubCoins},
 
 		// wrong message types
 		{[]sdk.Msg{goodMsgBorrow}, errMsg0type},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

1. The amount of IBC tokens we sent might be different than the amount we receive (eg operator can take fees). So, if a user will set a maximum amount (eg in MsgSupply) then we may get an error when executing the message. In that case we need to adjust the amount in the message.
2. chore: refactore ibc memo handling to unify GMP and standard hooks
3. support receiver fallback address in case hook execution fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Renamed and updated methods in `MemoHandler` for improved memo parsing and preparation.
	- Refactored `ICS20Module` to handle memo validation errors and manage fallback receivers efficiently.
	- Improved test coverage in `memo_handler_test.go` for enhanced functionality testing.
- **New Features**
	- Added new fields and methods to `MemoHandler` for advanced memo handling capabilities.
- **Bug Fixes**
	- Addressed issues related to memo message validation and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->