### PR TITLE
Consider module max withdraw in max_withdraw query

### DIFF
--- a/x/leverage/keeper/grpc_query.go
+++ b/x/leverage/keeper/grpc_query.go
@@ -414,7 +414,12 @@ func (q Querier) MaxWithdraw(
 		// will be nil and the resulting value will be what
 		// can safely be withdrawn even with missing prices.
 		// On non-nil error here, max withdraw is zero.
-		uToken, _, err := q.userMaxWithdraw(ctx, addr, denom)
+		uToken, _, err := q.Keeper.userMaxWithdraw(ctx, addr, denom)
+		if err == nil {
+			var moduleMaxWithdraw sdk.Int
+			moduleMaxWithdraw, err = q.Keeper.ModuleMaxWithdraw(ctx, uToken)
+			uToken.Amount = sdk.MinInt(uToken.Amount, moduleMaxWithdraw)
+		}
 		if err == nil && uToken.IsPositive() {
 			token, err := q.ToToken(ctx, uToken)
 			if err != nil {

--- a/x/leverage/keeper/grpc_query.go
+++ b/x/leverage/keeper/grpc_query.go
@@ -419,18 +419,16 @@ func (q Querier) MaxWithdraw(
 		if err != nil {
 			if nonOracleError(err) {
 				return nil, err
-			} else {
-				continue
 			}
+			continue
 		}
 
 		moduleMaxWithdrawUToken, err := q.Keeper.ModuleMaxWithdraw(ctx, userMaxWithdrawUToken)
 		if err != nil {
 			if nonOracleError(err) {
 				return nil, err
-			} else {
-				continue
 			}
+			continue
 		}
 
 		uToken := sdk.NewCoin(userMaxWithdrawUToken.Denom, sdk.MinInt(userMaxWithdrawUToken.Amount, moduleMaxWithdrawUToken))


### PR DESCRIPTION
Fix max_withdraw function so it considers MaxModuleWithdraw. 

There are cases in which MaxModuleWithdraw is smaller than user MaxWithdraw. When it happens umee allows user to select invalid withdraw amount that will result in error when broadcasting transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the calculation for maximum withdrawal amount for users, ensuring more accurate transaction limits.
	- Updated the `userMaxWithdraw` method call to use `q.Keeper.userMaxWithdraw` for better functionality.
	- Added logic to calculate the minimum value between `uToken.Amount` and `moduleMaxWithdraw` for enhanced processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->