### PR TITLE
chore: removing the ibc-transfer recv addr and memo length check

### DIFF
--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -8,12 +8,12 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	appparams "github.com/umee-network/umee/v6/app/params"
 	setup "github.com/umee-network/umee/v6/tests/e2e/setup"
 	"github.com/umee-network/umee/v6/tests/grpc"
 	"github.com/umee-network/umee/v6/tests/tsdk"
 	"github.com/umee-network/umee/v6/util/coin"
-	ibcutil "github.com/umee-network/umee/v6/util/ibc"
 	"github.com/umee-network/umee/v6/x/uibc"
 )
 
@@ -170,7 +170,7 @@ func (s *E2ETest) TestIBCTokenTransfer() {
 
 		// << Receiver Addr = maximum length + 1
 		// send $110 UMEE from umee to gaia (token_quota is 100$)
-		recvAddr := tsdk.GenerateString(ibcutil.MaximumMemoLength + 1)
+		recvAddr := tsdk.GenerateString(ibctransfertypes.MaximumReceiverLength + 1)
 		s.SendIBC(s.Chain.ID, setup.GaiaChainID, recvAddr, exceedUmee, "", "",
 			"recipient address must not exceed 2048 bytes")
 		// supply should not change

--- a/util/ibc/ibc.go
+++ b/util/ibc/ibc.go
@@ -2,7 +2,6 @@ package ibc
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	sdkmath "cosmossdk.io/math"
@@ -10,38 +9,11 @@ import (
 	ibcerrors "github.com/cosmos/ibc-go/v7/modules/core/errors"
 )
 
-const (
-	MaximumReceiverLength = 2048  // maximum length of the receiver address in bytes (value chosen arbitrarily)
-	MaximumMemoLength     = 32768 // maximum length of the memo in bytes (value chosen arbitrarily)
-)
-
-func ValidateRecvAddr(receiver string) error {
-	if len(receiver) > MaximumReceiverLength {
-		return ibcerrors.ErrInvalidAddress.Wrapf("recipient address must not exceed %d bytes", MaximumReceiverLength)
-	}
-	return nil
-}
-
-func ValidateMemo(memo string) error {
-	if len(memo) > MaximumMemoLength {
-		return fmt.Errorf("memo must not exceed %d bytes", MaximumMemoLength)
-	}
-	return nil
-}
-
 // GetFundsFromPacket returns transfer amount and denom
 func GetFundsFromPacket(data []byte) (sdkmath.Int, string, error) {
 	var packetData transfertypes.FungibleTokenPacketData
 	err := json.Unmarshal(data, &packetData)
 	if err != nil {
-		return sdkmath.Int{}, "", err
-	}
-
-	if err := ValidateRecvAddr(packetData.Receiver); err != nil {
-		return sdkmath.Int{}, "", err
-	}
-
-	if err := ValidateMemo(packetData.Memo); err != nil {
 		return sdkmath.Int{}, "", err
 	}
 

--- a/util/ibc/ibc_test.go
+++ b/util/ibc/ibc_test.go
@@ -34,17 +34,6 @@ func TestGetFundsFromPacket(t *testing.T) {
 	assert.Equal(t, denom, fdenom)
 	assert.Equal(t, famount.String(), amount)
 
-	// invalid address
-	data.Receiver = tsdk.GenerateString(ibctransfertypes.MaximumReceiverLength + 1)
-	_, _, err = GetFundsFromPacket(data.GetBytes())
-	assert.ErrorContains(t, err, "recipient address must not exceed")
-
-	// invalid memo
-	data.Receiver = AddressFromString("a4")
-	data.Memo = tsdk.GenerateString(ibctransfertypes.MaximumMemoLength + 1)
-	_, _, err = GetFundsFromPacket(data.GetBytes())
-	assert.ErrorContains(t, err, "memo must not exceed")
-
 	// valid address and memo
 	data.Receiver = tsdk.GenerateString(ibctransfertypes.MaximumReceiverLength)
 	data.Memo = tsdk.GenerateString(ibctransfertypes.MaximumMemoLength)

--- a/util/ibc/ibc_test.go
+++ b/util/ibc/ibc_test.go
@@ -35,19 +35,19 @@ func TestGetFundsFromPacket(t *testing.T) {
 	assert.Equal(t, famount.String(), amount)
 
 	// invalid address
-	data.Receiver = tsdk.GenerateString(MaximumReceiverLength + 1)
+	data.Receiver = tsdk.GenerateString(ibctransfertypes.MaximumReceiverLength + 1)
 	_, _, err = GetFundsFromPacket(data.GetBytes())
 	assert.ErrorContains(t, err, "recipient address must not exceed")
 
 	// invalid memo
 	data.Receiver = AddressFromString("a4")
-	data.Memo = tsdk.GenerateString(MaximumMemoLength + 1)
+	data.Memo = tsdk.GenerateString(ibctransfertypes.MaximumMemoLength + 1)
 	_, _, err = GetFundsFromPacket(data.GetBytes())
 	assert.ErrorContains(t, err, "memo must not exceed")
 
 	// valid address and memo
-	data.Receiver = tsdk.GenerateString(MaximumReceiverLength)
-	data.Memo = tsdk.GenerateString(MaximumMemoLength)
+	data.Receiver = tsdk.GenerateString(ibctransfertypes.MaximumReceiverLength)
+	data.Memo = tsdk.GenerateString(ibctransfertypes.MaximumMemoLength)
 	_, _, err = GetFundsFromPacket(data.GetBytes())
 	assert.NilError(t, err, "Should handle valid inputs without error")
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

The ibc-transfer msg recv and memo fields length check was added in ibc-go v7.6.0 

--


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated dependencies to use new paths for `ibctransfertypes` package.
  - Improved handling of receiver address and memo lengths.
  
- **Tests**
  - Adjusted end-to-end and unit tests to align with updated constants from `ibctransfertypes` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->