### PR TITLE
fix(ugov amino): don't use proto.MessageName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Features
+
+### Bug Fixes
+
+- [2473](https://github.com/umee-network/umee/pull/2462) Correct x/ugov Amino registration for x/ugov messages (they don't have MessageName option).
+
 ## v6.4.0 - 2024-03-21
 
 ### Features
@@ -54,7 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-- [2462](https://github.com/umee-network/umee/pull/2462) (x/leverage) Take `MaxModuleWithdraw` into account when computing user `MaxWithdraw`. 
+- [2462](https://github.com/umee-network/umee/pull/2462) (x/leverage) Take `MaxModuleWithdraw` into account when computing user `MaxWithdraw`.
 
 ## v6.4.0-beta1 - 2024-03-11
 

--- a/x/auction/codec.go
+++ b/x/auction/codec.go
@@ -22,7 +22,7 @@ func init() {
 	amino.Seal()
 }
 
-// RegisterLegacyAminoCodec registers the necessary x/uibc interfaces and
+// RegisterLegacyAminoCodec registers the necessary x/auction interfaces and
 // concrete types on the provided LegacyAmino codec. These types are used for
 // Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {

--- a/x/ugov/codec.go
+++ b/x/ugov/codec.go
@@ -1,8 +1,6 @@
 package ugov
 
 import (
-	"github.com/cosmos/gogoproto/proto"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -30,7 +28,7 @@ func init() {
 // concrete types on the provided LegacyAmino codec. These types are used for
 // Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgGovUpdateMinGasPrice{}, proto.MessageName(&MsgGovUpdateMinGasPrice{}), nil)
+	cdc.RegisterConcrete(&MsgGovUpdateMinGasPrice{}, "umee/ugov/MsgGovUpdateMinGasPrice", nil)
 	cdc.RegisterConcrete(&MsgGovSetEmergencyGroup{}, "umee/ugov/MsgGovSetEmergencyGroup", nil)
 	cdc.RegisterConcrete(&MsgGovUpdateInflationParams{}, "umee/ugov/MsgGovUpdateInflationParams", nil)
 }

--- a/x/ugov/codec.go
+++ b/x/ugov/codec.go
@@ -24,7 +24,7 @@ func init() {
 	amino.Seal()
 }
 
-// RegisterLegacyAminoCodec registers the necessary x/uibc interfaces and
+// RegisterLegacyAminoCodec registers the necessary x/ugov interfaces and
 // concrete types on the provided LegacyAmino codec. These types are used for
 // Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated comments for clarity and accuracy in codebase documentation.
	- Changed registration of message types for better implementation.
- **Bug Fixes**
	- Corrected Amino registration for messages in x/ugov package.
- **Chores**
	- Removed unnecessary import to improve codebase efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->