### PR TITLE
fix: ibc transfer memo and receiver length check (#2551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## v6.5.0
+
+### Bug Fixes
+
+- [2551](https://github.com/umee-network/umee/pull/2551) Restrict length of IBC transfer memo and receiver fields.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## v6.5.0
+## Unreleased
 
 ### Bug Fixes
 
@@ -69,6 +69,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [2473](https://github.com/umee-network/umee/pull/2473) Correct x/ugov Amino registration for x/ugov messages (they don't have MessageName option).
 - [2547](https://github.com/umee-network/umee/pull/2547) Fix the `MissCounters` grpc-web get api result.
+
+## v6.5.0
+
+### Bug Fixes
+
+- [2551](https://github.com/umee-network/umee/pull/2551) Restrict length of IBC transfer memo and receiver fields.
 
 ## v6.4.1 - 2024-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-### Bug Fixes
-
-- [2551](https://github.com/umee-network/umee/pull/2551) Restrict length of IBC transfer memo and receiver fields.
-
 ### Features
 
 - [2472](https://github.com/umee-network/umee/pull/2472) un-wire the `crisis` module from umee app.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See [Release procedure](CONTRIBUTING.md#release-procedure) for more information 
 |    v6.3.x    |    ✓    |  v0.47.7+  | v7.3.1 |   ---   |  umee/v2.3.0+  |            ---             |  v1.5.0   |
 |    v6.4.x    |    x    | v0.47.10+  | v7.3.2 |   ---   |  umee/v2.4.1+  |            ---             |  v1.5.2   |
 |    v6.5.x    |    x    | v0.47.11+  | v7.5.1 |   ---   |  umee/v2.4.3+  |            ---             |  v1.5.2   |
+|    v6.6.x    |    x    | v0.47.11+  | v7.5.1 |   ---   |  umee/v2.4.3+  |            ---             |  v1.5.2   |
 
 #### Price Feeder
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 The Release Procedure is defined in the [CONTRIBUTING](CONTRIBUTING.md#release-procedure) document.
 
-## v6.5.0
+## v6.6.0
 
 Highlights:
 
@@ -18,15 +18,12 @@ Highlights:
 
 ### Auction module
 
-We propose a new Cosmos SDK module, that will provide mechanism for protocol owned auctions.
-
-UX Chain will now auction a portion of collected fees and introduce a token burning mechanism, unlocking a way to a potentially deflationary UX token.
-
+We propose a new Cosmos SDK module, that will provide mechanism for protocol owned auctions. UX Chain will now auction a portion of collected fees and introduce a token burning mechanism, unlocking a way to a potentially deflationary UX token. 
 Documentation: [x/auction/README.md](https://github.com/umee-network/umee/blob/v6.5.0/x/auction/README.md)
 
 ### Validators
 
-**Upgrade Title** (for Cosmovisor): **v6.5**.
+**Upgrade Title** (for Cosmovisor): **v6.6**.
 
 Update Price Feeder to `umee/2.4.3+`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,7 @@ Documentation: [x/auction/README.md](https://github.com/umee-network/umee/blob/v
 
 Update Price Feeder to `umee/2.4.3+`.
 
-NOTE: after the upgrade, you should restart your Price Feeder. We observed that Price Feeder doesn't correctly re-established a connection after the chain upgrade.
+NOTE: after the upgrade, you should restart your Price Feeder. We observed that Price Feeder doesn't correctly re-establish a connection after the chain upgrade.
 
 #### libwasmvm update
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,8 +18,8 @@ Highlights:
 
 ### Auction module
 
-We propose a new Cosmos SDK module, that will provide mechanism for protocol owned auctions. UX Chain will now auction a portion of collected fees and introduce a token burning mechanism, unlocking a way to a potentially deflationary UX token. 
-Documentation: [x/auction/README.md](https://github.com/umee-network/umee/blob/v6.5.0/x/auction/README.md)
+We propose a new Cosmos SDK module, that will provide mechanism for protocol owned auctions. UX Chain will now auction a portion of collected fees and introduce a token burning mechanism, unlocking a way to a potentially deflationary UX token.
+Documentation: [x/auction/README.md](https://github.com/umee-network/umee/blob/v6.6.0/x/auction/README.md)
 
 ### Validators
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -50,9 +50,9 @@ func (app UmeeApp) RegisterUpgradeHandlers() {
 	app.registerUpgrade6_0(upgradeInfo)
 	app.registerOutdatedPlaceholderUpgrade("v6.1")
 	app.registerOutdatedPlaceholderUpgrade("v6.2")
-	app.registerUpgrade("v6.3", upgradeInfo)
+	app.registerUpgrade("v6.3", upgradeInfo, nil, nil, nil)
 	app.registerUpgrade6_4(upgradeInfo)
-	app.registerUpgrade("v6.5", upgradeInfo)
+	app.registerUpgrade("v6.5", upgradeInfo, nil, nil, nil)
 
 	app.registerUpgrade6_6(upgradeInfo)
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -50,14 +50,15 @@ func (app UmeeApp) RegisterUpgradeHandlers() {
 	app.registerUpgrade6_0(upgradeInfo)
 	app.registerOutdatedPlaceholderUpgrade("v6.1")
 	app.registerOutdatedPlaceholderUpgrade("v6.2")
-	app.registerUpgrade("v6.3", upgradeInfo, nil, nil, nil)
+	app.registerUpgrade("v6.3", upgradeInfo)
 	app.registerUpgrade6_4(upgradeInfo)
+	app.registerUpgrade("v6.5", upgradeInfo)
 
-	app.registerUpgrade6_5(upgradeInfo)
+	app.registerUpgrade6_6(upgradeInfo)
 }
 
-func (app *UmeeApp) registerUpgrade6_5(upgradeInfo upgradetypes.Plan) {
-	planName := "v6.5"
+func (app *UmeeApp) registerUpgrade6_6(upgradeInfo upgradetypes.Plan) {
+	planName := "v6.6"
 
 	app.UpgradeKeeper.SetUpgradeHandler(planName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {

--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -11,9 +11,9 @@ import (
 	appparams "github.com/umee-network/umee/v6/app/params"
 	setup "github.com/umee-network/umee/v6/tests/e2e/setup"
 	"github.com/umee-network/umee/v6/tests/grpc"
+	"github.com/umee-network/umee/v6/tests/tsdk"
 	"github.com/umee-network/umee/v6/util/coin"
 	ibcutil "github.com/umee-network/umee/v6/util/ibc"
-	"github.com/umee-network/umee/v6/util/sdkutil"
 	"github.com/umee-network/umee/v6/x/uibc"
 )
 
@@ -166,9 +166,9 @@ func (s *E2ETest) TestIBCTokenTransfer() {
 		// supply don't change
 		s.checkSupply(gaiaAPIEndpoint, umeeIBCHash, math.ZeroInt())
 
-		// << Recevier Addr = maximum length + 1
+		// << Receiver Addr = maximum length + 1
 		// send $110 UMEE from umee to gaia (token_quota is 100$)
-		recvAddr := sdkutil.GenerateString(ibcutil.MaximumMemoLength + 1)
+		recvAddr := tsdk.GenerateString(ibcutil.MaximumMemoLength + 1)
 		s.SendIBC(s.Chain.ID, setup.GaiaChainID, recvAddr, exceedUmee, true, "", "")
 		// check the ibc (umee) quota after ibc txs - this one should have failed
 		// supply don't change

--- a/tests/tsdk/string.go
+++ b/tests/tsdk/string.go
@@ -1,0 +1,13 @@
+package tsdk
+
+import "math/rand"
+
+func GenerateString(length uint) string {
+	// character set used for generating a random string in GenerateString
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	bytes := make([]byte, length)
+	for i := range bytes {
+		bytes[i] = charset[rand.Intn(len(charset))] //nolint
+	}
+	return string(bytes)
+}

--- a/tests/tsdk/string_test.go
+++ b/tests/tsdk/string_test.go
@@ -1,0 +1,15 @@
+package tsdk_test
+
+import (
+	"testing"
+
+	"github.com/umee-network/umee/v6/tests/tsdk"
+	"gotest.tools/v3/assert"
+)
+
+// TestGenerateString checks the randomness and length properties of the generated string.
+func TestGenerateString(t *testing.T) {
+	length := 10
+	str := tsdk.GenerateString(uint(length))
+	assert.Equal(t, len(str), length, "Generated string length should match the input length")
+}

--- a/util/ibc/ibc_test.go
+++ b/util/ibc/ibc_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cometbft/cometbft/crypto"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	"github.com/umee-network/umee/v6/util/sdkutil"
+	"github.com/umee-network/umee/v6/tests/tsdk"
 	"gotest.tools/v3/assert"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -35,15 +35,21 @@ func TestGetFundsFromPacket(t *testing.T) {
 	assert.Equal(t, famount.String(), amount)
 
 	// invalid address
-	data.Receiver = sdkutil.GenerateString(MaximumReceiverLength + 1)
+	data.Receiver = tsdk.GenerateString(MaximumReceiverLength + 1)
 	_, _, err = GetFundsFromPacket(data.GetBytes())
 	assert.ErrorContains(t, err, "recipient address must not exceed")
 
 	// invalid memo
 	data.Receiver = AddressFromString("a4")
-	data.Memo = sdkutil.GenerateString(MaximumMemoLength + 1)
+	data.Memo = tsdk.GenerateString(MaximumMemoLength + 1)
 	_, _, err = GetFundsFromPacket(data.GetBytes())
 	assert.ErrorContains(t, err, "memo must not exceed")
+
+	// valid address and memo
+	data.Receiver = tsdk.GenerateString(MaximumReceiverLength)
+	data.Memo = tsdk.GenerateString(MaximumMemoLength)
+	_, _, err = GetFundsFromPacket(data.GetBytes())
+	assert.NilError(t, err, "Should handle valid inputs without error")
 }
 
 func TestGetLocalDenom(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

* cherry pick the improvement to check IBC payload
* update release notes and changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `GenerateString` function in the new `tsdk` package for generating random strings.
  
- **Bug Fixes**
  - Restricted the length of IBC transfer memo and receiver fields.
  - Corrected Amino registration for `x/ugov` messages.
  - Fixed `MissCounters` grpc-web get API result.

- **Documentation**
  - Refined the description of the Auction module.
  - Updated version numbers and fixed typos in release notes.

- **Refactor**
  - Updated function calls and import statements to use the new `tsdk` package for test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->