### PR TITLE
chore(setup): use go v1.22

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
 
       - uses: actions/checkout@v4

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -26,5 +26,5 @@ jobs:
         id: govulncheck
         if: env.GIT_DIFF
         with:
-          go-version-input: 1.21
+          go-version-input: 1.22
           go-package: ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
 
       - name: golangci-lint main

--- a/.github/workflows/release-umee.yml
+++ b/.github/workflows/release-umee.yml
@@ -22,18 +22,18 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV
 
       # useful to test builds. However will require to add "push" rule to the "on" section
-      - name: generate and update swagger docs 
+      - name: generate and update swagger docs
         run: |
           make proto-swagger-gen
           make proto-update-swagger-docs
-      
+
       - name: goreleaser test-build
         uses: goreleaser/goreleaser-action@v5
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Enable:ReleaseBuild')

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Install runsim
         run: export GO111MODULE="on" && go install github.com/cosmos/tools/cmd/runsim@v1.0.0
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
       - name: Test application non-determinism
         if: env.GIT_DIFF
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
       - uses: actions/cache@v4
         if: env.GIT_DIFF
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
       - uses: actions/cache@v4
         if: env.GIT_DIFF
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
       - uses: actions/cache@v4
         if: env.GIT_DIFF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/cache@v4
         id: cache-go-tparse
         with:
@@ -52,7 +52,7 @@ jobs:
         if: steps.cache-binaries.outputs.cache-hit != 'true' && env.GIT_DIFF
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
         env:
           GOOS: ${{ matrix.targetos }}
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
       - name: Test and Create Coverage Report
         if: env.GIT_DIFF
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
 
       - name: Test E2E

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [2474](https://github.com/umee-network/umee/pull/2474) (proto) add `gogo.messagename_all` option to all messages.
 - [2494](https://github.com/umee-network/umee/pull/2494) Use go 1.22
 
-
-
 ### Bug Fixes
 
 - [2473](https://github.com/umee-network/umee/pull/2473) Correct x/ugov Amino registration for x/ugov messages (they don't have MessageName option).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [2474](https://github.com/umee-network/umee/pull/2474) (proto) add `gogo.messagename_all` option to all messages.
+- [2494](https://github.com/umee-network/umee/pull/2494) Use go 1.22
+
+
 
 ### Bug Fixes
 

--- a/contrib/images/umee.e2e-static.dockerfile
+++ b/contrib/images/umee.e2e-static.dockerfile
@@ -2,7 +2,7 @@
 # Creates static binaries, by building from the latest version of:
 # umeed, price-feeder.
 
-FROM golang:1.21-alpine3.18 AS builder
+FROM golang:1.22-alpine3.19 AS builder
 ENV PACKAGES make git gcc linux-headers build-base curl
 RUN apk add --no-cache $PACKAGES
 
@@ -25,7 +25,7 @@ RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make install && \
 
 
 ## Prepare the final clear binary
-FROM alpine:3.18
+FROM alpine:3.19
 EXPOSE 26656 26657 1317 9090 7171
 ENTRYPOINT ["umeed", "start"]
 

--- a/contrib/images/umee.e2e.dockerfile
+++ b/contrib/images/umee.e2e.dockerfile
@@ -1,7 +1,7 @@
 # Docker for e2e testing
 # Creates dynamic binaries, by building from the latest version of umeed
 
-FROM golang:1.21-bookworm AS builder
+FROM golang:1.22-bookworm AS builder
 ARG EXPERIMENTAL=true
 
 ## Download go module dependencies for umeed

--- a/contrib/images/umeed.dockerfile
+++ b/contrib/images/umeed.dockerfile
@@ -1,7 +1,7 @@
 # Stage-1: build
 # We use Debian Bullseye rather then Alpine because Alpine has problem building libwasmvm
 # - requires to download libwasmvm_muslc from external source. Build with glibc is straightforward.
-FROM golang:1.21-bookworm AS builder
+FROM golang:1.22-bookworm AS builder
 
 WORKDIR /src/
 # optimization: if go.sum didn't change, docker will use cached image

--- a/contrib/scripts/go-mod-tidy-all.sh
+++ b/contrib/scripts/go-mod-tidy-all.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 for modfile in $(find . -name go.mod); do
  echo "Updating $modfile"
- DIR=$(dirname $modfile)
- (cd $DIR; go mod tidy --compat=1.22)
+ DIR=$(dirname "$modfile")
+ (cd "$DIR"; go mod tidy --compat=1.22)
 done

--- a/contrib/scripts/go-mod-tidy-all.sh
+++ b/contrib/scripts/go-mod-tidy-all.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 for modfile in $(find . -name go.mod); do
  echo "Updating $modfile"
  DIR=$(dirname $modfile)
- (cd $DIR; go mod tidy --compat=1.21)
+ (cd $DIR; go mod tidy --compat=1.22)
 done

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/umee-network/umee/v6
 
-go 1.21
+go 1.22
 
 require (
 	cosmossdk.io/api v0.3.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Go version to 1.22 across various configurations and Dockerfiles to enhance performance and compatibility.
	- Minor formatting adjustments in workflow comments for clarity.
	- Updated `CHANGELOG.md` to reflect the changes related to Go 1.22 and `gogo.messagename_all` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->