### PR TITLE
Fix broken link to Axelar Cosmos GMP documentation

### DIFF
--- a/x/uibc/gmp/README.md
+++ b/x/uibc/gmp/README.md
@@ -1,7 +1,7 @@
 # GMP Handler
 
 Cross chain transfers using Axelar General Message Passing (GMP)
-More info about cosmos GMP find [here](https://docs.axelar.dev/dev/cosmos-gmp)
+More info about cosmos GMP find [here](https://docs.axelar.dev/dev/general-message-passing/developer-guides/example-gmp)
 
 ## Axelar IBC Memo
 


### PR DESCRIPTION
Replaced the outdated and broken link to the Axelar Cosmos GMP documentation in x/uibc/gmp/README.md with the current, working URL for the General Message Passing (GMP) developer guide: https://docs.axelar.dev/dev/general-message-passing/developer-guides/example-gmp. This ensures users have access to up-to-date resources for cross-chain transfers using Axelar GMP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new link to the latest Axelar General Message Passing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->